### PR TITLE
fix(providers/anthropic): re-export AnthropicTool, InputSchema, and CacheControlEphemeral types (#4286)

### DIFF
--- a/ts/packages/providers/anthropic/src/index.ts
+++ b/ts/packages/providers/anthropic/src/index.ts
@@ -35,6 +35,8 @@ export type AnthropicMcpServerGetResponse = {
   name: string;
 }[];
 
+export type { AnthropicTool, InputSchema, CacheControlEphemeral } from './types';
+
 /**
  * Collection of Anthropic tools
  */


### PR DESCRIPTION
## Summary
- Re-exports `AnthropicTool`, `InputSchema`, and `CacheControlEphemeral` types from `@composio/anthropic` entry point (`ts/packages/providers/anthropic/src/index.ts`).
- Allows TypeScript users to import schema types directly without reaching into internal paths.

## Test Plan
- Verified index exports in `@composio/anthropic`.