### PR TITLE
fix(sdk): cap automatic file downloads at 100 MiB

### DIFF
--- a/.changeset/bound-download-size.md
+++ b/.changeset/bound-download-size.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Fix: automatic S3 file downloads are now capped at 100 MiB (configurable per call) to prevent memory exhaustion from oversized or streaming responses.

--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -676,6 +676,7 @@ class FileDownloadable(BaseModel):
         chunk_size: int = _DEFAULT_CHUNK_SIZE,
         *,
         root: Path,
+        max_size: int = _MAX_RESPONSE_SIZE,
     ) -> Path:
         """Fetch the file into ``outdir``.
 
@@ -686,6 +687,10 @@ class FileDownloadable(BaseModel):
             checking containment against a directory that untrusted input has
             already relocated is not a check at all, and ``outdir`` may be
             exactly such a directory. Callers must name the anchor explicitly.
+        :param max_size: Maximum number of bytes to write to disk. ``s3url`` is
+            an API-response field, so the body behind it is untrusted: the
+            streamed byte count is authoritative because ``Content-Length`` can
+            be absent or dishonest.
         """
         # SEC-316: `self.name` also comes from the (potentially compromised or
         # MITM'd) API response. Collapsed to a bare filename and checked against
@@ -712,6 +717,18 @@ class FileDownloadable(BaseModel):
                 f"Error downloading file: {_sanitize_url_for_logging(self.s3url)}"
             )
 
+        # Early abort for a self-declared oversized body. The header is only a
+        # hint — `parse_content_length` returns None for anything untrustworthy
+        # and the streaming counter below is the authoritative limit.
+        content_length = parse_content_length(response.headers.get("Content-Length"))
+        if content_length is not None and content_length > max_size:
+            response.close()
+            raise ResponseTooLargeError(
+                f"File size ({content_length} bytes) exceeds maximum allowed "
+                f"size ({max_size} bytes)"
+            )
+
+        total_bytes = 0
         try:
             # Only once the fetch is validated and connected, so a blocked URL
             # leaves no directory behind — and inside the `try`, so a failure
@@ -719,8 +736,29 @@ class FileDownloadable(BaseModel):
             outdir.mkdir(exist_ok=True, parents=True)
             with outfile.open("wb") as fd:
                 for chunk in response.iter_content(chunk_size=chunk_size):
-                    fd.write(chunk)
+                    if chunk:
+                        total_bytes += len(chunk)
+                        if total_bytes > max_size:
+                            raise ResponseTooLargeError(
+                                "Response size exceeds maximum allowed size "
+                                f"({max_size} bytes)"
+                            )
+                        fd.write(chunk)
+        except ResponseTooLargeError:
+            # Propagates uncaught — callers must see the limit hit — but the
+            # truncated file must not be left behind as if it were the download.
+            outfile.unlink(missing_ok=True)
+            raise
         except requests.exceptions.RequestException as e:
