### PR TITLE
fix(sdk): preserve composed JSON Schema semantics

### DIFF
--- a/.changeset/calm-schema-composition.md
+++ b/.changeset/calm-schema-composition.md
@@ -1,0 +1,5 @@
+---
+'@composio/json-schema-to-zod': patch
+---
+
+Preserve Draft 7 positional tuple semantics, including optional positions and `additionalItems`.

--- a/.changeset/honest-schema-primitives.md
+++ b/.changeset/honest-schema-primitives.md
@@ -1,0 +1,5 @@
+---
+'@composio/json-schema-to-zod': patch
+---
+
+Intersect `enum` and `const` values with their declared JSON Schema type and constraints.

--- a/python/composio/utils/schema_converter.py
+++ b/python/composio/utils/schema_converter.py
@@ -27,6 +27,7 @@ from jsonschema.protocols import Validator
 from pydantic import (
     AfterValidator,
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
     StrictBool,
@@ -1234,7 +1235,7 @@ def _with_exact_validation(
         t.cast(t.Any, classmethod(validate_source_schema))
     )
 
-    name = f"{model.__name__}Validated"
+    name = model.__name__
     return t.cast(
         t.Type[BaseModel],
         type(
@@ -1246,6 +1247,92 @@ def _with_exact_validation(
                 "_validate_source_schema": validator,
             },
         ),
+    )
+
+
+def _override_composed_model_fields(
+    schema: t.Dict[str, t.Any],
+    base_model: t.Type[BaseModel],
+) -> t.Type[BaseModel]:
+    """Replace library approximations for compositions with exact adapters."""
+    properties = schema.get("properties", {})
+    field_definitions = {}
+
+    for internal_name, model_field in base_model.model_fields.items():
+        alias = (
+            model_field.alias if isinstance(model_field.alias, str) else internal_name
+        )
+        property_schema = properties.get(alias)
+        if not isinstance(property_schema, dict):
+            continue
+        is_tuple = isinstance(property_schema.get("items"), list)
+        if not (is_tuple or "allOf" in property_schema):
+            continue
+
+        annotation = t.List[t.Any] if is_tuple else t.Any
+        default = ... if model_field.is_required() else model_field.default
+        field_definitions[internal_name] = (
+            annotation,
+            Field(
+                default,
+                alias=model_field.alias,
+                description=model_field.description,
+                examples=model_field.examples,
+                title=model_field.title,
+            ),
+        )
+
+    if not field_definitions:
+        return base_model
+
+    return create_pydantic_model(  # type: ignore[call-overload]
+        f"{base_model.__name__}Composed",
+        __base__=base_model,
+        **field_definitions,
+    )
+
+
+def _convert_object_with_composed_properties(
+    schema: t.Dict[str, t.Any],
+    *,
+    root_schema: t.Dict[str, t.Any],
+) -> t.Type[BaseModel]:
+    """Build an object when the conversion library rejects valid composition."""
+    required = set(schema.get("required", []))
+    field_definitions = {}
+
+    for name, property_schema in schema.get("properties", {}).items():
+        is_tuple = isinstance(property_schema.get("items"), list)
+        annotation = (
+            t.List[t.Any]
+            if is_tuple
+            else t.Any
+            if "allOf" in property_schema
+            else json_schema_to_pydantic_type(
+                property_schema,
+                root_schema=root_schema,
+            )
+        )
+        default = (
+            ...
+            if name in required
+            else property_schema.get("default")
+            if "default" in property_schema
+            else None
+        )
+        field_definitions[name] = (
+            annotation,
+            Field(
+                default,
+                description=property_schema.get("description"),
+                examples=property_schema.get("examples"),
+                title=property_schema.get("title"),
+            ),
+        )
+
+    return create_pydantic_model(  # type: ignore[call-overload]
+        schema.get("title", "GeneratedModel"),
+        **field_definitions,
     )
 
 
@@ -1357,12 +1444,23 @@ def _convert_with_library(
         if "title" not in schema:
             schema = {**schema, "title": "GeneratedModel"}
 
+        has_tuple_property = any(
+            isinstance(property_schema, dict)
+            and isinstance(property_schema.get("items"), list)
+            for property_schema in schema.get("properties", {}).values()
+        )
         try:
-            base_model = create_model_from_schema(
-                schema,
-                allow_undefined_array_items=True,
-                allow_undefined_type=True,
-            )
+            if has_tuple_property:
+                base_model = _convert_object_with_composed_properties(
+                    schema,
+                    root_schema=document_root,
+                )
+            else:
+                base_model = create_model_from_schema(
+                    schema,
+                    allow_undefined_array_items=True,
+                    allow_undefined_type=True,
+                )
         except (SchemaError, CombinerError) as e:
             logger.debug(
                 f"Library schema conversion failed: {e}, falling back to string"
@@ -1374,6 +1472,10 @@ def _convert_with_library(
             )
             return str
 
+        base_model = _override_composed_model_fields(
+            schema,
+            base_model,
+        )
         return _with_exact_validation(
             apply_object_policy(
                 schema,
@@ -1397,6 +1499,15 @@ def _convert_with_library(
             items = schema.get("items")
             if _is_unsatisfiable_schema(items):
                 return t.List[_UnsatisfiableSchema]  # type: ignore[return-value]
+            if isinstance(items, list):
+                document_root = root_schema if root_schema is not None else schema
+                return t.cast(
+                    t.Type,
+                    t.Annotated[
+                        t.List[t.Any],
+                        BeforeValidator(_validate_json_schema(schema, document_root)),
+                    ],
+                )
             if items:
                 item_type = _filtered_schema_to_pydantic_type(
                     items,
@@ -1437,20 +1548,16 @@ def _handle_toplevel_combiner(
         )
         if result is type(None):
             return type(None)
-        # If result is a type (like a Union or Optional), return it directly
-        # If result is a model class, return it
         return result
     except (SchemaError, CombinerError):
         pass
     except Exception:
         pass
 
-    # Fallback: manually build union type for anyOf/oneOf
     if "anyOf" in schema or "oneOf" in schema:
         options = schema.get("anyOf", schema.get("oneOf", []))
         return _build_union_from_options(options, root_schema=root_schema)
 
-    # Fallback: use first option for allOf
     if "allOf" in schema and schema["allOf"]:
         return json_schema_to_pydantic_type(
             schema["allOf"][0],

--- a/python/composio/utils/schema_converter.py
+++ b/python/composio/utils/schema_converter.py
@@ -25,9 +25,14 @@ from json_schema_to_pydantic import (
 from jsonschema import validators as jsonschema_validators
 from jsonschema.protocols import Validator
 from pydantic import (
+    AfterValidator,
     BaseModel,
     ConfigDict,
     Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
     TypeAdapter,
     model_validator,
 )
@@ -80,7 +85,7 @@ PYDANTIC_TYPE_TO_PYTHON_TYPE = {
     "boolean": bool,
     "array": t.List,
     "object": t.Dict,
-    "null": t.Optional[t.Any],
+    "null": type(None),
 }
 
 CONTAINER_TYPE = ("array", "object")
@@ -1003,8 +1008,7 @@ def json_schema_to_pydantic_type(
     if isinstance(json_schema, bool):
         if json_schema:
             return t.Any  # true schema accepts any value
-        else:
-            return None  # false schema - will be filtered out in union processing
+        return _UnsatisfiableSchema
 
     # Pre-filter boolean schemas from combiners
     filtered_schema = _filter_boolean_schemas(json_schema)
@@ -1025,6 +1029,24 @@ def _filtered_schema_to_pydantic_type(
     """Convert a schema after boolean-schema normalization."""
     if schema is None or _is_unsatisfiable_schema(schema):
         return _UnsatisfiableSchema
+
+    if schema == {}:
+        return t.Any
+
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        if not schema_type:
+            return _UnsatisfiableSchema
+        return _build_union_from_options(
+            [
+                {**schema, "type": member, "x-composio-strict-type": True}
+                for member in schema_type
+            ],
+            root_schema=root_schema,
+        )
+
+    if schema_type is None and ("enum" in schema or "const" in schema):
+        return _apply_scalar_constraints(t.Any, schema)
 
     # Handle simple primitive types without complex combiners
     if _is_simple_primitive(schema):
@@ -1051,7 +1073,180 @@ def _is_simple_primitive(schema: t.Dict[str, t.Any]) -> bool:
 def _convert_simple_type(schema: t.Dict[str, t.Any]) -> t.Type[t.Any]:
     """Convert simple primitive types directly."""
     type_ = schema.get("type", "string")
-    return t.cast(t.Type[t.Any], PYDANTIC_TYPE_TO_PYTHON_TYPE.get(type_, str))
+    strict_types: t.Dict[str, t.Type[t.Any]] = {
+        "string": StrictStr,
+        "integer": StrictInt,
+        "number": StrictFloat,
+        "boolean": StrictBool,
+        "null": type(None),
+    }
+    use_strict_type = (
+        schema.get("x-composio-strict-type") is True
+        or "enum" in schema
+        or "const" in schema
+    )
+    base_type = (
+        strict_types.get(type_, str)
+        if use_strict_type
+        else t.cast(t.Type[t.Any], PYDANTIC_TYPE_TO_PYTHON_TYPE.get(type_, str))
+    )
+    return _apply_scalar_constraints(base_type, schema)
+
+
+def _json_values_equal(left: t.Any, right: t.Any) -> bool:
+    """Compare JSON values without treating booleans as numbers."""
+    if isinstance(left, bool) or isinstance(right, bool):
+        return type(left) is type(right) and left == right
+
+    if isinstance(left, list) and isinstance(right, list):
+        return len(left) == len(right) and all(
+            _json_values_equal(left_item, right_item)
+            for left_item, right_item in zip(left, right)
+        )
+
+    if isinstance(left, dict) and isinstance(right, dict):
+        return left.keys() == right.keys() and all(
+            _json_values_equal(left[key], right[key]) for key in left
+        )
+
+    return bool(left == right)
+
+
+def _allowed_values_validator(
+    allowed: t.Tuple[t.Any, ...],
+) -> t.Callable[[t.Any], t.Any]:
+    """Create a Pydantic validator for JSON Schema enum/const values."""
+
+    def validate(value: t.Any) -> t.Any:
+        if not any(_json_values_equal(value, candidate) for candidate in allowed):
+            raise ValueError(f"value must be one of {allowed!r}")
+        return value
+
+    return validate
+
+
+def _apply_scalar_constraints(
+    base_type: t.Type[t.Any],
+    schema: t.Dict[str, t.Any],
+) -> t.Type[t.Any]:
+    """Apply scalar JSON Schema validation keywords to a Python annotation."""
+    field_constraints: t.Dict[str, t.Any] = {}
+    type_ = schema.get("type")
+
+    if type_ == "string":
+        for keyword, field_name in (
+            ("minLength", "min_length"),
+            ("maxLength", "max_length"),
+            ("pattern", "pattern"),
+        ):
+            if keyword in schema:
+                field_constraints[field_name] = schema[keyword]
+
+    if type_ in ("integer", "number"):
+        if "minimum" in schema:
+            field_constraints[
+                "gt" if schema.get("exclusiveMinimum") is True else "ge"
+            ] = schema["minimum"]
+        if isinstance(schema.get("exclusiveMinimum"), (int, float)) and not isinstance(
+            schema["exclusiveMinimum"], bool
+        ):
+            field_constraints["gt"] = schema["exclusiveMinimum"]
+
+        if "maximum" in schema:
+            field_constraints[
+                "lt" if schema.get("exclusiveMaximum") is True else "le"
+            ] = schema["maximum"]
+        if isinstance(schema.get("exclusiveMaximum"), (int, float)) and not isinstance(
+            schema["exclusiveMaximum"], bool
+        ):
+            field_constraints["lt"] = schema["exclusiveMaximum"]
+
+        if "multipleOf" in schema:
+            field_constraints["multiple_of"] = schema["multipleOf"]
+
+    annotation: t.Any = base_type
+    if field_constraints:
+        annotation = t.Annotated[annotation, Field(**field_constraints)]
+
+    allowed: t.Optional[t.Tuple[t.Any, ...]] = None
+    if "const" in schema:
+        allowed = (schema["const"],)
+    elif "enum" in schema:
+        allowed = tuple(schema["enum"])
+
+    if allowed is not None:
+        if not allowed:
+            return _UnsatisfiableSchema
+        annotation = t.Annotated[
+            annotation,
+            AfterValidator(_allowed_values_validator(allowed)),
+        ]
+
+    return t.cast(t.Type[t.Any], annotation)
+
+
+def _schema_for_exact_validation(value: t.Any) -> t.Any:
+    """Turn internal boolean-schema markers back into JSON Schema values."""
+    if _is_unsatisfiable_schema(value):
+        return False
+    if isinstance(value, dict):
+        return {key: _schema_for_exact_validation(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_schema_for_exact_validation(item) for item in value]
+    return value
+
+
+def _validate_json_schema(
+    schema: t.Dict[str, t.Any],
+    root_schema: t.Dict[str, t.Any],
+) -> t.Callable[[t.Any], t.Any]:
+    """Compile an exact JSON Schema acceptance check for a Pydantic model."""
+    validation_schema = _schema_for_exact_validation(schema)
+    validation_root = _schema_for_exact_validation(root_schema)
+    validator_class = jsonschema_validators.validator_for(
+        validation_root,
+        default=jsonschema_validators.Draft7Validator,
+    )
+    validator_class.check_schema(validation_root)
+    validator = validator_class(validation_root).evolve(schema=validation_schema)
+
+    def validate(value: t.Any) -> t.Any:
+        error = next(validator.iter_errors(value), None)
+        if error is not None:
+            raise ValueError(error.message)
+        return value
+
+    return validate
+
+
+def _with_exact_validation(
+    model: t.Type[BaseModel],
+    schema: t.Dict[str, t.Any],
+    root_schema: t.Dict[str, t.Any],
+) -> t.Type[t.Any]:
+    """Keep model materialization while enforcing the source schema first."""
+    validate_schema = _validate_json_schema(schema, root_schema)
+
+    def validate_source_schema(cls, value: t.Any) -> t.Any:
+        return validate_schema(value)
+
+    validator = model_validator(mode="before")(
+        t.cast(t.Any, classmethod(validate_source_schema))
+    )
+
+    name = f"{model.__name__}Validated"
+    return t.cast(
+        t.Type[BaseModel],
+        type(
+            name,
+            (model,),
+            {
+                "__module__": __name__,
+                "__qualname__": name,
+                "_validate_source_schema": validator,
+            },
+        ),
+    )
 
 
 def _convert_object_with_unsatisfiable_properties(
@@ -1145,10 +1340,14 @@ def _convert_with_library(
                     f"Unexpected error in schema conversion: {e}, falling back to string"
                 )
                 return str
-            return apply_object_policy(
+            return _with_exact_validation(
+                apply_object_policy(
+                    schema,
+                    _apply_nested_object_policies(schema, base_model, document_root),
+                    root_schema=document_root,
+                ),
                 schema,
-                _apply_nested_object_policies(schema, base_model, document_root),
-                root_schema=document_root,
+                document_root,
             )
         # A property-less object with no dynamic-key constraints accepts and
         # preserves arbitrary content. Modelling it as an empty Pydantic
@@ -1175,10 +1374,14 @@ def _convert_with_library(
             )
             return str
 
-        return apply_object_policy(
+        return _with_exact_validation(
+            apply_object_policy(
+                schema,
+                _apply_nested_object_policies(schema, base_model, document_root),
+                root_schema=document_root,
+            ),
             schema,
-            _apply_nested_object_policies(schema, base_model, document_root),
-            root_schema=document_root,
+            document_root,
         )
 
     try:
@@ -1233,7 +1436,7 @@ def _handle_toplevel_combiner(
             allow_undefined_type=True,
         )
         if result is type(None):
-            return t.Optional[t.Any]
+            return type(None)
         # If result is a type (like a Union or Optional), return it directly
         # If result is a model class, return it
         return result
@@ -1277,7 +1480,7 @@ def _build_union_from_options(
         pydantic_types.append(ptype)
 
     if len(pydantic_types) == 0:
-        return t.Optional[t.Any] if has_null else _UnsatisfiableSchema  # type: ignore
+        return type(None) if has_null else _UnsatisfiableSchema
 
     if len(pydantic_types) == 1:
         base_type = pydantic_types[0]

--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -19,10 +19,10 @@ from composio.exceptions import InvalidParams, InvalidSchemaError
 from composio.utils.json_schema import dereference_json_schema
 from composio.utils.logging import get as get_logger
 from composio.utils.schema_converter import (
+    _EXPLICIT_DEFAULT_FIELDS_ATTRIBUTE,
     CONTAINER_TYPE,
     FALLBACK_VALUES,
     PYDANTIC_TYPE_TO_PYTHON_TYPE,
-    _EXPLICIT_DEFAULT_FIELDS_ATTRIBUTE,
     _mark_explicit_default_fields,
     apply_object_policy,
     json_schema_to_pydantic_type,
@@ -471,7 +471,7 @@ def _coerce_default_value(
 
 def json_schema_to_pydantic_field(
     name: str,
-    json_schema: t.Dict[str, t.Any],
+    json_schema: t.Union[t.Dict[str, t.Any], bool],
     required: t.List[str],
     skip_default: bool = False,
     *,
@@ -486,19 +486,20 @@ def json_schema_to_pydantic_field(
     :param root_schema: Full schema document used to resolve local references.
     :return: A Pydantic field definition.
     """
-    description = json_schema.get("description")
-    if "oneOf" in json_schema:
+    schema_object = json_schema if isinstance(json_schema, dict) else {}
+    description = schema_object.get("description")
+    if "oneOf" in schema_object:
         description = " | ".join(
-            [option.get("description", "") for option in json_schema["oneOf"]]
+            [option.get("description", "") for option in schema_object["oneOf"]]
         )
         description = f"Any of the following options(separated by |): {description}"
 
-    examples = json_schema.get("examples", [])
-    default = json_schema.get("default")
+    examples = schema_object.get("examples", [])
+    default = schema_object.get("default")
 
     # Coerce default value to match expected type from schema
     if default is not None:
-        default = _coerce_default_value(default, json_schema)
+        default = _coerce_default_value(default, schema_object)
 
     # Check if the field name is a reserved Pydantic name
     original_name = name
@@ -616,41 +617,27 @@ def pydantic_model_from_param_schema(param_schema: t.Dict) -> t.Type:
     required_props = param_schema.get("required", [])
 
     if param_schema.get("type") == "array":
-        # print("param_schema inside array - ", param_schema)
-        item_schema = param_schema.get("items")
-        if item_schema:
-            ItemType = t.cast(
-                t.Type,
-                json_schema_to_pydantic_type(
-                    json_schema=item_schema,
-                ),
-            )
-            return t.List[ItemType]  # type: ignore
-        return t.List
+        return t.cast(t.Type, json_schema_to_pydantic_type(param_schema))
 
     for prop_name, prop_info in param_schema.get("properties", {}).items():
-        prop_type = prop_info.get("type")
-        prop_title = prop_info.get("title", prop_name).replace(" ", "")
-        prop_default = prop_info.get("default", FALLBACK_VALUES.get(prop_type))
-        if (
-            prop_type is not None
-            and prop_type in PYDANTIC_TYPE_TO_PYTHON_TYPE
-            and prop_type not in CONTAINER_TYPE
-        ):
-            signature_prop_type = PYDANTIC_TYPE_TO_PYTHON_TYPE[prop_type]
-        elif prop_type is None:
-            # Schema uses anyOf/allOf/oneOf/$ref instead of a top-level "type" key.
-            # Delegate to json_schema_to_pydantic_type which handles all combiners.
-            signature_prop_type = t.cast(
-                t.Type,
-                json_schema_to_pydantic_type(json_schema=prop_info),
-            )
-        else:
-            signature_prop_type = pydantic_model_from_param_schema(prop_info)
+        prop_object = prop_info if isinstance(prop_info, dict) else {}
+        prop_type = prop_object.get("type")
+        prop_title = prop_object.get("title", prop_name).replace(" ", "")
+        fallback = (
+            FALLBACK_VALUES.get(prop_type) if isinstance(prop_type, str) else None
+        )
+        prop_default = prop_object.get("default", fallback)
+        signature_prop_type = t.cast(
+            t.Type,
+            json_schema_to_pydantic_type(
+                json_schema=prop_info,
+                root_schema=param_schema,
+            ),
+        )
 
         field_kwargs = {
-            "description": prop_info.get(
-                "description", prop_info.get("desc", prop_title)
+            "description": prop_object.get(
+                "description", prop_object.get("desc", prop_title)
             ),
         }
 

--- a/python/composio/utils/shared.py
+++ b/python/composio/utils/shared.py
@@ -24,6 +24,7 @@ from composio.utils.schema_converter import (
     FALLBACK_VALUES,
     PYDANTIC_TYPE_TO_PYTHON_TYPE,
     _mark_explicit_default_fields,
+    _with_exact_validation,
     apply_object_policy,
     json_schema_to_pydantic_type,
 )
@@ -521,7 +522,9 @@ def json_schema_to_pydantic_field(
         name,
         t.cast(
             t.Type,
-            json_schema_to_pydantic_type(
+            t.Any
+            if "allOf" in schema_object and root_schema is not None
+            else json_schema_to_pydantic_type(
                 json_schema=json_schema,
                 root_schema=root_schema,
             ),
@@ -558,6 +561,18 @@ def json_schema_to_fields_dict(json_schema: t.Dict[str, t.Any]) -> t.Dict[str, t
     return field_definitions  # type: ignore
 
 
+def _contains_composition(schema: t.Any) -> bool:
+    if isinstance(schema, list):
+        return any(_contains_composition(item) for item in schema)
+    if not isinstance(schema, dict):
+        return False
+    if any(key in schema for key in ("allOf", "oneOf")):
+        return True
+    if isinstance(schema.get("items"), list):
+        return True
+    return any(_contains_composition(value) for value in schema.values())
+
+
 def json_schema_to_model(
     json_schema: t.Dict[str, t.Any],
     skip_default: bool = False,
@@ -589,11 +604,14 @@ def json_schema_to_model(
         setattr(base_model, _EXPLICIT_DEFAULT_FIELDS_ATTRIBUTE, frozenset())
     else:
         _mark_explicit_default_fields(base_model, json_schema, json_schema)
-    return apply_object_policy(
+    result = apply_object_policy(
         json_schema,
         base_model,
         model_name=model_name,
     )
+    if _contains_composition(json_schema):
+        return _with_exact_validation(result, json_schema, json_schema)
+    return result
 
 
 def pydantic_model_from_param_schema(param_schema: t.Dict) -> t.Type:
@@ -629,7 +647,9 @@ def pydantic_model_from_param_schema(param_schema: t.Dict) -> t.Type:
         prop_default = prop_object.get("default", fallback)
         signature_prop_type = t.cast(
             t.Type,
-            json_schema_to_pydantic_type(
+            t.Any
+            if "allOf" in prop_object
+            else json_schema_to_pydantic_type(
                 json_schema=prop_info,
                 root_schema=param_schema,
             ),
@@ -662,11 +682,14 @@ def pydantic_model_from_param_schema(param_schema: t.Dict) -> t.Type:
     if not required_fields and not optional_fields:
         return t.Dict
 
-    return create_model(  # type: ignore
+    base_model = create_model(  # type: ignore
         param_title,
         **required_fields,
         **optional_fields,
     )
+    if _contains_composition(param_schema):
+        return _with_exact_validation(base_model, param_schema, param_schema)
+    return base_model
 
 
 def get_signature_format_from_schema_params(

--- a/python/tests/fixtures/json-schema-conversion/object-cases.json
+++ b/python/tests/fixtures/json-schema-conversion/object-cases.json
@@ -816,6 +816,141 @@
           "python": { "output": { "name": "a", "extra": { "enabled": false } } }
         }
       ]
+    },
+    {
+      "id": "composition-fixed-tuple-items",
+      "description": "Draft 7 tuple items preserve position, optional shorter arrays, and an additionalItems false bound.",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": [{ "type": "string" }, { "type": "integer" }],
+            "additionalItems": false
+          }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": [] }, "accepted": true },
+        { "input": { "value": ["ready"] }, "accepted": true },
+        { "input": { "value": ["ready", 2] }, "accepted": true },
+        { "input": { "value": [2, "ready"] }, "accepted": false },
+        { "input": { "value": ["ready", 2, true] }, "accepted": false }
+      ]
+    },
+    {
+      "id": "composition-open-tuple-items",
+      "description": "Tuple items default to Draft 7 and allow unconstrained trailing values unless additionalItems closes them.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": [{ "type": "string" }, { "type": "integer" }]
+          }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": ["ready", 2, { "extra": true }] }, "accepted": true },
+        { "input": { "value": ["ready", "wrong"] }, "accepted": false }
+      ]
+    },
+    {
+      "id": "composition-false-tuple-position",
+      "description": "A false positional schema rejects a value only when that position is present.",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": [{ "type": "string" }, false],
+            "additionalItems": false
+          }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": ["ready"] }, "accepted": true },
+        { "input": { "value": ["ready", "forbidden"] }, "accepted": false }
+      ]
+    },
+    {
+      "id": "composition-allof-object-intersection",
+      "description": "Every allOf object branch remains required after conversion.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "allOf": [
+              {
+                "type": "object",
+                "properties": { "a": { "type": "string" } },
+                "required": ["a"],
+                "additionalProperties": true
+              },
+              {
+                "type": "object",
+                "properties": { "b": { "type": "integer" } },
+                "required": ["b"],
+                "additionalProperties": true
+              }
+            ]
+          }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": { "a": "ready", "b": 2 } }, "accepted": true },
+        { "input": { "value": { "a": "ready" } }, "accepted": false },
+        { "input": { "value": { "b": 2 } }, "accepted": false }
+      ]
+    },
+    {
+      "id": "composition-scalar-allof",
+      "description": "Scalar allOf branches combine rather than selecting the first branch.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "allOf": [
+              { "type": "string", "minLength": 2 },
+              { "type": "string", "pattern": "^[A-Z]+$" }
+            ]
+          }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": "OK" }, "accepted": true },
+        { "input": { "value": "O" }, "accepted": false },
+        { "input": { "value": "ok" }, "accepted": false }
+      ]
+    },
+    {
+      "id": "composition-oneof-exclusive-match",
+      "description": "oneOf accepts exactly one matching branch, not a plain union of branches.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "oneOf": [
+              { "type": "number", "minimum": 0 },
+              { "type": "number", "maximum": 0 }
+            ]
+          }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": 1 }, "accepted": true },
+        { "input": { "value": -1 }, "accepted": true },
+        { "input": { "value": 0 }, "accepted": false },
+        { "input": { "value": "0" }, "accepted": false }
+      ]
     }
   ]
 }

--- a/python/tests/fixtures/json-schema-conversion/object-cases.json
+++ b/python/tests/fixtures/json-schema-conversion/object-cases.json
@@ -646,6 +646,145 @@
       ]
     },
     {
+      "id": "primitive-boolean-property-schemas",
+      "description": "Boolean property schemas accept every value for true and reject every supplied value for false.",
+      "schema": {
+        "type": "object",
+        "properties": { "allowed": true, "forbidden": false },
+        "required": ["allowed"]
+      },
+      "instances": [
+        { "input": { "allowed": { "nested": 1 } }, "accepted": true },
+        { "input": { "allowed": 42, "forbidden": "present" }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-empty-and-null-schemas",
+      "description": "An empty schema accepts any value while a pure null schema accepts only null.",
+      "schema": {
+        "type": "object",
+        "properties": { "anything": {}, "nullOnly": { "type": "null" } },
+        "required": ["anything", "nullOnly"]
+      },
+      "instances": [
+        { "input": { "anything": 42, "nullOnly": null }, "accepted": true },
+        { "input": { "anything": null, "nullOnly": "not-null" }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-type-array-union",
+      "description": "Every member of a JSON Schema type array remains accepted.",
+      "schema": {
+        "type": "object",
+        "properties": { "value": { "type": ["string", "integer", "null"] } },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": "ready" }, "accepted": true },
+        { "input": { "value": 2 }, "accepted": true },
+        { "input": { "value": null }, "accepted": true },
+        { "input": { "value": true }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-enum-intersects-declared-type",
+      "description": "Enum values cannot bypass the schema's declared JSON type.",
+      "schema": {
+        "type": "object",
+        "properties": { "value": { "type": "string", "enum": [1, "ready"] } },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": "ready" }, "accepted": true },
+        { "input": { "value": 1 }, "accepted": false },
+        { "input": { "value": "other" }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-null-only-unions",
+      "description": "A union containing only null accepts only null.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "typeArray": { "type": ["null"] },
+          "anyOf": { "anyOf": [{ "type": "null" }] }
+        },
+        "required": ["typeArray", "anyOf"]
+      },
+      "instances": [
+        { "input": { "typeArray": null, "anyOf": null }, "accepted": true },
+        { "input": { "typeArray": "anything", "anyOf": null }, "accepted": false },
+        { "input": { "typeArray": null, "anyOf": 1 }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-scalar-constraints",
+      "description": "String and numeric constraints survive conversion together.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string", "pattern": "^[A-Z]{2}$", "minLength": 2, "maxLength": 2 },
+          "count": { "type": "number", "exclusiveMinimum": 0, "multipleOf": 2 }
+        },
+        "required": ["code", "count"]
+      },
+      "instances": [
+        { "input": { "code": "OK", "count": 2 }, "accepted": true },
+        { "input": { "code": "ok", "count": 2 }, "accepted": false },
+        { "input": { "code": "OK", "count": 0 }, "accepted": false },
+        { "input": { "code": "OK", "count": 3 }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-independent-numeric-bounds",
+      "description": "Inclusive and numeric exclusive bounds apply independently under Draft 7.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "lower": { "type": "number", "minimum": 0, "exclusiveMinimum": 5 },
+          "upper": { "type": "number", "maximum": 10, "exclusiveMaximum": 5 }
+        },
+        "required": ["lower", "upper"]
+      },
+      "instances": [
+        { "input": { "lower": 6, "upper": 4 }, "accepted": true },
+        { "input": { "lower": 1, "upper": 4 }, "accepted": false },
+        { "input": { "lower": 6, "upper": 9 }, "accepted": false },
+        { "input": { "lower": 5, "upper": 5 }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-const-intersects-declared-type",
+      "description": "A const that conflicts with the declared type is unsatisfiable.",
+      "schema": {
+        "type": "object",
+        "properties": { "value": { "type": "string", "const": 1 } },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": 1 }, "accepted": false },
+        { "input": { "value": "1" }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-compound-enum-values",
+      "description": "Enum values may contain any JSON value, including objects and arrays.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": { "enum": [{ "mode": "safe" }, ["ready", 1]] }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": { "mode": "safe" } }, "accepted": true },
+        { "input": { "value": ["ready", 1] }, "accepted": true },
+        { "input": { "value": ["ready", true] }, "accepted": false },
+        { "input": { "value": { "mode": true } }, "accepted": false },
+        { "input": { "value": { "mode": "unsafe" } }, "accepted": false }
+      ]
+    },
+    {
       "id": "additional-property-default-materialization",
       "description": "Composio divergence: a schema-valued `additionalProperties` also materializes defaults in Zod and Pydantic while Effect leaves the input unchanged.",
       "divergesFromJsonSchema": "`default` is annotation-only in JSON Schema; the Zod and Pydantic converters materialize it.",

--- a/python/tests/test_schema_composition_parity.py
+++ b/python/tests/test_schema_composition_parity.py
@@ -1,0 +1,52 @@
+"""Cross-entry-point checks for composed JSON Schema conversion."""
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from composio.utils.shared import pydantic_model_from_param_schema
+from tests.fixtures.json_schema_conversion_corpus import find_case
+
+COMPOSITION_CASE_IDS = (
+    "composition-fixed-tuple-items",
+    "composition-open-tuple-items",
+    "composition-false-tuple-position",
+    "composition-allof-object-intersection",
+    "composition-scalar-allof",
+    "composition-oneof-exclusive-match",
+)
+
+
+@pytest.mark.parametrize("case_id", COMPOSITION_CASE_IDS)
+def test_legacy_model_entry_point_matches_shared_composition_corpus(
+    case_id: str,
+) -> None:
+    case = find_case(case_id)
+    model = pydantic_model_from_param_schema(
+        {**case.schema_, "title": f"Composition_{case_id}"}
+    )
+
+    for instance in case.instances:
+        if instance.accepted_for("python"):
+            model.model_validate(instance.input)
+        else:
+            with pytest.raises(ValidationError):
+                model.model_validate(instance.input)
+
+
+def test_standalone_draft7_tuple_preserves_positional_validation() -> None:
+    adapter = TypeAdapter(
+        pydantic_model_from_param_schema(
+            {
+                "title": "StandaloneTuple",
+                "type": "array",
+                "items": [{"type": "string"}, {"type": "integer"}],
+                "additionalItems": False,
+            }
+        )
+    )
+
+    assert adapter.validate_python(["ready"]) == ["ready"]
+    assert adapter.validate_python(["ready", 2]) == ["ready", 2]
+    for value in ([2, "ready"], ["ready", 2, True]):
+        with pytest.raises(ValidationError):
+            adapter.validate_python(value)

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -11,8 +11,6 @@ import pytest
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from pydantic.fields import PydanticUndefined
 
-from tests.fixtures.json_schema_conversion_corpus import find_case, load_object_cases
-
 from composio.utils.shared import (
     get_signature_format_from_schema_params,
     json_schema_to_fields_dict,
@@ -21,6 +19,7 @@ from composio.utils.shared import (
     json_schema_to_pydantic_type,
     pydantic_model_from_param_schema,
 )
+from tests.fixtures.json_schema_conversion_corpus import find_case, load_object_cases
 
 
 class TestJsonSchemaToPydanticField:
@@ -446,12 +445,10 @@ class TestJsonSchemaToPydanticType:
             assert result == expected_type
 
     def test_anyof_null_only_preserves_nullability(self):
-        """Test that anyOf with only null maps to Optional[Any] instead of str."""
+        """Test that anyOf with only null accepts no non-null value."""
         result = json_schema_to_pydantic_type({"anyOf": [{"type": "null"}]})
 
-        assert t.get_origin(result) is t.Union
-        assert t.Any in t.get_args(result)
-        assert type(None) in t.get_args(result)
+        assert result is type(None)
 
     def test_array_type(self):
         """Test array type conversion."""
@@ -604,12 +601,12 @@ class TestJsonSchemaToPydanticType:
         assert instance3.flexible_field is True
         assert instance4.flexible_field == 3.14
 
-    def test_fallback_to_string(self):
-        """Test that missing type defaults to string."""
+    def test_empty_schema_accepts_any_value(self):
+        """An empty JSON Schema accepts every value."""
         json_schema = {}  # No type specified
 
         result = json_schema_to_pydantic_type(json_schema)
-        assert result is str
+        assert result is t.Any
 
     def test_unsupported_type_fallback(self):
         """Test that unsupported types fall back to string (graceful degradation)."""
@@ -1122,9 +1119,11 @@ class TestBooleanSchemas:
     @pytest.mark.unit
     @pytest.mark.schema
     def test_standalone_false_schema(self):
-        """Test that standalone false schema returns None (to be filtered out)."""
-        result = json_schema_to_pydantic_type(False)
-        assert result is None
+        """Test that standalone false schema rejects every value."""
+        adapter = TypeAdapter(json_schema_to_pydantic_type(False))
+        for value in (None, "value", 1, {}, []):
+            with pytest.raises(ValidationError):
+                adapter.validate_python(value)
 
     @pytest.mark.unit
     @pytest.mark.schema

--- a/python/tests/test_schema_parser.py
+++ b/python/tests/test_schema_parser.py
@@ -592,12 +592,13 @@ class TestJsonSchemaToPydanticType:
 
         # Test with different oneOf values
         instance1 = model_class(flexible_field="hello", normal_field="world")
-        instance2 = model_class(flexible_field=42, normal_field="world")
         instance3 = model_class(flexible_field=True, normal_field="world")
         instance4 = model_class(flexible_field=3.14, normal_field="world")
+        with pytest.raises(ValidationError):
+            # Integers also satisfy `number`, so this matches two branches.
+            model_class(flexible_field=42, normal_field="world")
 
         assert instance1.flexible_field == "hello"
-        assert instance2.flexible_field == 42
         assert instance3.flexible_field is True
         assert instance4.flexible_field == 3.14
 

--- a/python/tests/test_schema_primitive_parity.py
+++ b/python/tests/test_schema_primitive_parity.py
@@ -1,0 +1,34 @@
+"""Cross-entry-point checks for primitive JSON Schema conversion."""
+
+import pytest
+from pydantic import ValidationError
+
+from composio.utils.shared import pydantic_model_from_param_schema
+from tests.fixtures.json_schema_conversion_corpus import find_case
+
+PRIMITIVE_CASE_IDS = (
+    "primitive-boolean-property-schemas",
+    "primitive-empty-and-null-schemas",
+    "primitive-type-array-union",
+    "primitive-null-only-unions",
+    "primitive-enum-intersects-declared-type",
+    "primitive-scalar-constraints",
+    "primitive-independent-numeric-bounds",
+    "primitive-const-intersects-declared-type",
+    "primitive-compound-enum-values",
+)
+
+
+@pytest.mark.parametrize("case_id", PRIMITIVE_CASE_IDS)
+def test_legacy_model_entry_point_matches_shared_primitive_corpus(case_id: str) -> None:
+    case = find_case(case_id)
+    model = pydantic_model_from_param_schema(
+        {**case.schema_, "title": f"Primitive_{case_id}"}
+    )
+
+    for instance in case.instances:
+        if instance.accepted_for("python"):
+            model.model_validate(instance.input)
+        else:
+            with pytest.raises(ValidationError):
+                model.model_validate(instance.input)

--- a/ts/packages/core/test/fixtures/json-schema-conversion/object-cases.json
+++ b/ts/packages/core/test/fixtures/json-schema-conversion/object-cases.json
@@ -816,6 +816,141 @@
           "python": { "output": { "name": "a", "extra": { "enabled": false } } }
         }
       ]
+    },
+    {
+      "id": "composition-fixed-tuple-items",
+      "description": "Draft 7 tuple items preserve position, optional shorter arrays, and an additionalItems false bound.",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": [{ "type": "string" }, { "type": "integer" }],
+            "additionalItems": false
+          }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": [] }, "accepted": true },
+        { "input": { "value": ["ready"] }, "accepted": true },
+        { "input": { "value": ["ready", 2] }, "accepted": true },
+        { "input": { "value": [2, "ready"] }, "accepted": false },
+        { "input": { "value": ["ready", 2, true] }, "accepted": false }
+      ]
+    },
+    {
+      "id": "composition-open-tuple-items",
+      "description": "Tuple items default to Draft 7 and allow unconstrained trailing values unless additionalItems closes them.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": [{ "type": "string" }, { "type": "integer" }]
+          }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": ["ready", 2, { "extra": true }] }, "accepted": true },
+        { "input": { "value": ["ready", "wrong"] }, "accepted": false }
+      ]
+    },
+    {
+      "id": "composition-false-tuple-position",
+      "description": "A false positional schema rejects a value only when that position is present.",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": [{ "type": "string" }, false],
+            "additionalItems": false
+          }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": ["ready"] }, "accepted": true },
+        { "input": { "value": ["ready", "forbidden"] }, "accepted": false }
+      ]
+    },
+    {
+      "id": "composition-allof-object-intersection",
+      "description": "Every allOf object branch remains required after conversion.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "allOf": [
+              {
+                "type": "object",
+                "properties": { "a": { "type": "string" } },
+                "required": ["a"],
+                "additionalProperties": true
+              },
+              {
+                "type": "object",
+                "properties": { "b": { "type": "integer" } },
+                "required": ["b"],
+                "additionalProperties": true
+              }
+            ]
+          }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": { "a": "ready", "b": 2 } }, "accepted": true },
+        { "input": { "value": { "a": "ready" } }, "accepted": false },
+        { "input": { "value": { "b": 2 } }, "accepted": false }
+      ]
+    },
+    {
+      "id": "composition-scalar-allof",
+      "description": "Scalar allOf branches combine rather than selecting the first branch.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "allOf": [
+              { "type": "string", "minLength": 2 },
+              { "type": "string", "pattern": "^[A-Z]+$" }
+            ]
+          }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": "OK" }, "accepted": true },
+        { "input": { "value": "O" }, "accepted": false },
+        { "input": { "value": "ok" }, "accepted": false }
+      ]
+    },
+    {
+      "id": "composition-oneof-exclusive-match",
+      "description": "oneOf accepts exactly one matching branch, not a plain union of branches.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "oneOf": [
+              { "type": "number", "minimum": 0 },
+              { "type": "number", "maximum": 0 }
+            ]
+          }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": 1 }, "accepted": true },
+        { "input": { "value": -1 }, "accepted": true },
+        { "input": { "value": 0 }, "accepted": false },
+        { "input": { "value": "0" }, "accepted": false }
+      ]
     }
   ]
 }

--- a/ts/packages/core/test/fixtures/json-schema-conversion/object-cases.json
+++ b/ts/packages/core/test/fixtures/json-schema-conversion/object-cases.json
@@ -646,6 +646,145 @@
       ]
     },
     {
+      "id": "primitive-boolean-property-schemas",
+      "description": "Boolean property schemas accept every value for true and reject every supplied value for false.",
+      "schema": {
+        "type": "object",
+        "properties": { "allowed": true, "forbidden": false },
+        "required": ["allowed"]
+      },
+      "instances": [
+        { "input": { "allowed": { "nested": 1 } }, "accepted": true },
+        { "input": { "allowed": 42, "forbidden": "present" }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-empty-and-null-schemas",
+      "description": "An empty schema accepts any value while a pure null schema accepts only null.",
+      "schema": {
+        "type": "object",
+        "properties": { "anything": {}, "nullOnly": { "type": "null" } },
+        "required": ["anything", "nullOnly"]
+      },
+      "instances": [
+        { "input": { "anything": 42, "nullOnly": null }, "accepted": true },
+        { "input": { "anything": null, "nullOnly": "not-null" }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-type-array-union",
+      "description": "Every member of a JSON Schema type array remains accepted.",
+      "schema": {
+        "type": "object",
+        "properties": { "value": { "type": ["string", "integer", "null"] } },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": "ready" }, "accepted": true },
+        { "input": { "value": 2 }, "accepted": true },
+        { "input": { "value": null }, "accepted": true },
+        { "input": { "value": true }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-enum-intersects-declared-type",
+      "description": "Enum values cannot bypass the schema's declared JSON type.",
+      "schema": {
+        "type": "object",
+        "properties": { "value": { "type": "string", "enum": [1, "ready"] } },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": "ready" }, "accepted": true },
+        { "input": { "value": 1 }, "accepted": false },
+        { "input": { "value": "other" }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-null-only-unions",
+      "description": "A union containing only null accepts only null.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "typeArray": { "type": ["null"] },
+          "anyOf": { "anyOf": [{ "type": "null" }] }
+        },
+        "required": ["typeArray", "anyOf"]
+      },
+      "instances": [
+        { "input": { "typeArray": null, "anyOf": null }, "accepted": true },
+        { "input": { "typeArray": "anything", "anyOf": null }, "accepted": false },
+        { "input": { "typeArray": null, "anyOf": 1 }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-scalar-constraints",
+      "description": "String and numeric constraints survive conversion together.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string", "pattern": "^[A-Z]{2}$", "minLength": 2, "maxLength": 2 },
+          "count": { "type": "number", "exclusiveMinimum": 0, "multipleOf": 2 }
+        },
+        "required": ["code", "count"]
+      },
+      "instances": [
+        { "input": { "code": "OK", "count": 2 }, "accepted": true },
+        { "input": { "code": "ok", "count": 2 }, "accepted": false },
+        { "input": { "code": "OK", "count": 0 }, "accepted": false },
+        { "input": { "code": "OK", "count": 3 }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-independent-numeric-bounds",
+      "description": "Inclusive and numeric exclusive bounds apply independently under Draft 7.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "lower": { "type": "number", "minimum": 0, "exclusiveMinimum": 5 },
+          "upper": { "type": "number", "maximum": 10, "exclusiveMaximum": 5 }
+        },
+        "required": ["lower", "upper"]
+      },
+      "instances": [
+        { "input": { "lower": 6, "upper": 4 }, "accepted": true },
+        { "input": { "lower": 1, "upper": 4 }, "accepted": false },
+        { "input": { "lower": 6, "upper": 9 }, "accepted": false },
+        { "input": { "lower": 5, "upper": 5 }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-const-intersects-declared-type",
+      "description": "A const that conflicts with the declared type is unsatisfiable.",
+      "schema": {
+        "type": "object",
+        "properties": { "value": { "type": "string", "const": 1 } },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": 1 }, "accepted": false },
+        { "input": { "value": "1" }, "accepted": false }
+      ]
+    },
+    {
+      "id": "primitive-compound-enum-values",
+      "description": "Enum values may contain any JSON value, including objects and arrays.",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": { "enum": [{ "mode": "safe" }, ["ready", 1]] }
+        },
+        "required": ["value"]
+      },
+      "instances": [
+        { "input": { "value": { "mode": "safe" } }, "accepted": true },
+        { "input": { "value": ["ready", 1] }, "accepted": true },
+        { "input": { "value": ["ready", true] }, "accepted": false },
+        { "input": { "value": { "mode": true } }, "accepted": false },
+        { "input": { "value": { "mode": "unsafe" } }, "accepted": false }
+      ]
+    },
+    {
       "id": "additional-property-default-materialization",
       "description": "Composio divergence: a schema-valued `additionalProperties` also materializes defaults in Zod and Pydantic while Effect leaves the input unchanged.",
       "divergesFromJsonSchema": "`default` is annotation-only in JSON Schema; the Zod and Pydantic converters materialize it.",

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-array.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-array.ts
@@ -58,11 +58,45 @@ export const parseArray = (jsonSchema: JsonSchemaObject & { type: 'array' }, ref
 
   // Handle regular array schema
   if (Array.isArray(jsonSchema.items)) {
-    return z.tuple(
-      jsonSchema.items.map((v, i) =>
-        parseSchema(v, { ...refs, path: [...refs.path, 'items', i] })
-      ) as [z.ZodTypeAny]
+    const parsedItems = jsonSchema.items.map((v, i) =>
+      parseSchema(v, { ...refs, path: [...refs.path, 'items', i] })
     );
+    const shorterTuples = parsedItems.map((_, length) =>
+      z.tuple(parsedItems.slice(0, length) as unknown as [z.ZodTypeAny])
+    );
+    const fullTuple = z.tuple(parsedItems as unknown as [z.ZodTypeAny]);
+
+    let fullLengthSchema: z.ZodTypeAny;
+    if (jsonSchema.additionalItems === false) {
+      fullLengthSchema = fullTuple;
+    } else if (jsonSchema.additionalItems && jsonSchema.additionalItems !== true) {
+      fullLengthSchema = fullTuple.rest(
+        parseSchema(jsonSchema.additionalItems, {
+          ...refs,
+          path: [...refs.path, 'additionalItems'],
+        })
+      );
+    } else {
+      fullLengthSchema = fullTuple.rest(z.any());
+    }
+
+    const variants = [...shorterTuples, fullLengthSchema];
+    let result: z.ZodTypeAny =
+      variants.length === 1
+        ? variants[0]
+        : z.union(variants as unknown as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]);
+
+    if (typeof jsonSchema.minItems === 'number') {
+      result = result.refine(value => value.length >= jsonSchema.minItems!, {
+        message: `Array must contain at least ${jsonSchema.minItems} element(s)`,
+      });
+    }
+    if (typeof jsonSchema.maxItems === 'number') {
+      result = result.refine(value => value.length <= jsonSchema.maxItems!, {
+        message: `Array must contain at most ${jsonSchema.maxItems} element(s)`,
+      });
+    }
+    return result;
   }
 
   let zodSchema = !jsonSchema.items

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-const.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-const.ts
@@ -1,7 +1,10 @@
-import { z } from 'zod/v3';
+import { parseLiteralValues } from './parse-literal-values';
+import { parseSchema } from './parse-schema';
+import type { JsonSchemaObject, Refs, Serializable } from '../types';
 
-import type { JsonSchemaObject, Serializable } from '../types';
-
-export const parseConst = (jsonSchema: JsonSchemaObject & { const: Serializable }) => {
-  return z.literal(jsonSchema.const as z.Primitive);
+export const parseConst = (jsonSchema: JsonSchemaObject & { const: Serializable }, refs: Refs) => {
+  const { const: value, ...baseSchema } = jsonSchema;
+  return parseSchema(baseSchema, { ...refs, seen: new Map(refs.seen) }, true).and(
+    parseLiteralValues([value])
+  );
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-enum.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-enum.ts
@@ -1,22 +1,10 @@
-import { z } from 'zod/v3';
+import { parseLiteralValues } from './parse-literal-values';
+import { parseSchema } from './parse-schema';
+import type { JsonSchemaObject, Refs, Serializable } from '../types';
 
-import type { JsonSchemaObject, Serializable } from '../types';
-
-export const parseEnum = (jsonSchema: JsonSchemaObject & { enum: Serializable[] }) => {
-  if (jsonSchema.enum.length === 0) {
-    return z.never();
-  }
-
-  if (jsonSchema.enum.length === 1) {
-    // union does not work when there is only one element
-    return z.literal(jsonSchema.enum[0] as z.Primitive);
-  }
-
-  if (jsonSchema.enum.every(x => typeof x === 'string')) {
-    return z.enum(jsonSchema.enum as [string]);
-  }
-
-  return z.union(
-    jsonSchema.enum.map(x => z.literal(x as z.Primitive)) as unknown as [z.ZodTypeAny, z.ZodTypeAny]
+export const parseEnum = (jsonSchema: JsonSchemaObject & { enum: Serializable[] }, refs: Refs) => {
+  const { enum: values, ...baseSchema } = jsonSchema;
+  return parseSchema(baseSchema, { ...refs, seen: new Map(refs.seen) }, true).and(
+    parseLiteralValues(values)
   );
 };

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-literal-values.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-literal-values.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod/v3';
+
+import type { Serializable } from '../types';
+
+const jsonValuesEqual = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) return true;
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((value, index) => jsonValuesEqual(value, right[index]))
+    );
+  }
+
+  if (
+    left !== null &&
+    right !== null &&
+    typeof left === 'object' &&
+    typeof right === 'object' &&
+    !Array.isArray(left) &&
+    !Array.isArray(right)
+  ) {
+    const leftRecord = left as Record<string, unknown>;
+    const rightRecord = right as Record<string, unknown>;
+    const leftKeys = Object.keys(leftRecord);
+    return (
+      leftKeys.length === Object.keys(rightRecord).length &&
+      leftKeys.every(
+        key => Object.hasOwn(rightRecord, key) && jsonValuesEqual(leftRecord[key], rightRecord[key])
+      )
+    );
+  }
+
+  return false;
+};
+
+export const parseLiteralValues = (values: ReadonlyArray<Serializable>): z.ZodTypeAny => {
+  if (values.length === 0) return z.never();
+
+  if (values.every(value => value === null || typeof value !== 'object')) {
+    if (values.length === 1) return z.literal(values[0] as z.Primitive);
+    if (values.every(value => typeof value === 'string')) return z.enum(values as [string]);
+    return z.union(
+      values.map(value => z.literal(value as z.Primitive)) as unknown as [
+        z.ZodTypeAny,
+        z.ZodTypeAny,
+      ]
+    );
+  }
+
+  return z.custom<Serializable>(value =>
+    values.some(candidate => jsonValuesEqual(value, candidate))
+  );
+};

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-number.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-number.ts
@@ -50,7 +50,8 @@ export const parseNumber = (jsonSchema: JsonSchemaObject & { type: 'number' | 'i
         (zs, minimum, errorMsg) => zs.gte(minimum, errorMsg)
       );
     }
-  } else if (typeof jsonSchema.exclusiveMinimum === 'number') {
+  }
+  if (typeof jsonSchema.exclusiveMinimum === 'number') {
     zodSchema = extendSchemaWithMessage(
       zodSchema,
       jsonSchema,
@@ -75,7 +76,8 @@ export const parseNumber = (jsonSchema: JsonSchemaObject & { type: 'number' | 'i
         (zs, maximum, errorMsg) => zs.lte(maximum, errorMsg)
       );
     }
-  } else if (typeof jsonSchema.exclusiveMaximum === 'number') {
+  }
+  if (typeof jsonSchema.exclusiveMaximum === 'number') {
     zodSchema = extendSchemaWithMessage(
       zodSchema,
       jsonSchema,

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-schema.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-schema.ts
@@ -103,9 +103,9 @@ const selectParser: ParserSelector = (schema, refs) => {
   } else if (its.a.not(schema)) {
     return parseNot(schema, refs);
   } else if (its.an.enum(schema)) {
-    return parseEnum(schema); //<-- needs to come before primitives
+    return parseEnum(schema, refs); //<-- needs to come before primitives
   } else if (its.a.const(schema)) {
-    return parseConst(schema);
+    return parseConst(schema, refs);
   } else if (its.a.multipleType(schema)) {
     return parseMultipleType(schema, refs);
   } else if (its.a.primitive(schema, 'string')) {


### PR DESCRIPTION
## Summary

- build on [#4316](https://github.com/ComposioHQ/composio/pull/4316) · [Glen](https://app.tryglen.com/ComposioHQ/composio/pull/4316)
- enforce the same `allOf`, `oneOf`, and Draft 7 positional tuple acceptance rules in Python and TypeScript
- preserve Python model/default materialization while validating composed inputs against the source schema
- validate standalone Python tuple arrays at the same exact boundary as object properties
- support optional tuple prefixes and `additionalItems` behavior in the Zod converter
- extend the byte-identical cross-SDK corpus with composition cases

## Verification

- Python `make chk`
- Python `make tst`: 1,599 passed
- focused Python composition parity: 7 passed
- TypeScript core: 53 files, 1,243 passed and 2 expected failures
- Zod and Effect package tests/typechecks passed
- shared Python/TypeScript corpus files are byte-identical
- `git diff --check`

## Contributor context

This independently addresses the composition category reported across the simpleqt submissions. The implementation and tests came from local reproduction against JSON Schema semantics, not from trusting the proposed patches.