### PR TITLE
docs(anthropic): tidy the Messages API tool-call helper name [DEMO — DO NOT MERGE]

### DIFF
--- a/docs/content/docs/migration-guide/new-sdk.mdx
+++ b/docs/content/docs/migration-guide/new-sdk.mdx
@@ -318,7 +318,7 @@ response = openai_client.chat.completions.create(
     tools=tools,
 )
 
-result = composio.provider.handle_tool_calls(user_id="user@acme.com", response=response)
+result = composio.provider.execute_tool_calls(user_id="user@acme.com", response=response)
 print(result)
 ```
   </Tab>
@@ -351,7 +351,7 @@ const msg = await anthropic.messages.create({
   max_tokens: 1024,
 });
 
-const result = await composio.provider.handleToolCalls(userId, msg);
+const result = await composio.provider.executeToolCalls(userId, msg);
 console.log('Tool results:', result);
 ```
   </Tab>

--- a/docs/content/docs/providers/anthropic.mdx
+++ b/docs/content/docs/providers/anthropic.mdx
@@ -84,7 +84,7 @@ response = client.messages.create(
 # Agentic loop: keep executing tool calls until the model responds with text
 while response.stop_reason == "tool_use":
     tool_use_blocks = [block for block in response.content if block.type == "tool_use"]
-    results = composio.provider.handle_tool_calls(response=response, session=session)
+    results = composio.provider.execute_tool_calls(response=response)
     messages.append({"role": "assistant", "content": response.content})
     messages.append({
         "role": "user",

--- a/docs/content/docs/providers/anthropic.mdx
+++ b/docs/content/docs/providers/anthropic.mdx
@@ -57,53 +57,19 @@ Passing a session to `handle_tool_calls` / `handleToolCalls` requires `composio`
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
 <Tab value="Python">
 ```python
-import json
+from composio_openai import ComposioToolSet, Action
 
-import anthropic
-from composio import Composio
-from composio_anthropic import AnthropicProvider
+# ComposioToolSet is the entry point for fetching and running tools.
+toolset = ComposioToolSet()
 
-composio = Composio(provider=AnthropicProvider())
-client = anthropic.Anthropic()
+# Fetch a tool by its action name, then run it directly. No session needed.
+tools = toolset.get_tools(actions=[Action.WEATHERMAP_WEATHER])
 
-# Create a session for your user
-session = composio.create(user_id="user_123")
-tools = session.tools()
-
-messages = [
-    {"role": "user", "content": "Send an email to john@example.com with the subject 'Hello' and body 'Hello from Composio!'"}
-]
-
-response = client.messages.create(
-    model="claude-opus-4-6",
-    max_tokens=4096,
-    tools=tools,
-    messages=messages,
+result = toolset.execute_action(
+    action=Action.WEATHERMAP_WEATHER,
+    params={"location": "San Francisco"},
 )
-
-# Agentic loop: keep executing tool calls until the model responds with text
-while response.stop_reason == "tool_use":
-    tool_use_blocks = [block for block in response.content if block.type == "tool_use"]
-    results = composio.provider.execute_tool_calls(response=response)
-    messages.append({"role": "assistant", "content": response.content})
-    messages.append({
-        "role": "user",
-        "content": [
-            {"type": "tool_result", "tool_use_id": tool_use_blocks[i].id, "content": json.dumps(result)}
-            for i, result in enumerate(results)
-        ],
-    })
-    response = client.messages.create(
-        model="claude-opus-4-6",
-        max_tokens=4096,
-        tools=tools,
-        messages=messages,
-    )
-
-# Print final response
-for block in response.content:
-    if block.type == "text":
-        print(block.text)
+print(result)
 ```
 </Tab>
 <Tab value="TypeScript">

--- a/docs/content/docs/providers/openai.mdx
+++ b/docs/content/docs/providers/openai.mdx
@@ -55,7 +55,7 @@ OPENAI_API_KEY=xxxxxxxxx
 The [Responses API](https://platform.openai.com/docs/api-reference/responses) is the recommended way to build agentic flows with OpenAI. You pass `previous_response_id` on each turn so the model keeps the prior context, and you send back only the new `function_call_output` items.
 
 <Callout type="info">
-Passing a session to `handle_tool_calls` / `handleToolCalls` requires `composio` newer than 0.19.0 (Python) or `@composio/core` ≥ 0.17.0 with `@composio/openai` ≥ 0.12.0 (TypeScript). On earlier versions, execute session tools with [`session.execute()`](/docs/how-composio-works#executing-session-tools).
+Passing a session to `execute_tool_calls` / `executeToolCalls` requires `composio` newer than 0.19.0 (Python) or `@composio/core` ≥ 0.17.0 with `@composio/openai` ≥ 0.12.0 (TypeScript). On earlier versions, execute session tools with [`session.execute()`](/docs/how-composio-works#executing-session-tools).
 </Callout>
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
@@ -89,7 +89,7 @@ while True:
     tool_calls = [o for o in response.output if o.type == "function_call"]
     if not tool_calls:
         break
-    results = composio.provider.handle_tool_calls(response=response, session=session)
+    results = composio.provider.execute_tool_calls(response=response, session=session)
     response = client.responses.create(
         model="gpt-5.2",
         tools=tools,
@@ -141,7 +141,7 @@ while (true) {
     const toolCalls = response.output.filter((o) => o.type === "function_call");
     if (toolCalls.length === 0) break;
 
-    const outputs = await composio.provider.handleToolCalls(session, response.output);
+    const outputs = await composio.provider.executeToolCalls(session, response.output);
     response = await client.responses.create({
         model: "gpt-5.2",
         tools: tools,
@@ -203,7 +203,7 @@ OPENAI_API_KEY=xxxxxxxxx
 The [Chat Completions API](https://platform.openai.com/docs/api-reference/chat) generates a model response from a list of messages. You keep the full message list yourself and append each assistant message and its `tool` results before the next call.
 
 <Callout type="info">
-Passing a session to `handle_tool_calls` / `handleToolCalls` requires `composio` newer than 0.19.0 (Python) or `@composio/core` ≥ 0.17.0 with `@composio/openai` ≥ 0.12.0 (TypeScript). On earlier versions, execute session tools with [`session.execute()`](/docs/how-composio-works#executing-session-tools).
+Passing a session to `execute_tool_calls` / `executeToolCalls` requires `composio` newer than 0.19.0 (Python) or `@composio/core` ≥ 0.17.0 with `@composio/openai` ≥ 0.12.0 (TypeScript). On earlier versions, execute session tools with [`session.execute()`](/docs/how-composio-works#executing-session-tools).
 </Callout>
 
 <Tabs groupId="language" items={["Python", "TypeScript"]} persist>
@@ -233,7 +233,7 @@ response = client.chat.completions.create(
 
 # Agentic loop: keep executing tool calls until the model responds with text
 while response.choices[0].message.tool_calls:
-    results = composio.provider.handle_tool_calls(response=response, session=session)
+    results = composio.provider.execute_tool_calls(response=response, session=session)
     messages.append(response.choices[0].message)
     for i, tc in enumerate(response.choices[0].message.tool_calls):
         messages.append({
@@ -280,7 +280,7 @@ let response = await client.chat.completions.create({
 
 // Agentic loop: keep executing tool calls until the model responds with text
 while (response.choices[0].message.tool_calls) {
-    const results = await composio.provider.handleToolCalls(session, response);
+    const results = await composio.provider.executeToolCalls(session, response);
     messages.push(response.choices[0].message);
     messages.push(...results);
     response = await client.chat.completions.create({
@@ -402,12 +402,12 @@ console.log(result.finalOutput);
 
 The OpenAI integration ships three providers, one per API surface:
 
-- **`OpenAIResponsesProvider`** for the Responses API. `handleToolCalls` executes each `function_call` and returns `function_call_output` items keyed by `call_id`, paired with `previous_response_id` so you only resend new outputs each turn.
+- **`OpenAIResponsesProvider`** for the Responses API. `executeToolCalls` executes each `function_call` and returns `function_call_output` items keyed by `call_id`, paired with `previous_response_id` so you only resend new outputs each turn.
 - **`OpenAIProvider`** for the Chat Completions API. This is the SDK default, so `new Composio()` with no provider uses it. You keep the full message list and append each assistant message plus its `tool` results yourself.
 - **`OpenAIAgentsProvider`** for the Agents SDK. Tools come with execution wired in, so the SDK runs the loop for you.
 
 <Callout type="info">
-Pass the session to `handleToolCalls` / `handle_tool_calls` when the model received tools from `session.tools()`. The helper preserves the provider's argument normalization and executes every call through that session. For tools fetched via [`tools.get`](/docs/tools-direct/executing-tools), pass the user ID instead.
+Pass the session to `executeToolCalls` / `execute_tool_calls` when the model received tools from `session.tools()`. The helper preserves the provider's argument normalization and executes every call through that session. For tools fetched via [`tools.get`](/docs/tools-direct/executing-tools), pass the user ID instead.
 </Callout>
 
 Use the Responses or Agents provider for new agentic flows; reach for Chat Completions when you are extending an existing Chat Completions codebase.

--- a/docs/content/docs/tools-direct/executing-tools.mdx
+++ b/docs/content/docs/tools-direct/executing-tools.mdx
@@ -76,7 +76,7 @@ result = openai.chat.completions.create(
 )
 
 # Handle tool calls
-result = composio.provider.handle_tool_calls(user_id=user_id, response=result)
+result = composio.provider.execute_tool_calls(user_id=user_id, response=result)
 print(result)
 ```
   </Tab>
@@ -117,7 +117,7 @@ const msg = await anthropic.messages.create({
 });
 
 // Handle tool calls
-const result = await composio.provider.handleToolCalls(userId, msg);
+const result = await composio.provider.executeToolCalls(userId, msg);
 console.log('Results:', JSON.stringify(result, null, 2));
 ```
   </Tab>


### PR DESCRIPTION
**Demo PR for a docs-agent-eval walkthrough video. DO NOT MERGE.**

This PR introduces a docs regression on purpose: the Anthropic Messages-API example now calls `composio.provider.execute_tool_calls(response=response)`, which is NOT a real method (the correct one is `handle_tool_calls(response=..., session=...)`). An agent building only from these docs will copy the broken call and fail at runtime.

Expected result: the docs-only gating arm FAILS, while the full-internet control arm PASSES (it knows the real method) — demonstrating the check pinpoints the docs page, not the task, as the blocker. Companion to the passing demo PR.