### PR TITLE
fix: update Python package license classifiers from Apache-2.0 to MIT

### DIFF
--- a/python/providers/anthropic/pyproject.toml
+++ b/python/providers/anthropic/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/anthropic/setup.py
+++ b/python/providers/anthropic/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",

--- a/python/providers/autogen/pyproject.toml
+++ b/python/providers/autogen/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/autogen/setup.py
+++ b/python/providers/autogen/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",

--- a/python/providers/claude_agent_sdk/pyproject.toml
+++ b/python/providers/claude_agent_sdk/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/claude_agent_sdk/setup.py
+++ b/python/providers/claude_agent_sdk/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",

--- a/python/providers/crewai/pyproject.toml
+++ b/python/providers/crewai/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/crewai/setup.py
+++ b/python/providers/crewai/setup.py
@@ -15,7 +15,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",

--- a/python/providers/gemini/pyproject.toml
+++ b/python/providers/gemini/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/gemini/setup.py
+++ b/python/providers/gemini/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",

--- a/python/providers/google/pyproject.toml
+++ b/python/providers/google/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/google/setup.py
+++ b/python/providers/google/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",

--- a/python/providers/google_adk/pyproject.toml
+++ b/python/providers/google_adk/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/google_adk/setup.py
+++ b/python/providers/google_adk/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",

--- a/python/providers/langchain/pyproject.toml
+++ b/python/providers/langchain/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/langchain/setup.py
+++ b/python/providers/langchain/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",

--- a/python/providers/langgraph/pyproject.toml
+++ b/python/providers/langgraph/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/langgraph/setup.py
+++ b/python/providers/langgraph/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",

--- a/python/providers/llamaindex/pyproject.toml
+++ b/python/providers/llamaindex/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/llamaindex/setup.py
+++ b/python/providers/llamaindex/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",

--- a/python/providers/openai/pyproject.toml
+++ b/python/providers/openai/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/openai/setup.py
+++ b/python/providers/openai/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",

--- a/python/providers/openai_agents/pyproject.toml
+++ b/python/providers/openai_agents/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/openai_agents/setup.py
+++ b/python/providers/openai_agents/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/composiohq/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",


### PR DESCRIPTION
## Summary

Fixes #4261

The repo's `LICENSE` file is MIT, but all Python package classifiers declared `"License :: OSI Approved :: Apache Software License"`. This caused packaging ambiguity downstream — conda-forge had to guess which license to trust when packaging `composio-langchain`.

### Changes

Updated the license classifier in **26 files** (13 `setup.py` + 13 `pyproject.toml`) across all Python packages:

```diff
- "License :: OSI Approved :: Apache Software License",
+ "License :: OSI Approved :: MIT License",
```

**Affected packages:**
- `composio` (core)
- `composio-anthropic`
- `composio-autogen`
- `composio-claude-agent-sdk`
- `composio-crewai`
- `composio-gemini`
- `composio-google`
- `composio-google-adk`
- `composio-langchain`
- `composio-langgraph`
- `composio-llamaindex`
- `composio-openai`
- `composio-openai-agents`

No functional code changes — metadata only.

## Test plan

- [x] All classifiers now match the repo's MIT LICENSE file
- [x] No remaining Apache references in package metadata
- [x] `grep -r "Apache" python/ --include="*.py" --include="*.toml"` returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)