### PR TITLE
fix(cli): keep credential files private and redact API keys from debug logs

### DIFF
--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -131,7 +131,10 @@ const writePendingLoginSession = (session: Omit<PendingLoginSession, 'cachedAt'>
       ...session,
       cachedAt: new Date().toISOString(),
     };
-    yield* fs.writeFileString(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+    // The pending session file carries the login session key; keep it
+    // private (mode masked by umask, chmod pins it) like user_data.json.
+    yield* fs.writeFileString(filePath, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
+    yield* fs.chmod(filePath, 0o600);
   });
 
 const clearPendingLoginSession = Effect.gen(function* () {

--- a/ts/packages/cli/src/services/user-context.ts
+++ b/ts/packages/cli/src/services/user-context.ts
@@ -17,6 +17,17 @@ import type { KeyringServiceShape } from '@composio/cli-keyring/effect';
 import { KeyringError, type MacOSBackend } from '@composio/cli-keyring';
 import { ComposioCliUserConfig, ComposioCliUserConfigLive } from 'src/services/cli-user-config';
 
+/** Debug logs must never carry the API key: stderr is routinely captured by
+ * CI logs, terminal recorders, and agent-session transcripts. */
+export const redactApiKey = (json: string): string =>
+  json.replace(/("api_key"\s*:\s*)"[^"]*"/g, '$1"***redacted***"');
+
+const redactParsedUserData = (data: UserData): UserData => ({
+  ...data,
+  apiKey: Option.map(data.apiKey, () => '***redacted***'),
+});
+
+
 /**
  * Keyring specifier for the Composio API key. `service` is a reverse
  * DNS identifier shared by every composio CLI install; `user` is a
@@ -188,6 +199,17 @@ export const rawComposioUserContextLive = Layer.effect(
       testUserId: Option.none(),
     });
 
+    // The user-data file carries the plaintext API key in the default
+    // ('auto'/'json') storage mode, so it must never be world-readable.
+    // `writeFileString({ mode })` is masked by the process umask, and a
+    // pre-existing 0644 file (written by older CLI versions) keeps its mode
+    // across an overwrite — the follow-up chmod pins 0600 either way.
+    const writeCredentialsJson = (contents: string): Effect.Effect<void, PlatformError> =>
+      Effect.gen(function* () {
+        yield* fs.writeFileString(jsonUserConfigPath, contents, { mode: 0o600 });
+        yield* fs.chmod(jsonUserConfigPath, 0o600);
+      });
+
     const writeJson = (snapshot: UserData) =>
       Effect.gen(function* () {
         const onDisk: UserData = useLegacyStorage
@@ -195,8 +217,8 @@ export const rawComposioUserContextLive = Layer.effect(
           : { ...snapshot, apiKey: Option.none() };
         const encoded = yield* userDataToJSON(onDisk);
         const normalized = yield* normalizeEncodedUserData(encoded, !useLegacyStorage);
-        yield* Effect.logDebug('Saving user data:', normalized);
-        yield* fs.writeFileString(jsonUserConfigPath, normalized);
+        yield* Effect.logDebug('Saving user data:', redactApiKey(normalized));
+        yield* writeCredentialsJson(normalized);
       });
 
     const logout = Effect.gen(function* () {
@@ -238,8 +260,8 @@ export const rawComposioUserContextLive = Layer.effect(
           // temporarily writing with the legacy-storage codepath.
           const onDisk = yield* userDataToJSON(next);
           const normalized = yield* normalizeEncodedUserData(onDisk, false);
-          yield* Effect.logDebug('Saving user data (keyring fallback):', normalized);
-          yield* fs.writeFileString(jsonUserConfigPath, normalized);
+          yield* Effect.logDebug('Saving user data (keyring fallback):', redactApiKey(normalized));
+          yield* writeCredentialsJson(normalized);
         }
       });
 
@@ -248,15 +270,15 @@ export const rawComposioUserContextLive = Layer.effect(
         const nextUserData = { ...userData, ...data } satisfies UserData;
         userData = nextUserData;
         yield* writeJson(nextUserData);
-        yield* Effect.logDebug('User data updated:', userData);
+        yield* Effect.logDebug('User data updated:', redactParsedUserData(userData));
       });
 
     const load = Effect.gen(function* () {
       yield* Effect.logDebug('Loading user data from', jsonUserConfigPath);
       const userDataJson = yield* fs.readFileString(jsonUserConfigPath, 'utf8');
-      yield* Effect.logDebug('User data (raw):', userDataJson);
+      yield* Effect.logDebug('User data (raw):', redactApiKey(userDataJson));
       const parsedUserData = (yield* userDataFromJSON(userDataJson)) satisfies UserData;
-      yield* Effect.logDebug('User data (parsed):', parsedUserData);
+      yield* Effect.logDebug('User data (parsed):', redactParsedUserData(parsedUserData));
 
       const overriddenUserData = {
         ...userData,

--- a/ts/packages/cli/test/src/services/user-context.test.ts
+++ b/ts/packages/cli/test/src/services/user-context.test.ts
@@ -4,7 +4,7 @@ import { FileSystem } from '@effect/platform';
 import { BunFileSystem, BunPath } from '@effect/platform-bun';
 import { ConfigProvider, Effect, Layer, Option, Data } from 'effect';
 import * as tempy from 'tempy';
-import { ComposioUserContext, rawComposioUserContextLive } from 'src/services/user-context';
+import { ComposioUserContext, rawComposioUserContextLive, redactApiKey } from 'src/services/user-context';
 import { defaultNodeOs, NodeOs } from 'src/services/node-os';
 import { UserData, UserDataWithDefaults, userDataToJSON } from 'src/models/user-data';
 import { extendConfigProvider } from 'src/services/config';
@@ -381,5 +381,67 @@ describe('ComposioUserContext', () => {
         }).pipe(Effect.provide(ComposioUserContextTest));
       });
     });
+  });
+});
+
+
+describe('ComposioUserContext — credential file hygiene', () => {
+  const withMapConfigProvider = (map: Map<string, string>) =>
+    Layer.setConfigProvider(extendConfigProvider(ConfigProvider.fromMap(map)));
+
+  const makeLayer = (cwd: string, map: Map<string, string> = new Map()) =>
+    Layer.provideMerge(
+      ComposioUserContextLive,
+      Layer.mergeAll(
+        BunFileSystem.layer,
+        BunPath.layer,
+        Layer.succeed(NodeOs, defaultNodeOs({ homedir: cwd })),
+        withMapConfigProvider(map)
+      )
+    );
+
+  it.scoped('[Then] user_data.json is written mode 0600 (plaintext fallback path)', () => {
+    const cwd = tempy.temporaryDirectory();
+
+    return Effect.gen(function* () {
+      const ctx = yield* ComposioUserContext;
+      // Force the legacy plaintext path: a Config-provided key with a
+      // keyring that has no storage (headless) falls back to JSON storage.
+      yield* ctx.login('sk-live-test-key-123');
+      const fs = yield* FileSystem.FileSystem;
+      const stat = yield* fs.stat(path.join(cwd, '.composio', 'user_data.json'));
+      assertEquals(stat.mode & 0o777, 0o600);
+    }).pipe(Effect.provide(makeLayer(cwd, new Map([['COMPOSIO_API_KEY', 'sk-live-test-key-123']]))));
+  });
+
+  it.scoped('[Then] an existing world-readable user_data.json is tightened to 0600', () => {
+    const cwd = tempy.temporaryDirectory();
+
+    return Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      // Simulate a file written by an older CLI version: default 0644.
+      const target = path.join(cwd, '.composio', 'user_data.json');
+      yield* fs.makeDirectory(path.join(cwd, '.composio'), { recursive: true });
+      yield* fs.writeFileString(target, '{"api_key":null}\n');
+      yield* fs.chmod(target, 0o644);
+
+      const ctx = yield* ComposioUserContext;
+      yield* ctx.login('sk-live-test-key-456');
+
+      const stat = yield* fs.stat(target);
+      assertEquals(stat.mode & 0o777, 0o600);
+    }).pipe(Effect.provide(makeLayer(cwd, new Map([['COMPOSIO_API_KEY', 'sk-live-test-key-456']]))));
+  });
+});
+
+describe('redactApiKey', () => {
+  it('masks the api_key value and leaves other fields intact', () => {
+    const input = '{"api_key":"sk-live-secret","base_url":"https://backend.composio.dev","org_id":null}';
+    const output = redactApiKey(input);
+    assertEquals(output, '{"api_key":"***redacted***","base_url":"https://backend.composio.dev","org_id":null}');
+  });
+
+  it('leaves a null api_key untouched', () => {
+    assertEquals(redactApiKey('{"api_key":null}'), '{"api_key":null}');
   });
 });


### PR DESCRIPTION
## Summary

Two credential-hygiene gaps in the CLI's user-data storage:

1. **World-readable credential files (CWE-732).** In the default storage mode (`security: 'auto'` → legacy JSON), `~/.composio/user_data.json` carries the plaintext API key but was written with `fs.writeFileString` and no mode → `0644` under the usual umask. Same for `pending-login-session.json` (written during `composio login`, carries the login session key). On a shared machine, any local user can read the Composio API key.
2. **API key in debug logs.** `composio --log-level debug` (or `COMPOSIO_LOG_LEVEL=debug`) printed the full serialized user-data payload — `api_key` included — to stderr at every login/logout/config-load. stderr is exactly what CI logs, terminal recorders, and agent-session transcripts capture, which is this CLI's primary audience.

## Changes

- `user-context.ts`: both credential writes go through a `writeCredentialsJson` helper that passes `mode: 0o600` **and follows with `chmod(0o600)`** — `{ mode }` alone is masked by the process umask, and a pre-existing `0644` file (written by older CLI versions) keeps its mode across an overwrite, so the chmod pins it either way. This is the same technique `utils/atomic-write.ts` already documents for private tmp files.
- `login.cmd.ts`: the pending-login-session write gets the same treatment.
- All five `logDebug` sites that serialize user data now pass through `redactApiKey` (JSON-string sites) / `redactParsedUserData` (decoded `UserData` sites) — the `api_key` value is replaced with `***redacted***`. `redactApiKey` is exported for tests.

## Tests

- Login writes `user_data.json` with mode `0600` (plaintext-fallback path).
- A pre-existing world-readable (`0644`) `user_data.json` is tightened to `0600` by a subsequent login — the migration case for machines where an older CLI already wrote the file.
- `redactApiKey` masks the key value and leaves every other field byte-identical; a `null` key passes through untouched.

## Notes

I could not run the CLI package's tests locally — the workspace needs the bun-based build chain for `@composio/cli-keyring`'s dist to resolve under vitest — so the test run is left to CI. The permission technique itself is copied from this repo's own `atomic-write.ts` comment ("private contents must never sit in a default-mode, world-readable file").
