### PR TITLE
chore(py): add manual composio-core publisher

### DIFF
--- a/.github/workflows/py.publish-composio-core.yml
+++ b/.github/workflows/py.publish-composio-core.yml
@@ -19,18 +19,18 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Build and optionally publish composio-core
+  build:
+    name: Build composio-core
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
       run:
         working-directory: python
     steps:
-      - name: Checkout archive-v2
+      - name: Checkout reviewed composio-core source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: archive-v2
+          ref: 93ef3c6b5311a6df7f82bc64ce04e2424a34c9e3 # PR #4270
           persist-credentials: false
 
       - name: Setup Python
@@ -47,19 +47,50 @@ jobs:
       - name: Build composio-core
         run: |
           uv build
-          uvx twine check dist/*
+          uvx --from twine==6.2.0 twine check --strict dist/*
 
       - name: Verify artifacts
         run: |
           test -f dist/composio_core-0.7.22-py3-none-any.whl
           test -f dist/composio_core-0.7.22.tar.gz
 
+      - name: Store verified artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: composio-core-0.7.22
+          path: |
+            python/dist/composio_core-0.7.22-py3-none-any.whl
+            python/dist/composio_core-0.7.22.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish composio-core
+    if: inputs.publish
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: '0.8.19'
+          enable-cache: false
+
+      - name: Download verified artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: composio-core-0.7.22
+          path: python/dist
+
       - name: Publish composio-core to PyPI
-        if: inputs.publish
         env:
           UV_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}
           UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          uv publish \
+          uv publish --check-url https://pypi.org/simple/ \
             dist/composio_core-0.7.22-py3-none-any.whl \
             dist/composio_core-0.7.22.tar.gz

--- a/.github/workflows/py.publish-composio-core.yml
+++ b/.github/workflows/py.publish-composio-core.yml
@@ -23,6 +23,9 @@ jobs:
     name: Build and optionally publish composio-core
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: python
     steps:
       - name: Checkout archive-v2
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -42,20 +45,17 @@ jobs:
           enable-cache: false
 
       - name: Build composio-core
-        working-directory: python
         run: |
           uv build
           uvx twine check dist/*
 
       - name: Verify artifacts
-        working-directory: python
         run: |
           test -f dist/composio_core-0.7.22-py3-none-any.whl
           test -f dist/composio_core-0.7.22.tar.gz
 
       - name: Publish composio-core to PyPI
         if: inputs.publish
-        working-directory: python
         env:
           UV_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}
           UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/py.publish-composio-core.yml
+++ b/.github/workflows/py.publish-composio-core.yml
@@ -1,0 +1,65 @@
+name: Publish composio-core 0.7.22
+
+run-name: Publish composio-core 0.7.22 (publish=${{ inputs.publish }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Upload the verified artifacts to PyPI
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-composio-core-0.7.22
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build and optionally publish composio-core
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout archive-v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: archive-v2
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.10'
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: '0.8.19'
+          enable-cache: false
+
+      - name: Build composio-core
+        working-directory: python
+        run: |
+          uv build
+          uvx twine check dist/*
+
+      - name: Verify artifacts
+        working-directory: python
+        run: |
+          test -f dist/composio_core-0.7.22-py3-none-any.whl
+          test -f dist/composio_core-0.7.22.tar.gz
+
+      - name: Publish composio-core to PyPI
+        if: inputs.publish
+        working-directory: python
+        env:
+          UV_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          uv publish \
+            dist/composio_core-0.7.22-py3-none-any.whl \
+            dist/composio_core-0.7.22.tar.gz


### PR DESCRIPTION
This PR:

- builds on top of https://github.com/ComposioHQ/composio/pull/4270
- adds a manual-only publisher for `composio-core` 0.7.22 on the `next` branch
- pins the release source to the exact reviewed #4270 commit instead of mutable `archive-v2`
- defaults `publish` to false so the first dispatch only builds and validates
- transfers the two verified distributions into a separate publish job so build code cannot access PyPI credentials
- uploads only the expected 0.7.22 artifacts and safely skips files already present on PyPI
- disables persisted checkout credentials and pins every GitHub Action to a full commit SHA

Verification:

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10 .github/workflows/py.publish-composio-core.yml`
- `uvx zizmor .github/workflows/py.publish-composio-core.yml` (only trusted-publishing informational finding; this one-off workflow intentionally uses the existing PyPI token)
- `uv build` from the pinned `93ef3c6b5311a6df7f82bc64ce04e2424a34c9e3` source revision
- `uvx --from twine==6.2.0 twine check --strict dist/*`
- exact 0.7.22 wheel and source distribution checks
- `ce-simplify-code` and `ce-code-review`, including an independent Claude Opus adversarial pass

Run order after review:

1. Merge #4270 into `archive-v2`.
2. Merge this PR into `next`.
3. Dispatch `Publish composio-core 0.7.22` with `publish=false`.
4. After the validation run is green, dispatch it with `publish=true`.