### PR TITLE
fix(schema-converter): convert tuple-form array items instead of degrading to str

### DIFF
--- a/python/composio/utils/schema_converter.py
+++ b/python/composio/utils/schema_converter.py
@@ -1194,6 +1194,25 @@ def _convert_with_library(
             items = schema.get("items")
             if _is_unsatisfiable_schema(items):
                 return t.List[_UnsatisfiableSchema]  # type: ignore[return-value]
+            if isinstance(items, list):
+                # Draft-04 tuple validation: positional per-index subschemas.
+                # Converting to positional args is out of scope, but degrading to
+                # bare `str` (the historical behavior — the list raises in the
+                # simple-type lookup and lands in the string fallback) rejected
+                # every legitimate array input. Treat it as a list of the union
+                # of the positional subschemas' types instead.
+                member_types = []
+                for member in _filter_boolean_schemas(items) or []:
+                    if not _is_unsatisfiable_schema(member):
+                        member_types.append(
+                            _filtered_schema_to_pydantic_type(member, root_schema=root_schema)
+                        )
+                if not member_types:
+                    return t.List[t.cast(t.Type, t.Any)]
+                unique_types = list(dict.fromkeys(member_types))
+                if len(unique_types) == 1:
+                    return t.List[t.cast(t.Type, unique_types[0])]
+                return t.List[t.Union[tuple(unique_types)]]  # type: ignore
             if items:
                 item_type = _filtered_schema_to_pydantic_type(
                     items,

--- a/python/tests/test_tuple_items_conversion.py
+++ b/python/tests/test_tuple_items_conversion.py
@@ -1,0 +1,36 @@
+"""Draft-04 tuple-form ``items`` (a list of positional subschemas) must convert to
+a usable list type — the historical behavior degraded the whole array field to
+bare ``str``, rejecting every legitimate list input."""
+
+from composio.utils.shared import json_schema_to_model
+
+
+def test_tuple_items_with_boolean_member_converts_to_list() -> None:
+    model = json_schema_to_model(
+        {"properties": {"pair": {"type": "array", "items": [{"type": "string"}, False]}}}
+    )
+    annotation = model.model_fields["pair"].annotation
+    assert annotation is not str
+    assert model(pair=["a", "b"]).pair == ["a", "b"]
+
+
+def test_mixed_tuple_items_become_union_list() -> None:
+    model = json_schema_to_model(
+        {"properties": {"mix": {"type": "array", "items": [{"type": "string"}, {"type": "integer"}]}}}
+    )
+    assert model(mix=["x", 3]).mix == ["x", 3]
+
+
+def test_all_members_unsatable_degrades_to_list_any() -> None:
+    model = json_schema_to_model(
+        {"properties": {"odd": {"type": "array", "items": [False, False]}}}
+    )
+    annotation = model.model_fields["odd"].annotation
+    assert annotation is not str
+
+
+def test_single_schema_items_still_work() -> None:
+    model = json_schema_to_model(
+        {"properties": {"tags": {"type": "array", "items": {"type": "string"}}}}
+    )
+    assert model(tags=["a"]).tags == ["a"]


### PR DESCRIPTION
## Summary

Draft-04 **tuple-form `items`** (a list of positional subschemas — legacy but legal JSON Schema) crashed the simple-type lookup and landed in the catch-all string fallback, so:

```json
{"type": "array", "items": [{"type": "string"}, false]}
```

typed the whole field as **bare `str`** — every legitimate list input was then rejected with `Input should be a valid string`. Verified before the fix: `model(pair=["a", "b"])` failed validation for a field whose schema says "array".

## Change

Tuple-form `items` now converts to a list of the **union of the positional subschemas' types**: each member is filtered through the existing boolean-schema policy and converted individually, deduplicated, and a single type becomes `List[T]` while multiple become `List[Union[...]]`. An all-filtered-out tuple degrades to `List[Any]`. Positional (per-index) validation itself is out of scope — the goal is that valid inputs validate, instead of none of them.

## Tests

New `test_tuple_items_conversion.py` (4 tests): tuple with a boolean member converts to a usable list, mixed-type tuples become a union list, all-unsatisfiable tuples degrade to `List[Any]` (not `str`), and single-schema `items` behave unchanged. Existing suites (`test_schema_converter.py` + `test_json_schema.py` + `test_schema_parser.py` + `test_files.py`) → 503 passed, no regressions.
