### PR TITLE
docs(openai): restack Responses examples on current next

### DIFF
--- a/python/providers/openai/openai_assistant_demo.py
+++ b/python/providers/openai/openai_assistant_demo.py
@@ -1,64 +1,51 @@
-from datetime import datetime
+"""
+OpenAI Responses API demo.
+"""
 
-from composio_openai import OpenAIProvider
+import json
+
+from composio_openai import OpenAIResponsesProvider
 from openai import OpenAI
 
 from composio import Composio
 
 # Initialize tools.
 openai_client = OpenAI()
-composio = Composio(provider=OpenAIProvider())
+composio = Composio(provider=OpenAIResponsesProvider())
 
-# Retrieve actions
-actions = composio.tools.get(
-    user_id="default",
-    tools=["NOTION_ADD_PAGE_CONTENT"],
+# Define task.
+task = "Tell me about the user `pg` on Hacker News."
+
+# Get tools that are pre-configured for the Responses API.
+tools = composio.tools.get(user_id="default", tools=["HACKERNEWS_GET_USER"])
+
+# Get the first response from the LLM.
+response = openai_client.responses.create(
+    model="gpt-5.2",
+    tools=tools,
+    input=task,
 )
+print(response)
 
-# Setup openai assistant
-assistant_instruction = (
-    "You are a super intelligent personal assistant."
-    + "You have been given a set of tools that you are supposed to choose from."
-    + "You decide the right tool and execute it."
-)
-# Prepare assistant
-assistant = openai_client.beta.assistants.create(
-    name="Personal Assistant",
-    instructions=assistant_instruction,
-    model="gpt-5",
-    tools=actions,  # type: ignore
-)
+# Execute tool calls until the model returns a final answer.
+while True:
+    tool_calls = [item for item in response.output if item.type == "function_call"]
+    if not tool_calls:
+        break
 
-# Give a task to execute via Openai Assistants
-my_task = (
-    f"Can you copy all the events in coming week from google calendar to notion? "
-    f"Today's date is {datetime.now()} and day is {datetime.now().strftime('%A')}"
-)
+    results = composio.provider.handle_tool_calls(response=response, user_id="default")
+    response = openai_client.responses.create(
+        model="gpt-5.2",
+        tools=tools,
+        previous_response_id=response.id,
+        input=[
+            {
+                "type": "function_call_output",
+                "call_id": tool_calls[index].call_id,
+                "output": json.dumps(result),
+            }
+            for index, result in enumerate(results)
+        ],
+    )
 
-# create a thread
-thread = openai_client.beta.threads.create()
-print("Thread ID: ", thread.id)
-print("Assistant ID: ", assistant.id)
-
-# start the asssitant with my task
-message = openai_client.beta.threads.messages.create(
-    thread_id=thread.id,
-    role="user",
-    content=my_task,
-)
-
-# Execute Agent with integrations
-run = openai_client.beta.threads.runs.create(
-    thread_id=thread.id,
-    assistant_id=assistant.id,
-)
-
-# Execute function calls
-run_after_tool_calls = composio.provider.wait_and_handle_assistant_tool_calls(
-    user_id="default",
-    client=openai_client,
-    run=run,
-    thread=thread,
-)
-
-print(run_after_tool_calls)
+print(response.output_text)

--- a/ts/docs/providers/openai.md
+++ b/ts/docs/providers/openai.md
@@ -8,8 +8,7 @@ The OpenAI Provider allows you to:
 
 1. Format Composio tools as OpenAI function tools
 2. Handle tool calls from OpenAI chat completions
-3. Handle tool calls from OpenAI assistants
-4. Process streaming responses from OpenAI with tool calls
+3. Handle tool calls from the OpenAI Responses API through `OpenAIResponsesProvider`
 
 ## Basic Usage
 
@@ -132,131 +131,48 @@ if (completion.choices[0].message.tool_calls) {
 }
 ```
 
-## Working with OpenAI Assistants
+## Working with OpenAI Responses
 
-The OpenAI Provider includes helper methods for working with OpenAI Assistants:
+Use `OpenAIResponsesProvider` for new agentic flows. It formats Composio tools for the Responses API and returns `function_call_output` items that you can pass back with `previous_response_id`.
 
 ```typescript
 import { Composio } from '@composio/core';
-import { OpenAIProvider } from '@composio/openai';
+import { OpenAIResponsesProvider } from '@composio/openai';
 import OpenAI from 'openai';
 
 const composio = new Composio({
   apiKey: 'your-composio-api-key',
+  provider: new OpenAIResponsesProvider(),
 });
 
 const openai = new OpenAI({
   apiKey: 'your-openai-api-key',
 });
 
-// Get the OpenAI Provider
-const openaiProvider = composio.provider as OpenAIProvider;
-
 // Get GitHub tools
 const tools = await composio.tools.get('default', {
   toolkits: ['github'],
 });
 
-// Create an assistant with Composio tools
-const assistant = await openai.beta.assistants.create({
-  name: 'GitHub Assistant',
-  instructions: 'You are a helpful assistant with GitHub tools.',
-  model: 'gpt-4',
+let response = await openai.responses.create({
+  model: 'gpt-5.2',
   tools,
+  input: 'Find information about the Composio SDK repository',
 });
 
-// Create a thread
-const thread = await openai.beta.threads.create();
+while (response.output.some(item => item.type === 'function_call')) {
+  const toolOutputs = await composio.provider.handleToolCalls('default', response.output);
+  response = await openai.responses.create({
+    model: 'gpt-5.2',
+    tools,
+    previous_response_id: response.id,
+    input: toolOutputs,
+  });
+}
 
-// Add a message to the thread
-await openai.beta.threads.messages.create(thread.id, {
-  role: 'user',
-  content: 'Find information about the Composio SDK repository',
-});
-
-// Run the assistant
-const run = await openai.beta.threads.runs.create(thread.id, {
-  assistant_id: assistant.id,
-});
-
-// Wait for the run to complete and handle any tool calls
-const finalRun = await openaiProvider.waitAndHandleAssistantToolCalls(
-  'default', // userId
-  openai,
-  run,
-  thread,
-  { connectedAccountId: 'connected_account_123' } // Optional
-);
-
-// Get the assistant's response
-const messages = await openai.beta.threads.messages.list(thread.id);
-console.log(messages.data[0].content);
-```
-
-## Handling Streaming Responses with Tool Calls
-
-The OpenAI Provider can also handle streaming responses with tool calls:
-
-```typescript
-import { Composio } from '@composio/core';
-import { OpenAIProvider } from '@composio/openai';
-import OpenAI from 'openai';
-
-const composio = new Composio({
-  apiKey: 'your-composio-api-key',
-});
-
-const openai = new OpenAI({
-  apiKey: 'your-openai-api-key',
-});
-
-// Get the OpenAI Provider
-const openaiProvider = composio.provider as OpenAIProvider;
-
-// Get GitHub tools
-const tools = await composio.tools.get('default', {
-  toolkits: ['github'],
-});
-
-// Create an assistant with Composio tools
-const assistant = await openai.beta.assistants.create({
-  name: 'GitHub Assistant',
-  instructions: 'You are a helpful assistant with GitHub tools.',
-  model: 'gpt-4',
-  tools,
-});
-
-// Create a thread
-const thread = await openai.beta.threads.create();
-
-// Add a message to the thread
-await openai.beta.threads.messages.create(thread.id, {
-  role: 'user',
-  content: 'Find information about the Composio SDK repository',
-});
-
-// Run the assistant with streaming
-const runStream = await openai.beta.threads.runs.createAndStream(thread.id, {
-  assistant_id: assistant.id,
-});
-
-// Process the stream and handle tool calls
-for await (const event of openaiProvider.waitAndHandleAssistantStreamToolCalls(
-  'default', // userId
-  openai,
-  runStream,
-  thread,
-  { connectedAccountId: 'connected_account_123' } // Optional
-)) {
-  // Process different event types
-  if (event.event === 'thread.message.created') {
-    console.log('New message created');
-  } else if (event.event === 'thread.message.delta') {
-    console.log('Message update:', event.data.delta.content);
-  } else if (event.event === 'thread.run.requires_action') {
-    console.log('Run requires action (tools being executed)');
-  } else if (event.event === 'thread.run.completed') {
-    console.log('Run completed');
+for (const item of response.output) {
+  if (item.type === 'message' && item.content[0].type === 'output_text') {
+    console.log(item.content[0].text);
   }
 }
 ```
@@ -344,30 +260,5 @@ class OpenAIProvider extends BaseNonAgenticProvider<OpenAiToolCollection, OpenAi
     options?: ExecuteToolFnOptions,
     modifiers?: ExecuteToolModifiers
   ): Promise<OpenAI.ChatCompletionToolMessageParam[]>;
-
-  handleAssistantMessage(
-    userId: string,
-    run: OpenAI.Beta.Threads.Run,
-    options?: ExecuteToolFnOptions,
-    modifiers?: ExecuteToolModifiers
-  ): Promise<OpenAI.Beta.Threads.Runs.RunSubmitToolOutputsParams.ToolOutput[]>;
-
-  waitAndHandleAssistantStreamToolCalls(
-    userId: string,
-    client: OpenAI,
-    runStream: Stream<OpenAI.Beta.Assistants.AssistantStreamEvent>,
-    thread: OpenAI.Beta.Threads.Thread,
-    options?: ExecuteToolFnOptions,
-    modifiers?: ExecuteToolModifiers
-  ): AsyncGenerator<OpenAI.Beta.Assistants.AssistantStreamEvent, void, unknown>;
-
-  waitAndHandleAssistantToolCalls(
-    userId: string,
-    client: OpenAI,
-    run: OpenAI.Beta.Threads.Run,
-    thread: OpenAI.Beta.Threads.Thread,
-    options?: ExecuteToolFnOptions,
-    modifiers?: ExecuteToolModifiers
-  ): Promise<OpenAI.Beta.Threads.Run>;
 }
 ```


### PR DESCRIPTION
Restacks the docs/demo cleanup from #4165 by @srijavuppala onto the current `next` head.

Source PR: #4165
Source head: `a1ae274e549dfb5c787d05b08e80a385c30946f6`
Current base used for this rescue: `b20ca59d91a22b965f7a72389c598aadf32074a6`

The current `next` tree still contains the deprecated `openai.beta.assistants` / `openai.beta.threads` demo and the old Assistants sections in `ts/docs/providers/openai.md`, so the source PR remains materially relevant after the August 26, 2026 shutdown date.

This rescue transplants only the original two changed blobs:
- Python demo rewritten around `OpenAIResponsesProvider` and `client.responses.create`
- TypeScript provider docs rewritten around the Responses API tool-call loop

No unrelated stale history is carried forward. The rescue is one commit ahead of current `next`, 2 changed paths, +60/-182. Credit for the original implementation belongs to @srijavuppala / #4165; this PR only provides a freshness-safe restack for maintainer review.