### PR TITLE
fix(openai): stop logging MCP server URLs to stdout

### DIFF
--- a/.changeset/mcp-url-log-leak.md
+++ b/.changeset/mcp-url-log-leak.md
@@ -1,0 +1,5 @@
+---
+'@composio/openai': patch
+---
+
+Fix: stop printing MCP server URLs (credential-bearing) to stdout via console.log in the OpenAI Responses provider; log server names via logger.debug instead.

--- a/ts/packages/providers/openai/src/OpenAIResponsesProvider.ts
+++ b/ts/packages/providers/openai/src/OpenAIResponsesProvider.ts
@@ -100,7 +100,9 @@ export class OpenAIResponsesProvider extends BaseNonAgenticProvider<
    * @returns OpenAI-specific MCP server response format
    */
   override wrapMcpServerResponse(data: McpUrlResponse): OpenAiMcpTool[] {
-    console.log('Wrapping MCP server response', data);
+    logger.debug(
+      `Wrapping MCP server response for ${data.length} server(s): ${data.map(server => server.name).join(', ')}`
+    );
     return data.map(item => ({
       type: 'mcp',
       server_label: item.name,

--- a/ts/packages/providers/openai/test/opeanai-responses.test.ts
+++ b/ts/packages/providers/openai/test/opeanai-responses.test.ts
@@ -263,6 +263,19 @@ describe('OpenAIResponsesProvider', () => {
     });
   });
 
+  describe('wrapMcpServerResponse', () => {
+    it('never logs MCP server URLs to stdout', () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const mcpUrl = 'https://mcp.example.com/t/super-secret-token';
+      const result = provider.wrapMcpServerResponse([{ name: 'srv', url: mcpUrl }]);
+      expect(logSpy).not.toHaveBeenCalled();
+      logSpy.mockRestore();
+      expect(result).toEqual([
+        { type: 'mcp', server_label: 'srv', server_url: mcpUrl, require_approval: 'never' },
+      ]);
+    });
+  });
+
   describe('wrapTools', () => {
     it('should wrap multiple tools', () => {
       const anotherTool: Tool = {


### PR DESCRIPTION
This PR:
- replaces the `console.log` in `wrapMcpServerResponse` with a redacted `logger.debug` line (server names and count only)
- MCP URLs are user-scoped, bearer-equivalent endpoints; they previously landed in stdout and aggregated production logs on every call
- adds a regression test asserting no stdout write and an unchanged return shape
- treats MCP URLs already captured in existing logs as exposed; regenerate those endpoints server-side