### PR TITLE
fix(cli): route URL tool-input uploads through ssrfSafeFetch

### DIFF
--- a/ts/packages/cli/src/services/tool-file-uploads.ts
+++ b/ts/packages/cli/src/services/tool-file-uploads.ts
@@ -5,7 +5,7 @@
 // is run to completion inside this promise pipeline.
 import type { FileSystem, Path } from '@effect/platform';
 import type { Composio as RawComposioClient } from '@composio/client';
-import { assertSafeFileUploadPath } from '@composio/core';
+import { assertSafeFileUploadPath, ssrfSafeFetch } from '@composio/core';
 import { Cause, Data, Effect, Exit, Predicate } from 'effect';
 import { guessToolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
 
@@ -143,7 +143,12 @@ export const findFileUploadablePaths = (
 };
 
 const readFileFromUrl = async (path: Path.Path, url: string) => {
-  const response = await fetch(url);
+  // ssrfSafeFetch: URL tool inputs are attacker-influenced (the documented
+  // threat model is a prompt-injected agent supplying its own tool
+  // arguments), so loopback/RFC1918/link-local targets and redirects to
+  // them must be refused — the core SDK applies the same guard to this
+  // exact pipeline (fileUtils.node.ts readFileContentFromURL).
+  const response = await ssrfSafeFetch(url);
   if (!response.ok) {
     throw new ToolFileUploadError({
       message: `Failed to fetch file: ${response.statusText}`,
@@ -249,7 +254,9 @@ const uploadFile = async (params: {
     toolkit_slug: params.toolkitSlug,
   });
 
-  const uploadResponse = await fetch(presigned.new_presigned_url, {
+  // Guarded like the core upload path: a compromised/intercepted presign
+  // response naming an internal address must not receive the file bytes.
+  const uploadResponse = await ssrfSafeFetch(presigned.new_presigned_url, {
     method: 'PUT',
     body: fileData.bytes,
     headers: {

--- a/ts/packages/cli/test/src/services/tool-file-uploads.test.ts
+++ b/ts/packages/cli/test/src/services/tool-file-uploads.test.ts
@@ -6,7 +6,7 @@ import { FileSystem, Path } from '@effect/platform';
 import { BunFileSystem, BunPath } from '@effect/platform-bun';
 import { Effect, Layer } from 'effect';
 import { Composio as RawComposioClient } from '@composio/client';
-import { ComposioSensitiveFilePathBlockedError } from '@composio/core';
+import { ComposioBlockedInternalUrlError, ComposioSensitiveFilePathBlockedError } from '@composio/core';
 import { schemaHasFileUploadable, uploadToolInputFiles } from 'src/services/tool-file-uploads';
 
 // Schema with a single `file_uploadable` attachment field — mirrors tools like
@@ -163,4 +163,89 @@ describe('uploadToolInputFiles — sensitive-path guard (issue #3746)', () => {
       Effect.ensuring(Effect.sync(() => rmSync(root, { recursive: true, force: true })))
     );
   });
+});
+
+
+describe('uploadToolInputFiles — URL source SSRF guard', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // URL tool inputs are attacker-influenced (the documented threat model is a
+  // prompt-injected agent supplying its own tool arguments): a loopback,
+  // link-local, or RFC1918 target — reached directly or through a redirect —
+  // must be refused before any upload happens.
+  it.each([
+    'http://127.0.0.1:8080/secret',
+    'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+    'http://10.1.2.3/internal',
+    'http://192.168.1.10/admin',
+  ])('refuses to fetch URL tool input from an internal address (%s)', (url) =>
+    Effect.gen(function* () {
+      const fsApi = yield* FileSystem.FileSystem;
+      const pathApi = yield* Path.Path;
+      const createPresignedURL = vi.fn();
+      const client = makeClient(createPresignedURL);
+
+      yield* Effect.promise(() =>
+        expect(
+          uploadToolInputFiles({
+            fs: fsApi,
+            path: pathApi,
+            toolSlug: 'GMAIL_SEND_EMAIL',
+            arguments_: { attachment: url },
+            inputSchema,
+            client,
+          })
+        ).rejects.toBeInstanceOf(ComposioBlockedInternalUrlError)
+      );
+
+      // The guard must fire BEFORE any presign round-trip or upload.
+      expect(createPresignedURL).not.toHaveBeenCalled();
+    }).pipe(Effect.provide(Layer.mergeAll(BunFileSystem.layer, BunPath.layer)))
+  );
+
+  it.effect(
+    'still uploads a public URL source (guard does not over-block)',
+    () =>
+      Effect.gen(function* () {
+        const fsApi = yield* FileSystem.FileSystem;
+        const pathApi = yield* Path.Path;
+        const createPresignedURL = vi.fn(async () => ({
+          new_presigned_url: 'https://s3.example.com/put',
+          key: 's3key-123',
+        }));
+        const client = makeClient(createPresignedURL);
+
+        // Public target: the ssrf guard lets it through and the (stubbed)
+        // fetch serves bytes; the pipeline completes with an @tmpfile.
+        vi.stubGlobal(
+          'fetch',
+          vi.fn(async () => ({
+            ok: true,
+            statusText: 'OK',
+            arrayBuffer: async () => new TextEncoder().encode('file-bytes').buffer,
+          }))
+        );
+
+        const result = yield* Effect.promise(() =>
+          uploadToolInputFiles({
+            fs: fsApi,
+            path: pathApi,
+            toolSlug: 'GMAIL_SEND_EMAIL',
+            arguments_: { attachment: 'https://example.com/report.pdf' },
+            inputSchema,
+            client,
+          })
+        );
+
+        expect(result).toEqual([
+          expect.objectContaining({
+            fieldName: 'attachment',
+            filename: 'report.pdf',
+          }),
+        ]);
+      }).pipe(Effect.provide(Layer.mergeAll(BunFileSystem.layer, BunPath.layer)))
+  );
 });

--- a/ts/packages/core/src/index.ts
+++ b/ts/packages/core/src/index.ts
@@ -23,6 +23,8 @@ export type {
   StrictJsonSchemaResult,
 } from './utils/jsonSchema';
 export { getExtensionFromMimeType } from './utils/mime';
+export { ssrfSafeFetch } from './utils/ssrfGuard.node';
+export { ComposioBlockedInternalUrlError } from './errors/SsrfErrors';
 export { normalizeToolArguments } from './utils/toolArguments';
 // Sensitive-file-upload denylist guard. This is the single canonical
 // implementation; downstream packages (e.g. `@composio/cli`) import it here so


### PR DESCRIPTION
## Summary

The CLI's tool-input file upload pipeline fetched URL sources with a bare `fetch()`:

- `ts/packages/cli/src/services/tool-file-uploads.ts` — `readFileFromUrl` (`fetch(url)`) and the presigned-URL `PUT`.
- A URL tool input is attacker-influenced: the file's own comment block documents the threat model ("the primary attack vector is the agent being prompt-injected into supplying its own tool arguments"), e.g. `composio tools execute <slug> -d '{"attachment": "http://169.254.169.254/latest/meta-data/iam/security-credentials/"}'`.
- Consequences: blind SSRF / internal service probing from the user's machine, and — because the response body is uploaded to the presigned URL and passed as tool input — an exfiltration channel for a prompt-injected agent. Redirects were followed (`redirect: 'follow'`), so a public URL 302-ing to an internal address also passed.

The core SDK guards this **exact pipeline** with `ssrfSafeFetch` (`core/src/utils/fileUtils.node.ts` — both the source read and the presigned PUT, the latter with its own comment about internal addresses in presign responses), but the CLI package had never adopted it. The stale comment in `assertSafeFileUploadPath` ("URLs and File objects are deliberately not path-checked, consistent with core") predates core adding the URL guard.

## Changes

- `tool-file-uploads.ts`: both fetches now go through `ssrfSafeFetch` (loopback/RFC1918/link-local refused, redirects re-validated per hop, DNS-rebinding pinned — the same guarantees core has).
- `core/src/index.ts`: export `ssrfSafeFetch` and `ComposioBlockedInternalUrlError` (both already public-API quality; core consumes them internally today).
- Tests (`tool-file-uploads.test.ts`): parameterized refusal of `127.0.0.1`, `169.254.169.254`, and RFC1918 sources with `createPresignedURL` asserted uncalled (guard fires before any network round-trip), plus a public-URL happy path proving no over-blocking.

## Notes

- Verified the attack chain statically end to end (`parseArguments` → `uploadToolInputFiles` → `readUploadSource` → `readFileFromUrl`), including the agent path (`run-helpers-runtime.ts` `execute(slug, data)` builds the same CLI invocation with LLM-chosen arguments).
- Local typecheck of the full monorepo isn't runnable on my machine (needs the bun-based build chain); the patch is a call-for-call swap onto a function whose signature is `(url: string, init?: RequestInit) => Promise<Response>`, and CI's typecheck + tests cover it.