+            outfile.unlink(missing_ok=True)
+            raise ErrorDownloadingFile(
+                "Error downloading file: "
+                f"{_sanitize_url_for_logging(self.s3url)}. Error: {type(e).__name__}"
+            ) from e
+        except OSError as e:
+            # A failing `fd.write` (disk full, permissions) would otherwise
+            # escape the `ErrorDownloadingFile` contract this method documents.
+            outfile.unlink(missing_ok=True)
             raise ErrorDownloadingFile(
                 "Error downloading file: "
                 f"{_sanitize_url_for_logging(self.s3url)}. Error: {type(e).__name__}"

--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import functools
 import hashlib
 import os
@@ -663,6 +664,17 @@ class FileUploadable(BaseModel):
         return cls(name=file.name, mimetype=mimetype, s3key=s3meta.key)
 
 
+def _discard_partial_download(outfile: Path) -> None:
+    """Remove a half-written download so it is never mistaken for the file.
+
+    Cleanup failures are swallowed on purpose: the error that triggered the
+    cleanup is what the caller needs to see, and an ``OSError`` raised from
+    here would replace it.
+    """
+    with contextlib.suppress(OSError):
+        outfile.unlink(missing_ok=True)
+
+
 class FileDownloadable(BaseModel):
     model_config = ConfigDict(json_schema_extra={"file_downloadable": True})
 
@@ -747,18 +759,14 @@ class FileDownloadable(BaseModel):
         except ResponseTooLargeError:
             # Propagates uncaught — callers must see the limit hit — but the
             # truncated file must not be left behind as if it were the download.
-            outfile.unlink(missing_ok=True)
+            _discard_partial_download(outfile)
             raise
-        except requests.exceptions.RequestException as e:
-            outfile.unlink(missing_ok=True)
-            raise ErrorDownloadingFile(
-                "Error downloading file: "
-                f"{_sanitize_url_for_logging(self.s3url)}. Error: {type(e).__name__}"
-            ) from e
         except OSError as e:
-            # A failing `fd.write` (disk full, permissions) would otherwise
-            # escape the `ErrorDownloadingFile` contract this method documents.
-            outfile.unlink(missing_ok=True)
+            # `requests.exceptions.RequestException` subclasses `OSError`, so a
+            # mid-stream transport failure and a failing `fd.write`/`mkdir`
+            # (disk full, permissions) both land here — and both owe the caller
+            # the `ErrorDownloadingFile` this method documents.
+            _discard_partial_download(outfile)
             raise ErrorDownloadingFile(
                 "Error downloading file: "
                 f"{_sanitize_url_for_logging(self.s3url)}. Error: {type(e).__name__}"

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -2630,6 +2630,77 @@ class TestResponseSizeLimit:
         assert mimetype == "image/jpeg"
 
 
+class TestDownloadSizeLimit:
+    """``FileDownloadable.download`` streams an untrusted body to disk."""
+
+    @staticmethod
+    def _downloadable() -> FileDownloadable:
+        return FileDownloadable(
+            name="report.bin",
+            mimetype="application/octet-stream",
+            s3url="https://example.com/report.bin",
+        )
+
+    @patch("composio.core.models._files.safe_get")
+    def test_download_rejects_oversized_content_length(self, mock_get, tmp_path):
+        """A self-declared oversized body is rejected before any bytes are read."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Length": "200000000"}
+        mock_response.close = MagicMock()
+        mock_get.return_value = mock_response
+
+        with pytest.raises(ResponseTooLargeError):
+            self._downloadable().download(outdir=tmp_path, root=tmp_path, max_size=1024)
+
+        mock_response.iter_content.assert_not_called()
+
+    @patch("composio.core.models._files.safe_get")
+    def test_download_rejects_oversized_during_streaming(self, mock_get, tmp_path):
+        """A dishonest (here, absent) Content-Length cannot bypass the cap."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.iter_content.return_value = [b"x" * 512 for _ in range(4)]
+        mock_response.close = MagicMock()
+        mock_get.return_value = mock_response
+
+        with pytest.raises(ResponseTooLargeError):
+            self._downloadable().download(outdir=tmp_path, root=tmp_path, max_size=1024)
+
+    @patch("composio.core.models._files.safe_get")
+    def test_download_removes_partial_file_on_failure(self, mock_get, tmp_path):
+        """A truncated download must not be left behind as if it succeeded."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.iter_content.return_value = [b"x" * 512 for _ in range(4)]
+        mock_response.close = MagicMock()
+        mock_get.return_value = mock_response
+
+        with pytest.raises(ResponseTooLargeError):
+            self._downloadable().download(outdir=tmp_path, root=tmp_path, max_size=1024)
+
+        assert list(tmp_path.iterdir()) == []
+
+    @patch("composio.core.models._files.safe_get")
+    def test_download_accepts_file_within_limit(self, mock_get, tmp_path):
+        """A body under the cap is written through unchanged."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.iter_content.return_value = [b"x" * 256, b"y" * 256]
+        mock_response.close = MagicMock()
+        mock_get.return_value = mock_response
+
+        outfile = self._downloadable().download(
+            outdir=tmp_path, root=tmp_path, max_size=1024
+        )
+
+        assert outfile.exists()
+        assert outfile.read_bytes() == b"x" * 256 + b"y" * 256
+
+
 class TestRedirectHandling:
     """Test redirect handling (redirects should be rejected)."""
 

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -2700,6 +2700,50 @@ class TestDownloadSizeLimit:
         assert outfile.exists()
         assert outfile.read_bytes() == b"x" * 256 + b"y" * 256
 
+    @patch("composio.core.models._files.safe_get")
+    def test_download_wraps_stream_failure_and_removes_partial_file(
+        self, mock_get, tmp_path
+    ):
+        """A transport failure mid-stream keeps the documented error contract."""
+
+        def failing_stream(chunk_size=None):
+            yield b"x" * 256
+            raise requests.exceptions.ConnectionError("connection reset")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.iter_content.side_effect = failing_stream
+        mock_response.close = MagicMock()
+        mock_get.return_value = mock_response
+
+        with pytest.raises(ErrorDownloadingFile):
+            self._downloadable().download(outdir=tmp_path, root=tmp_path, max_size=1024)
+
+        assert list(tmp_path.iterdir()) == []
+
+    @patch("composio.core.models._files.safe_get")
+    def test_download_wraps_write_failure_and_removes_partial_file(
+        self, mock_get, tmp_path
+    ):
+        """A disk failure while writing is an `ErrorDownloadingFile`, not a raw OSError."""
+
+        def failing_stream(chunk_size=None):
+            yield b"x" * 256
+            raise OSError(28, "No space left on device")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.iter_content.side_effect = failing_stream
+        mock_response.close = MagicMock()
+        mock_get.return_value = mock_response
+
+        with pytest.raises(ErrorDownloadingFile):
+            self._downloadable().download(outdir=tmp_path, root=tmp_path, max_size=1024)
+
+        assert list(tmp_path.iterdir()) == []
+
 
 class TestRedirectHandling:
     """Test redirect handling (redirects should be rejected)."""

--- a/ts/packages/core/src/utils/fileUtils.node.ts
+++ b/ts/packages/core/src/utils/fileUtils.node.ts
@@ -340,6 +340,7 @@ export const downloadFileFromS3 = async ({
   mimeType,
   fileDownloadDir,
   signal,
+  maxDownloadBytes,
 }: {
   toolSlug: string;
   s3Url: string;
@@ -350,6 +351,11 @@ export const downloadFileFromS3 = async ({
    */
   fileDownloadDir?: string;
   signal?: AbortSignal;
+  /**
+   * Maximum number of bytes to read from the response before rejecting.
+   * Defaults to {@link MAX_URL_UPLOAD_SIZE_BYTES} (100 MiB).
+   */
+  maxDownloadBytes?: number;
 }): Promise<FileDownloadData> => {
   // SSRF guard: `s3Url` is a field of the tool-execution response, so it is no
   // more trusted than a user-supplied URL — and the bytes it returns are
@@ -358,11 +364,13 @@ export const downloadFileFromS3 = async ({
   if (!response.ok) {
     throw new Error(`Failed to download file: ${response.statusText}`);
   }
-  const data = await response.arrayBuffer();
+  // The response is attacker-influencable and streamed to disk, so the body is
+  // read through the shared size guard rather than buffered wholesale.
+  const data = await readResponseBodyWithLimit(response, maxDownloadBytes);
 
   const extension = getExtensionFromMimeType(mimeType);
   const fileName = generateTimestampedFilename(extension, `${toolSlug}_`);
-  const filePath = saveFile(fileName, new Uint8Array(data), {
+  const filePath = saveFile(fileName, data, {
     isTempFile: fileDownloadDir === undefined,
     outputDir: fileDownloadDir,
   });

--- a/ts/packages/core/test/utils/fileUtils.test.ts
+++ b/ts/packages/core/test/utils/fileUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import * as path from 'node:path';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { getFileDataAfterUploadingToS3, downloadFileFromS3 } from '../../src/utils/fileUtils.node';
 import ComposioClient from '@composio/client';
 import { ComposioSensitiveFilePathBlockedError } from '../../src/errors/FileModifierErrors';

--- a/ts/packages/core/test/utils/fileUtils.test.ts
+++ b/ts/packages/core/test/utils/fileUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import * as path from 'node:path';
+import * as fs from 'fs';
 import { getFileDataAfterUploadingToS3, downloadFileFromS3 } from '../../src/utils/fileUtils.node';
 import ComposioClient from '@composio/client';
 import { ComposioSensitiveFilePathBlockedError } from '../../src/errors/FileModifierErrors';
@@ -64,6 +65,10 @@ const fetchedFileResponse = (contentType: string = 'application/pdf') =>
     status: 200,
     headers: { 'content-type': contentType },
   });
+
+/** A small, well-formed S3 download response (no `content-length` header). */
+const downloadedFileResponse = (body: Uint8Array = new Uint8Array(10)) =>
+  new Response(body, { status: 200 });
 
 describe('fileUtils', () => {
   let mockClient: ComposioClient;
@@ -314,10 +319,7 @@ describe('fileUtils', () => {
 
   describe('downloadFileFromS3', () => {
     it('should generate filename with tool slug prefix', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        arrayBuffer: () => Promise.resolve(new ArrayBuffer(10)),
-      });
+      mockFetch.mockResolvedValue(downloadedFileResponse());
 
       const result = await downloadFileFromS3({
         toolSlug: 'github',
@@ -329,10 +331,7 @@ describe('fileUtils', () => {
     });
 
     it('should handle MIME types with + in downloadFileFromS3', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        arrayBuffer: () => Promise.resolve(new ArrayBuffer(10)),
-      });
+      mockFetch.mockResolvedValue(downloadedFileResponse());
 
       const result = await downloadFileFromS3({
         toolSlug: 'api-tool',
@@ -364,10 +363,7 @@ describe('fileUtils', () => {
       // If a future change started reflecting the s3Url path or query into
       // the local filename, an attacker-controlled CDN response could write
       // outside the download dir or stomp on existing files.
-      mockFetch.mockResolvedValue({
-        ok: true,
-        arrayBuffer: () => Promise.resolve(new ArrayBuffer(10)),
-      });
+      mockFetch.mockResolvedValue(downloadedFileResponse());
 
       const result = await downloadFileFromS3({
         toolSlug: 'github',
@@ -390,10 +386,7 @@ describe('fileUtils', () => {
       // could in theory smuggle path components into the saved filename.
       // `saveFile` defends against that by running the assembled filename
       // through `path.basename` before joining with the download dir.
-      mockFetch.mockResolvedValue({
-        ok: true,
-        arrayBuffer: () => Promise.resolve(new ArrayBuffer(10)),
-      });
+      mockFetch.mockResolvedValue(downloadedFileResponse());
 
       const result = await downloadFileFromS3({
         toolSlug: 'AAA/../etc/passwd',
@@ -408,6 +401,39 @@ describe('fileUtils', () => {
       expect(result.filePath).toBeDefined();
       expect(path.dirname(result.filePath as string)).not.toContain('etc');
       expect(path.basename(result.filePath as string)).toBe('passwd_1640995200000abc12345.txt');
+    });
+
+    it('rejects a stream that exceeds the download limit and writes nothing', async () => {
+      // `s3Url` is an API-response field, so the body behind it is untrusted:
+      // without a cap, a dishonest (or absent) Content-Length lets the server
+      // stream unbounded bytes into the host process's heap and onto disk.
+      mockFetch.mockResolvedValue(downloadedFileResponse(new Uint8Array(2048)));
+
+      await expect(
+        downloadFileFromS3({
+          toolSlug: 'github',
+          s3Url: 'https://s3.example.com/huge.bin',
+          mimeType: 'text/plain',
+          maxDownloadBytes: 1024,
+        })
+      ).rejects.toThrow(/exceeds maximum allowed size/);
+
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('downloads a body within the limit', async () => {
+      const body = new Uint8Array(512).fill(7);
+      mockFetch.mockResolvedValue(downloadedFileResponse(body));
+
+      const result = await downloadFileFromS3({
+        toolSlug: 'github',
+        s3Url: 'https://s3.example.com/small.bin',
+        mimeType: 'text/plain',
+        maxDownloadBytes: 1024,
+      });
+
+      expect(result.filePath).toBeDefined();
+      expect(fs.writeFileSync).toHaveBeenCalledWith(result.filePath, body);
     });
   });
 


### PR DESCRIPTION
This PR:

- caps automatic S3 file downloads at 100 MiB in both SDKs — these were the only fetch paths left without a size limit, and `s3url` is a tool-execution response field, so the body behind it is no more trusted than a user-supplied URL (the same input the SSRF guard already defends against)
- TypeScript: `downloadFileFromS3` buffered the whole body with `response.arrayBuffer()`; it now reads through the existing `readResponseBodyWithLimit` guard, overridable per call via `maxDownloadBytes`
- Python: `FileDownloadable.download` streamed straight to disk with no byte accounting; it now uses the same `Content-Length` pre-check plus authoritative streamed-byte counter as its sibling `_fetch_file_from_url`, overridable via `max_size`
- fixes two latent defects in the Python write loop found along the way:
  - an `OSError` from `fd.write` (disk full, permissions) escaped the `ErrorDownloadingFile` contract the method documents, surfacing as a raw `OSError(28)`
  - every failure left a partial file on disk that no caller was told about; cleanup now runs on all error paths via `_discard_partial_download()`, which suppresses cleanup failures so an `unlink` error cannot replace the error the caller needs to see
- adds 8 regression tests (2 TypeScript, 6 Python) covering oversized `Content-Length`, oversized streaming with no/dishonest header, partial-file cleanup, transport and write failures, and the within-limit success path
- not a breaking change: the caps default to the existing 100 MiB used by both sibling paths, and both new parameters are optional

## Context

The streamed byte counter — not the `Content-Length` check — is the authoritative limit in both SDKs, because a malicious or misconfigured server can omit or lie in that header. The header check is only an early abort.

Deliberately out of scope: `RemoteFile.buffer()` / `RemoteFile.blob()` in `ts/packages/core/src/models/RemoteFile.ts` are explicit user-initiated whole-file reads. The same `readResponseBodyWithLimit` treatment is the natural follow-up, but they are not on the automatic path this PR closes.