### PR TITLE
fix(release): keep providers stable during core beta

### DIFF
--- a/.github/workflows/ts.audit.yml
+++ b/.github/workflows/ts.audit.yml
@@ -89,5 +89,4 @@ jobs:
           comment-tag: pnpm-audit-security-warning
 
       - name: Fail on high/critical advisories
-        # Mastra's pinned provider-utils release has no patched version for this low advisory.
-        run: pnpm audit --prod --audit-level=high --ignore=GHSA-866g-f22w-33x8
+        run: pnpm audit --prod --audit-level=high

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -140,3 +140,12 @@ overrides:
   'brace-expansion@<=5.0.8': '>=5.0.9 <6'
   'vite@<=7.3.4': 7.3.5
   'esbuild@>=0.27.3 <0.28.1': 0.28.1
+
+auditConfig:
+  ignoreGhsas:
+    # extract-zip has no patched release, but every call goes through the
+    # symlink-rejecting wrappers covered by the CLI and local-tools tests.
+    - GHSA-jmr9-qjv8-65gv
+    # Mastra exact-pins affected provider-utils versions with no patched
+    # release; these paths only exist in examples and runtime-test workspaces.
+    - GHSA-866g-f22w-33x8

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import semver from 'semver';
 import {
   findIgnoredChangesetReleases,
   validateChangesets,
@@ -421,6 +422,31 @@ if (
     throw new Error(
       `Public TypeScript workspaces must declare engines.node as ${MIN_NODE_VERSION}:\n${details}`
     );
+  }
+}
+
+{
+  const providerPackages = readTypeScriptWorkspacePackages().filter(({ path }) =>
+    path.startsWith('ts/packages/providers/')
+  );
+
+  for (const { manifest, path } of providerPackages) {
+    const coreRange = manifest.peerDependencies?.['@composio/core'];
+    if (!coreRange) {
+      throw new Error(`${path} must declare @composio/core as a peer dependency`);
+    }
+    if (semver.prerelease(manifest.version)) {
+      throw new Error(`${path} must remain on its stable release train, got ${manifest.version}`);
+    }
+    if (!semver.satisfies('0.18.0', coreRange)) {
+      throw new Error(`${path} must accept the stable @composio/core 0.18 release`);
+    }
+    if (!semver.satisfies('1.0.0-beta.0', coreRange)) {
+      throw new Error(`${path} must accept @composio/core 1.0 betas`);
+    }
+    if (semver.satisfies('1.0.0', coreRange)) {
+      throw new Error(`${path} must require an upgrade before @composio/core 1.0.0`);
+    }
   }
 }
 
