### PR TITLE
fix(files): map mid-stream transport failures to the declared error contracts

### DIFF
--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -456,11 +456,18 @@ def _fetch_file_from_url(
             if chunk:
                 total_bytes += len(chunk)
                 if total_bytes > max_size:
-                    response.close()
                     raise ResponseTooLargeError(
                         f"Response size exceeds maximum allowed size ({max_size} bytes)"
                     )
                 chunks.append(chunk)
+    except requests.exceptions.RequestException as e:
+        # Mid-stream transport failures (connection reset, chunked-encoding
+        # breakage) must surface through the declared error type — the sibling
+        # download path (FileDownloadable.download) already maps OSError-family
+        # failures to its own error; this fetch path leaked them bare.
+        raise ErrorUploadingFile(
+            message=f"Failed to download file from URL: {e}",
+        ) from e
     finally:
         response.close()
 

--- a/python/composio/core/models/tool_router_session_files.py
+++ b/python/composio/core/models/tool_router_session_files.py
@@ -121,16 +121,23 @@ def _fetch_url_bytes(url: str) -> t.Tuple[bytes, str]:
 
     chunks: t.List[bytes] = []
     total_bytes = 0
-    for chunk in response.iter_content(chunk_size=8192):
-        if chunk:
-            total_bytes += len(chunk)
-            if total_bytes > _MAX_RESPONSE_SIZE:
-                response.close()
-                raise _UrlFetchError(
-                    size_detail="Response size exceeds maximum allowed size"
-                )
-            chunks.append(chunk)
-    response.close()
+    try:
+        for chunk in response.iter_content(chunk_size=8192):
+            if chunk:
+                total_bytes += len(chunk)
+                if total_bytes > _MAX_RESPONSE_SIZE:
+                    raise _UrlFetchError(
+                        size_detail="Response size exceeds maximum allowed size"
+                    )
+                chunks.append(chunk)
+    except requests.exceptions.RequestException as e:
+        # Mid-stream transport failures (connection reset, chunked-encoding
+        # breakage) must surface through the declared error contract, not leak
+        # as bare requests exceptions — _fetch_from_url's _UrlFetchError
+        # mapping carries the remediation context.
+        raise _UrlFetchError(cause=e) from e
+    finally:
+        response.close()
 
     mimetype = response.headers.get("content-type", "application/octet-stream")
     mimetype = mimetype.split(";")[0].strip()

--- a/python/tests/test_url_stream_error_contract.py
+++ b/python/tests/test_url_stream_error_contract.py
@@ -1,0 +1,48 @@
+"""Mid-stream transport failures must surface through the declared error
+contracts, not leak as bare requests exceptions past the _UrlFetchError /
+ErrorUploadingFile mappings."""
+
+import requests
+
+import composio.core.models._files as files_mod
+import composio.core.models.tool_router_session_files as trsf_mod
+
+
+class _MidStreamResetResponse:
+    """A response that delivers headers + one chunk, then dies mid-stream."""
+
+    headers = {"Content-Length": "100"}
+    status_code = 200
+    ok = True
+    reason = "OK"
+
+    def close(self):
+        pass
+
+    def iter_content(self, chunk_size=8192):
+        yield b"partial"
+        raise requests.exceptions.ConnectionError("peer reset mid-stream")
+
+
+def test_tool_router_fetch_maps_midstream_failure(monkeypatch):
+    monkeypatch.setattr(trsf_mod, "safe_get", lambda url, **kw: _MidStreamResetResponse())
+    # Before the fix this leaked requests.exceptions.ConnectionError past the
+    # ValidationError mapping the function declares.
+    try:
+        trsf_mod._fetch_from_url("https://example.com/file")
+        raise AssertionError("expected ValidationError")
+    except trsf_mod.ValidationError as e:
+        assert "peer reset mid-stream" in str(e)
+    except requests.exceptions.RequestException:
+        raise AssertionError("transport exception leaked outside the contract")
+
+
+def test_files_fetch_maps_midstream_failure(monkeypatch):
+    monkeypatch.setattr(files_mod, "safe_get", lambda url, **kw: _MidStreamResetResponse())
+    try:
+        files_mod._fetch_file_from_url("https://example.com/file")
+        raise AssertionError("expected ErrorUploadingFile")
+    except files_mod.ErrorUploadingFile as e:
+        assert "peer reset mid-stream" in str(e)
+    except requests.exceptions.RequestException:
+        raise AssertionError("transport exception leaked outside the contract")


### PR DESCRIPTION
## Summary

Mid-stream transport failures — a connection reset or chunked-encoding breakage **after** the response headers arrived — escaped both URL-fetch error contracts as bare `requests` exceptions:

- `tool_router_session_files._fetch_url_bytes`: the `iter_content` loop sat **outside** the `try` that wraps `safe_get`, so `requests.exceptions.ConnectionError` / `ChunkedEncodingError` leaked past the `_UrlFetchError → ValidationError` mapping — the remediation context (`Failed to fetch file from URL: <cause>`) never reached the caller.
- `_files._fetch_file_from_url`: same shape — only a bare `finally: close()`, no `except`, so the leak bypassed `ErrorUploadingFile`.

Both were verified with a stubbed response that yields one chunk then raises `ConnectionError('peer reset mid-stream')`. The sibling download path (`FileDownloadable.download`) already wraps its iteration with `except OSError` (`RequestException` is an `IOError` subclass) — the inconsistency within `_files.py` itself indicates this is an omission, not a design choice.

Additionally, on the non-finally paths the response object was only closed via explicit `response.close()` calls inside the loops — a raise between them leaked the connection.

## Change

Both stream loops now wrap `iter_content` with `except requests.exceptions.RequestException` mapped into the file's own declared error (`_UrlFetchError(cause=...)` → the existing `ValidationError` mapping; `ErrorUploadingFile` with the cause message), and `response.close()` moved into `finally` so every exit path releases the connection.

## Tests

New `test_url_stream_error_contract.py` (2 tests): each fetch surface asserts the mapped error type is raised and the cause text survives, and that no bare `requests` exception escapes. Existing `test_files.py` → 198 passed alongside.
