### PR TITLE
fix(python): preserve mixed multi-execute result order

### DIFF
--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -410,8 +410,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         """Route a COMPOSIO_MULTI_EXECUTE_TOOL call.
 
         Splits the tools[] array into local and remote, executes each
-        appropriately, and merges results: remotes first, locals appended
-        (matches TS — remote results may have workbench index references).
+        appropriately, and merges results in the original request order.
 
         Modifiers are NOT applied here — the caller (routing_execute)
         handles before_execute/after_execute to avoid double application.
@@ -498,14 +497,14 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
                     "data": result["data"],
                 },
                 "tool_slug": parsed[idx]["tool_slug"],
+                "index": idx,
             }
             if result.get("error"):
                 local_entry["response"]["error"] = result["error"]
                 local_entry["error"] = result["error"]
             local_entries.append(local_entry)
 
-        # Merge: remotes first, locals appended (matches TS behavior —
-        # remote results may have workbench index references)
+        # Restore original request order, then re-index sequentially.
         remote_data_raw = (remote_result or {}).get("data")
         remote_data = remote_data_raw if isinstance(remote_data_raw, dict) else {}
         remote_results_list = (
@@ -513,10 +512,18 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
             if isinstance(remote_data.get("results"), list)
             else []
         )
-        all_results = [
-            {**entry, "index": i}
-            for i, entry in enumerate([*remote_results_list, *local_entries])
+        merged_results = [
+            {
+                **entry,
+                "index": remote_indices[position]
+                if position < len(remote_indices)
+                else position,
+            }
+            for position, entry in enumerate(remote_results_list)
         ]
+        merged_results.extend(local_entries)
+        merged_results.sort(key=lambda entry: int(entry["index"]))
+        all_results = [{**entry, "index": i} for i, entry in enumerate(merged_results)]
         failed = sum(1 for r in all_results if r.get("error"))
         merged_data = {**remote_data, "results": all_results}
         if local_entries and any(

--- a/python/tests/test_custom_tools.py
+++ b/python/tests/test_custom_tools.py
@@ -941,9 +941,11 @@ class TestMultiExecuteRouting:
         )
         results = result["data"]["results"]
         assert len(results) == 2
-        # Remotes first, locals appended (matches TS)
-        assert results[0]["tool_slug"] == "R"
-        assert results[1]["tool_slug"] == "GREP"
+        # Results preserve the original request order.
+        assert results[0]["tool_slug"] == "GREP"
+        assert results[1]["tool_slug"] == "R"
+        assert results[0]["index"] == 0
+        assert results[1]["index"] == 1
         assert result["data"]["total_count"] == 2
         assert result["data"]["success_count"] == 2
         assert result["data"]["error_count"] == 0


### PR DESCRIPTION
## Summary

`ToolRouterSession._route_multi_execute` currently concatenates remote results before local results and assigns new indexes from that concatenated list. For a request such as `[LOCAL_TOOL, REMOTE_TOOL]`, callers receive `[REMOTE_TOOL, LOCAL_TOOL]`, so code that correlates `results[index]` with the requested tools can use the wrong result.

This brings the Python implementation in line with the merged TypeScript behavior in [#3800](https://github.com/ComposioHQ/composio/pull/3800): preserve each tool's original request index, restore that order after local/remote execution, and then assign contiguous result indexes.

Fixes #

## Changes

- Preserve the original index on locally executed result entries.
- Map remote sub-batch results back to their original request indexes before merging.
- Sort the merged results by original index and re-index them sequentially.
- Update the mixed local/remote regression test to assert request order and indexes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

- `uv run --locked --group dev pytest tests/test_custom_tools.py -q` — 69 passed.
- `uv run --locked --group dev nox -s tst -- tests/test_custom_tools.py` — 69 passed.
- `uv run --locked --group dev ruff --config config/ruff.toml check composio/core/models/tool_router_session.py tests/test_custom_tools.py` — passed.
- Ruff format check on both changed files — passed.
- Verified the regression test fails on the pre-fix implementation and passes after the fix.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages

## Additional context

This change is limited to Python multi-execute result ordering. All-local and all-remote fast paths remain unchanged. No changeset is needed because this repository does not use Changesets for Python package changes.