@@ -1038,6 +1064,132 @@ esac
     if (providerFixturePackage.peerDependencies['@composio/core'] !== '>=0.10.0 <1.0.0') {
       throw new Error(
         `fixture provider peer range should still accept core 0.11.0 without widening, got ${providerFixturePackage.peerDependencies['@composio/core']}`
+      );
+    }
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
+}
+
+// Entering the core 1.0 beta must leave stable providers unversioned when their
+// peer range explicitly accepts the prerelease. Providers should use the beta
+// only when consumers install it at the workspace root.
+{
+  const fixtureDir = mkdtempSync(join(tmpdir(), 'composio-changeset-beta-peer-'));
+  try {
+    mkdirSync(join(fixtureDir, '.changeset'), { recursive: true });
+    mkdirSync(join(fixtureDir, 'packages/core'), { recursive: true });
+    mkdirSync(join(fixtureDir, 'packages/openai'), { recursive: true });
+
+    writeFileSync(
+      join(fixtureDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'changeset-beta-peer-fixture',
+          private: true,
+          workspaces: ['packages/*'],
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(join(fixtureDir, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
+    writeFileSync(
+      join(fixtureDir, '.changeset/config.json'),
+      JSON.stringify(
+        {
+          changelog: false,
+          commit: false,
+          fixed: [],
+          linked: [],
+          access: 'restricted',
+          baseBranch: 'next',
+          updateInternalDependencies: 'patch',
+          ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+            onlyUpdatePeerDependentsWhenOutOfRange: true,
+          },
+          ignore: [],
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(
+      join(fixtureDir, '.changeset/pre.json'),
+      JSON.stringify(
+        {
+          mode: 'pre',
+          tag: 'beta',
+          initialVersions: {
+            '@composio/core': '0.18.0',
+            '@composio/openai': '0.12.1',
+          },
+          changesets: [],
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(
+      join(fixtureDir, '.changeset/core-beta.md'),
+      ['---', '"@composio/core": major', '---', '', 'Release the core 1.0 beta.', ''].join('\n')
+    );
+    writeFileSync(
+      join(fixtureDir, 'packages/core/package.json'),
+      JSON.stringify(
+        {
+          name: '@composio/core',
+          version: '0.18.0',
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(
+      join(fixtureDir, 'packages/openai/package.json'),
+      JSON.stringify(
+        {
+          name: '@composio/openai',
+          version: '0.12.1',
+          peerDependencies: {
+            '@composio/core': '>=0.10.0 <1.0.0 || >=1.0.0-beta.0 <1.0.0',
+          },
+          devDependencies: {
+            '@composio/core': 'workspace:*',
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const result = spawnSync(changesetBinPath, ['version'], {
+      cwd: fixtureDir,
+      encoding: 'utf8',
+      env: process.env,
+    });
+
+    if (result.status !== 0) {
+      throw new Error(
+        `changeset beta peer fixture failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+      );
+    }
+
+    const coreFixturePackage = JSON.parse(
+      readFileSync(join(fixtureDir, 'packages/core/package.json'), 'utf8')
+    );
+    const providerFixturePackage = JSON.parse(
+      readFileSync(join(fixtureDir, 'packages/openai/package.json'), 'utf8')
+    );
+
+    if (coreFixturePackage.version !== '1.0.0-beta.0') {
+      throw new Error(
+        `fixture core version should be 1.0.0-beta.0, got ${coreFixturePackage.version}`
+      );
+    }
+    if (providerFixturePackage.version !== '0.12.1') {
+      throw new Error(
+        `fixture provider should stay at 0.12.1, got ${providerFixturePackage.version}`
       );
     }
   } finally {

--- a/ts/packages/providers/anthropic/CHANGELOG.md
+++ b/ts/packages/providers/anthropic/CHANGELOG.md
@@ -1,11 +1,10 @@
 # @composio/anthropic
 
-## 0.11.1-beta.0
+## 0.11.1
 
 ### Patch Changes
 
-- Updated dependencies [fb1b530]
-  - @composio/core@1.0.0-beta.0
+- db7b576: Declare Node.js 22.22.3 as the minimum supported runtime for every published TypeScript package so package managers surface incompatible runtimes before users encounter ESM loading failures.
 
 ## 0.11.0
 

--- a/ts/packages/providers/anthropic/package.json
+++ b/ts/packages/providers/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/anthropic",
-  "version": "0.11.1-beta.0",
+  "version": "0.11.1",
   "description": "Non-Agentic Provider for Anthropic in Composio SDK",
   "main": "src/index.ts",
   "type": "module",
@@ -45,7 +45,7 @@
   "license": "ISC",
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
-    "@composio/core": ">=1.0.0-beta.0 <2.0.0",
+    "@composio/core": ">=0.10.0 <1.0.0 || >=1.0.0-beta.0 <1.0.0",
     "@mastra/mcp": "^1.13.1"
   },
   "devDependencies": {

--- a/ts/packages/providers/claude-agent-sdk/CHANGELOG.md
+++ b/ts/packages/providers/claude-agent-sdk/CHANGELOG.md
@@ -1,11 +1,10 @@
 # @composio/claude-code-agents
 
-## 0.11.1-beta.0
+## 0.11.1
 
 ### Patch Changes
 
-- Updated dependencies [fb1b530]
-  - @composio/core@1.0.0-beta.0
+- db7b576: Declare Node.js 22.22.3 as the minimum supported runtime for every published TypeScript package so package managers surface incompatible runtimes before users encounter ESM loading failures.
 
 ## 0.11.0
 

--- a/ts/packages/providers/claude-agent-sdk/package.json
+++ b/ts/packages/providers/claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/claude-agent-sdk",
-  "version": "0.11.1-beta.0",
+  "version": "0.11.1",
   "description": "Composio provider for Claude Agent SDK",
   "main": "src/index.ts",
   "type": "module",
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.199",
-    "@composio/core": ">=1.0.0-beta.0 <2.0.0",
+    "@composio/core": ">=0.10.0 <1.0.0 || >=1.0.0-beta.0 <1.0.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/cloudflare/CHANGELOG.md
+++ b/ts/packages/providers/cloudflare/CHANGELOG.md
@@ -1,11 +1,10 @@
 # @composio/cloudflare
 
-## 0.10.2-beta.0
+## 0.10.2
 
 ### Patch Changes
 
-- Updated dependencies [fb1b530]
-  - @composio/core@1.0.0-beta.0
+- db7b576: Declare Node.js 22.22.3 as the minimum supported runtime for every published TypeScript package so package managers surface incompatible runtimes before users encounter ESM loading failures.
 
 ## 0.10.1
 

--- a/ts/packages/providers/cloudflare/package.json
+++ b/ts/packages/providers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/cloudflare",
-  "version": "0.10.2-beta.0",
+  "version": "0.10.2",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -41,7 +41,7 @@
   "license": "ISC",
   "peerDependencies": {
     "@cloudflare/workers-types": "catalog:",
-    "@composio/core": ">=1.0.0-beta.0 <2.0.0"
+    "@composio/core": ">=0.10.0 <1.0.0 || >=1.0.0-beta.0 <1.0.0"
   },
   "devDependencies": {
     "@composio/core": "workspace:*",

--- a/ts/packages/providers/google/CHANGELOG.md
+++ b/ts/packages/providers/google/CHANGELOG.md
@@ -1,11 +1,10 @@
 # @composio/google
 
-## 0.10.3-beta.0
+## 0.10.3
 
 ### Patch Changes
 
-- Updated dependencies [fb1b530]
-  - @composio/core@1.0.0-beta.0
+- db7b576: Declare Node.js 22.22.3 as the minimum supported runtime for every published TypeScript package so package managers surface incompatible runtimes before users encounter ESM loading failures.
 
 ## 0.10.2
 

--- a/ts/packages/providers/google/package.json
+++ b/ts/packages/providers/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/google",
-  "version": "0.10.3-beta.0",
+  "version": "0.10.3",
   "description": "Google GenAI Provider for Composio SDK",
   "main": "src/index.ts",
   "type": "module",
@@ -46,7 +46,7 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "@composio/core": ">=1.0.0-beta.0 <2.0.0",
+    "@composio/core": ">=0.16.0 <1.0.0 || >=1.0.0-beta.0 <1.0.0",
     "@google/genai": "^1.1.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/langchain/CHANGELOG.md
+++ b/ts/packages/providers/langchain/CHANGELOG.md
@@ -1,11 +1,10 @@
 # @composio/langchain
 
-## 0.10.2-beta.0
+## 0.10.2
 
 ### Patch Changes
 
-- Updated dependencies [fb1b530]
-  - @composio/core@1.0.0-beta.0
+- db7b576: Declare Node.js 22.22.3 as the minimum supported runtime for every published TypeScript package so package managers surface incompatible runtimes before users encounter ESM loading failures.
 
 ## 0.10.1
 

--- a/ts/packages/providers/langchain/package.json
+++ b/ts/packages/providers/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/langchain",
-  "version": "0.10.2-beta.0",
+  "version": "0.10.2",
   "description": "",
   "main": "dist/index.js",
   "type": "module",
@@ -40,7 +40,7 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "@composio/core": ">=1.0.0-beta.0 <2.0.0",
+    "@composio/core": ">=0.10.0 <1.0.0 || >=1.0.0-beta.0 <1.0.0",
     "@langchain/core": "^1.1.4"
   },
   "devDependencies": {

--- a/ts/packages/providers/llamaindex/CHANGELOG.md
+++ b/ts/packages/providers/llamaindex/CHANGELOG.md
@@ -1,11 +1,10 @@
 # @composio/llamaindex
 
-## 0.10.2-beta.0
+## 0.10.2
 
 ### Patch Changes
 
-- Updated dependencies [fb1b530]
-  - @composio/core@1.0.0-beta.0
+- db7b576: Declare Node.js 22.22.3 as the minimum supported runtime for every published TypeScript package so package managers surface incompatible runtimes before users encounter ESM loading failures.
 
 ## 0.10.1
 

--- a/ts/packages/providers/llamaindex/package.json
+++ b/ts/packages/providers/llamaindex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/llamaindex",
-  "version": "0.10.2-beta.0",
+  "version": "0.10.2",
   "description": "Agentic Provider for llamaindex in Composio SDK",
   "main": "src/index.ts",
   "type": "module",
@@ -43,7 +43,7 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "@composio/core": ">=1.0.0-beta.0 <2.0.0",
+    "@composio/core": ">=0.10.0 <1.0.0 || >=1.0.0-beta.0 <1.0.0",
     "llamaindex": "^0.12.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/mastra/CHANGELOG.md
+++ b/ts/packages/providers/mastra/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @composio/mastra
 
-## 0.10.4-beta.0
+## 0.10.4
 
 ### Patch Changes
 
-- Updated dependencies [fb1b530]
-  - @composio/core@1.0.0-beta.0
+- db7b576: Declare Node.js 22.22.3 as the minimum supported runtime for every published TypeScript package so package managers surface incompatible runtimes before users encounter ESM loading failures.
+- 3c3b4da: `MastraProvider({ strict: true })` now keeps optional parameters instead of dropping them: every property becomes required and optional ones accept `null`, matching the OpenAI providers, and a `null` argument the tool's own schema does not accept is dropped before execution. Tools whose schema strict mode cannot express keep their original schema with a warning.
 
 ## 0.10.3
 

--- a/ts/packages/providers/mastra/package.json
+++ b/ts/packages/providers/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/mastra",
-  "version": "0.10.4-beta.0",
+  "version": "0.10.4",
   "description": "Agentic Provider for mastra in Composio SDK",
   "main": "src/index.ts",
   "type": "module",
@@ -45,7 +45,7 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "@composio/core": ">=1.0.0-beta.0 <2.0.0",
+    "@composio/core": ">=0.10.0 <1.0.0 || >=1.0.0-beta.0 <1.0.0",
     "@mastra/core": "^1.46.0",
     "zod": "^3.25 || ^4"
   },

--- a/ts/packages/providers/openai-agents/CHANGELOG.md
+++ b/ts/packages/providers/openai-agents/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @composio/openai-agents
 
-## 0.10.2-beta.0
+## 0.10.2
 
 ### Patch Changes
 
-- Updated dependencies [fb1b530]
-  - @composio/core@1.0.0-beta.0
+- db7b576: Declare Node.js 22.22.3 as the minimum supported runtime for every published TypeScript package so package managers surface incompatible runtimes before users encounter ESM loading failures.
+- 9692db5: `OpenAIAgentsProvider({ strict: true })` now takes effect: tools are registered with `strict: true` and a schema normalized for OpenAI structured outputs (every property required, optional ones accept `null`), a `null` argument the tool's own schema does not accept is dropped before execution, and tools whose schema strict mode cannot express are registered without strict mode with a warning. The option was previously ignored.
 
 ## 0.10.1
 

--- a/ts/packages/providers/openai-agents/package.json
+++ b/ts/packages/providers/openai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/openai-agents",
-  "version": "0.10.2-beta.0",
+  "version": "0.10.2",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -40,7 +40,7 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "@composio/core": ">=1.0.0-beta.0 <2.0.0",
+    "@composio/core": ">=0.10.0 <1.0.0 || >=1.0.0-beta.0 <1.0.0",
     "@openai/agents": "^0.1.3",
     "zod": "catalog:"
   },

--- a/ts/packages/providers/openai/CHANGELOG.md
+++ b/ts/packages/providers/openai/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @composio/openai
 
-## 0.12.1-beta.0
+## 0.12.1
 
 ### Patch Changes
 
-- Updated dependencies [fb1b530]
-  - @composio/core@1.0.0-beta.0
+- db7b576: Declare Node.js 22.22.3 as the minimum supported runtime for every published TypeScript package so package managers surface incompatible runtimes before users encounter ESM loading failures.
+- 04817cb: Fix strict-mode tool schemas for OpenAI structured outputs. Strict normalization now applies OpenAI's contract at every depth (nested objects, `anyOf` branches, array items, inlined `$ref`/`$defs`): every object lists all of its properties in `required` and sets `additionalProperties: false`, so tools with nested or optional parameters no longer produce schemas the API rejects with a 400. Optional parameters are no longer dropped: they stay available and are widened to accept `null`, the emulation of optional fields OpenAI documents, and the strict providers drop a `null` argument the tool's own schema does not accept before executing the tool. Tools whose schema strict mode cannot express (objects with arbitrary keys, `allOf`, `prefixItems`, unresolved `$ref`s) are sent without strict mode with a warning naming the tool and path, instead of being narrowed. `@composio/core` exports the new `toStrictJsonSchema()` and `omitNullToolArguments()` utilities; `removeNonRequiredProperties` is unchanged for other callers. The Python `OpenAIResponsesProvider` gains a matching opt-in `strict=True` constructor flag that also emits `strict: true` on the wrapped tool.
 
 ## 0.12.0
 

--- a/ts/packages/providers/openai/package.json
+++ b/ts/packages/providers/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/openai",
-  "version": "0.12.1-beta.0",
+  "version": "0.12.1",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -40,7 +40,7 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "@composio/core": ">=1.0.0-beta.0 <2.0.0",
+    "@composio/core": ">=0.10.0 <1.0.0 || >=1.0.0-beta.0 <1.0.0",
     "openai": "^6.49.0 || ^7.0.0"
   },
   "devDependencies": {

--- a/ts/packages/providers/vercel/CHANGELOG.md
+++ b/ts/packages/providers/vercel/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @composio/vercel
 
-## 0.11.2-beta.0
+## 0.11.2
 
 ### Patch Changes
 
-- Updated dependencies [fb1b530]
-  - @composio/core@1.0.0-beta.0
+- db7b576: Declare Node.js 22.22.3 as the minimum supported runtime for every published TypeScript package so package managers surface incompatible runtimes before users encounter ESM loading failures.
+- 04817cb: Fix strict-mode tool schemas for OpenAI structured outputs. Strict normalization now applies OpenAI's contract at every depth (nested objects, `anyOf` branches, array items, inlined `$ref`/`$defs`): every object lists all of its properties in `required` and sets `additionalProperties: false`, so tools with nested or optional parameters no longer produce schemas the API rejects with a 400. Optional parameters are no longer dropped: they stay available and are widened to accept `null`, the emulation of optional fields OpenAI documents, and the strict providers drop a `null` argument the tool's own schema does not accept before executing the tool. Tools whose schema strict mode cannot express (objects with arbitrary keys, `allOf`, `prefixItems`, unresolved `$ref`s) are sent without strict mode with a warning naming the tool and path, instead of being narrowed. `@composio/core` exports the new `toStrictJsonSchema()` and `omitNullToolArguments()` utilities; `removeNonRequiredProperties` is unchanged for other callers. The Python `OpenAIResponsesProvider` gains a matching opt-in `strict=True` constructor flag that also emits `strict: true` on the wrapped tool.
 
 ## 0.11.1
 

--- a/ts/packages/providers/vercel/package.json
+++ b/ts/packages/providers/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composio/vercel",
-  "version": "0.11.2-beta.0",
+  "version": "0.11.2",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -40,7 +40,7 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "@composio/core": ">=1.0.0-beta.0 <2.0.0",
+    "@composio/core": ">=0.10.0 <1.0.0 || >=1.0.0-beta.0 <1.0.0",
     "ai": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR:
- builds on top of https://github.com/ComposioHQ/composio/pull/4263
- restores TypeScript provider manifests and changelogs to the stable versions already published under `latest`
- accepts existing core 0.x releases and `>=1.0.0-beta.0 <1.0.0`, while requiring a provider upgrade for stable core 1.0
- adds release assertions that providers remain stable and a Changesets prerelease fixture proving a core beta does not version providers
- intentionally adds no provider changeset so this correction cannot publish another provider release

Verification:
- `pnpm test:release-workflow`
- `pnpm check:peer-deps`
- `./node_modules/.bin/oxlint ts test tsdown.config.base.ts`
- `./node_modules/.bin/prettier --check test/release-workflow.test.ts \"ts/packages/providers/*/{package.json,CHANGELOG.md}\"`