### PR TITLE
docs(anthropic): clarify handle_tool_calls result ordering [DEMO — DO NOT MERGE]

### DIFF
--- a/docs/content/docs/providers/anthropic.mdx
+++ b/docs/content/docs/providers/anthropic.mdx
@@ -84,6 +84,8 @@ response = client.messages.create(
 # Agentic loop: keep executing tool calls until the model responds with text
 while response.stop_reason == "tool_use":
     tool_use_blocks = [block for block in response.content if block.type == "tool_use"]
+    # Run every tool call Claude requested through the session; the results
+    # come back in the same order the model called them.
     results = composio.provider.handle_tool_calls(response=response, session=session)
     messages.append({"role": "assistant", "content": response.content})
     messages.append({


### PR DESCRIPTION
**Demo PR for a docs-agent-eval walkthrough video. DO NOT MERGE.**

A small, valid docs improvement: a clarifying comment on the tool-call line in the Anthropic Messages-API example. The code is unchanged and correct, so the eval should PASS on this PR.

Paired with a companion PR that introduces a docs regression (expected FAIL) to show both states of the check.