### PR TITLE
fix(core): respect authConfigId in trigger subscriptions

### DIFF
--- a/.changeset/trigger-auth-config-filter.md
+++ b/.changeset/trigger-auth-config-filter.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Fix trigger subscriptions ignoring the `authConfigId` filter.

--- a/ts/packages/core/src/models/Triggers.ts
+++ b/ts/packages/core/src/models/Triggers.ts
@@ -558,7 +558,10 @@ export class Triggers<TProvider extends BaseComposioProvider<unknown, unknown, u
       return false;
     }
 
-    // Check if authConfigId filter matches
+    // Check if authConfigId filter matches.
+    // Only V3 trigger payloads (and the legacy TriggerData shape) carry an auth config id;
+    // V1/V2 payloads and non-trigger V3 events normalize it to '', so this filter drops
+    // those events entirely. This mirrors the Python SDK's `auth_config_id` filter.
     if (
       filters.authConfigId &&
       filters.authConfigId !== data.metadata.connectedAccount.authConfigId

--- a/ts/packages/core/src/models/Triggers.ts
+++ b/ts/packages/core/src/models/Triggers.ts
@@ -558,6 +558,18 @@ export class Triggers<TProvider extends BaseComposioProvider<unknown, unknown, u
       return false;
     }
 
+    // Check if authConfigId filter matches
+    if (
+      filters.authConfigId &&
+      filters.authConfigId !== data.metadata.connectedAccount.authConfigId
+    ) {
+      logger.debug(
+        'Trigger does not match authConfigId filter',
+        JSON.stringify(filters.authConfigId, null, 2)
+      );
+      return false;
+    }
+
     // Check if triggerName filter matches
     if (
       filters.triggerSlug?.length &&

--- a/ts/packages/core/test/models/triggers.test.ts
+++ b/ts/packages/core/test/models/triggers.test.ts
@@ -1251,6 +1251,16 @@ describe('Triggers', () => {
       expect(logger.debug).toHaveBeenCalledWith('Parsed Pusher payload as V3 format');
     });
 
+    it('should not call callback when V3 auth config does not match', async () => {
+      await triggers.subscribe(mockCallback, { authConfigId: 'auth-other' });
+      const subscribeCall = vi.mocked(mockPusherService.subscribe).mock.calls[0];
+      const filterCallback = subscribeCall[0];
+
+      filterCallback(mockV3Payload);
+
+      expect(mockCallback).not.toHaveBeenCalled();
+    });
+
     it('should parse V2 Pusher payload', async () => {
       await triggers.subscribe(mockCallback);
       const subscribeCall = vi.mocked(mockPusherService.subscribe).mock.calls[0];


### PR DESCRIPTION
## Summary

- Apply the existing authConfigId subscription filter to incoming trigger events.
- Add a V3 regression test for mismatched auth configurations.
- Add a patch changeset for @composio/core.

Previously, a subscription filtered by authConfigId still invoked its callback for events belonging to a different auth configuration.

## Verification

- Vitest targeted tests: 76 passed
- Vitest core suite: 1244 passed, 2 expected failures
- TypeScript typecheck and Prettier passed

Fixes the missing authConfigId filtering in trigger subscriptions.
