### PR TITLE
fix(files): skip boolean sub-schemas in enhance_schema_descriptions

### DIFF
--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -962,6 +962,12 @@ class FileHelper(WithLogger):
             return schema
         required = schema.get("required") or []
         for _param, _schema in schema["properties"].items():
+            if not isinstance(_schema, dict):
+                # Boolean sub-schemas (``True`` = accept anything, ``False`` = reject
+                # everything) are valid draft-06+ JSON Schema and carry no description
+                # to enhance — the converter pre-filters them on its path, but this
+                # helper runs unconditionally before that.
+                continue
             if _schema.get("type") in ["string", "integer", "number", "boolean"]:
                 ext = f"Please provide a value of type {_schema['type']}."
                 description = _schema.get("description", "").rstrip(".")

--- a/python/tests/test_enhance_schema_bool_subschemas.py
+++ b/python/tests/test_enhance_schema_bool_subschemas.py
@@ -1,0 +1,25 @@
+"""Boolean sub-schemas (``True``/``False`` properties) are valid draft-06+ JSON
+Schema; helpers that walk fetched tool schemas must skip them instead of crashing."""
+
+from composio.core.models._files import FileHelper
+
+
+def test_enhance_schema_descriptions_skips_boolean_subschemas() -> None:
+    """`True`/`False` property schemas used to crash the enhancer with
+    AttributeError ('bool' object has no attribute 'get') — it runs unconditionally
+    on fetched tool schemas, before the converter's boolean pre-filter."""
+    helper = FileHelper(client=None)
+    schema = {
+        "properties": {
+            "x": True,  # accept anything
+            "y": False,  # reject everything
+            "name": {"type": "string"},
+        },
+        "required": ["name"],
+    }
+    result = helper.enhance_schema_descriptions(schema)
+
+    assert result["properties"]["x"] is True
+    assert result["properties"]["y"] is False
+    assert "value of type string" in result["properties"]["name"]["description"]
+    assert "required" in result["properties"]["name"]["description"].lower()


### PR DESCRIPTION
## Summary

`FileHelper.enhance_schema_descriptions` crashed with `AttributeError: 'bool' object has no attribute 'get'` on tools whose parameter schemas contain **boolean sub-schemas** (`"x": true` / `"x": false`) — valid JSON Schema since draft-06 (`true` = accept anything, `false` = reject everything).

The helper runs **unconditionally** on every fetched tool schema (`core/models/tools.py` and `core/models/tool_router_session.py` call it regardless of `dangerously_allow_auto_upload_download_files`), and it runs *before* the schema converter's boolean pre-filter (`_filter_boolean_schemas` in `utils/schema_converter.py`, whose module docstring explicitly says boolean sub-schemas appear in tool schemas). So one tool with a boolean sub-schema in the catalog failed wrapping for the whole batch.

## Change

Non-dict property schemas are skipped in the walk (they carry no `type` and no `description` to enhance). Dict properties behave exactly as before.

## Tests

New `test_enhance_schema_bool_subschemas.py`: `True`/`False` properties pass through untouched while a sibling string property still gets its type/required description enhancement. Full `test_files.py` suite → 198 passed alongside.
