### PR TITLE
fix(sdk): keep credentials private in storage and logs

### DIFF
--- a/.changeset/quiet-logs-stay-private.md
+++ b/.changeset/quiet-logs-stay-private.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Redact credential-shaped values at the SDK log boundary.

--- a/python/composio/utils/logging.py
+++ b/python/composio/utils/logging.py
@@ -7,6 +7,8 @@ import os
 import typing as t
 from enum import Enum
 
+from composio.utils.redaction import redact_sensitive_text
+
 ENV_COMPOSIO_LOGGING_LEVEL = "COMPOSIO_LOGGING_LEVEL"
 
 _DEFAULT_FORMAT = "[%(asctime)s][%(levelname)s] %(message)s"
@@ -71,7 +73,7 @@ class _VerbosityWrapper:
         self.size = _LOG_LINE_SIZE_BY_VERBOSITY[self.verbosity]
 
     def _trim(self, msg) -> str:
-        msg = str(msg)
+        msg = redact_sensitive_text(str(msg))
         if self.size == -1:
             return msg
 
@@ -80,17 +82,38 @@ class _VerbosityWrapper:
 
         return msg[: self.size] + "..."
 
+    def _prepare(
+        self,
+        msg,
+        args: t.Tuple[t.Any, ...],
+        *,
+        trim: bool = True,
+    ) -> str:
+        if args:
+            try:
+                format_args = (
+                    args[0] if len(args) == 1 and isinstance(args[0], dict) else args
+                )
+                msg = msg % format_args
+            except (KeyError, TypeError, ValueError):
+                msg = f"{msg} {args}"
+        return self._trim(msg) if trim else redact_sensitive_text(str(msg))
+
     def info(self, msg, *args, **kwargs):
-        self.logger.info(self._trim(msg), *args, **kwargs)
+        if self.logger.isEnabledFor(logging.INFO):
+            self.logger.info(self._prepare(msg, args), **kwargs)
 
     def debug(self, msg, *args, **kwargs):
-        self.logger.debug(self._trim(msg), *args, **kwargs)
+        if self.logger.isEnabledFor(logging.DEBUG):
+            self.logger.debug(self._prepare(msg, args), **kwargs)
 
     def warning(self, msg, *args, **kwargs):
-        self.logger.warning(self._trim(msg), *args, **kwargs)
+        if self.logger.isEnabledFor(logging.WARNING):
+            self.logger.warning(self._prepare(msg, args), **kwargs)
 
     def error(self, msg, *args, **kwargs):
-        self.logger.error(msg, *args, **kwargs)
+        if self.logger.isEnabledFor(logging.ERROR):
+            self.logger.error(self._prepare(msg, args, trim=False), **kwargs)
 
     def isEnabledFor(self, level: int):
         return self.logger.isEnabledFor(level=level)

--- a/python/composio/utils/logging.py
+++ b/python/composio/utils/logging.py
@@ -2,7 +2,6 @@
 Logging utilities.
 """
 
-import copy
 import logging
 import os
 import sys
@@ -134,17 +133,20 @@ class _VerbosityWrapper:
         try:
             if hasattr(exception, "exceptions"):
                 raise TypeError("exception groups require a generic sanitized wrapper")
-            sanitized = copy.copy(exception)
+            sanitized = type(exception)("[details redacted]")
+            if hasattr(sanitized, "__dict__"):
+                sanitized.__dict__.clear()
             sanitized.args = ("[details redacted]",)
             sanitized.__cause__ = None
             sanitized.__context__ = None
             sanitized.__traceback__ = None
-            if redact_sensitive_text(str(sanitized)) != str(sanitized):
+            sanitized_text = str(sanitized)
+            if redact_sensitive_text(sanitized_text) != sanitized_text:
                 raise ValueError(
                     "custom exception string still contains sensitive data"
                 )
             return sanitized
-        except (AttributeError, TypeError, ValueError):
+        except Exception:
             return RuntimeError(f"{type(exception).__name__}: [details redacted]")
 
     def info(self, msg, *args, **kwargs):

--- a/python/composio/utils/logging.py
+++ b/python/composio/utils/logging.py
@@ -4,6 +4,7 @@ Logging utilities.
 
 import logging
 import os
+import sys
 import typing as t
 from enum import Enum
 
@@ -96,24 +97,45 @@ class _VerbosityWrapper:
                 )
                 msg = msg % format_args
             except (KeyError, TypeError, ValueError):
-                msg = f"{msg} {args}"
+                msg = f"{msg} [logging arguments omitted: formatting failed]"
         return self._trim(msg) if trim else redact_sensitive_text(str(msg))
+
+    def _prepare_exception(self, msg: str, kwargs):
+        exc_info = kwargs.get("exc_info")
+        if not exc_info:
+            return msg, kwargs
+
+        if isinstance(exc_info, BaseException):
+            exc_info = (type(exc_info), exc_info, exc_info.__traceback__)
+        elif not isinstance(exc_info, tuple):
+            exc_info = sys.exc_info()
+
+        exception_text = logging.Formatter().formatException(exc_info)
+        sanitized_kwargs = dict(kwargs)
+        sanitized_kwargs["exc_info"] = None
+        return f"{msg}\n{redact_sensitive_text(exception_text)}", sanitized_kwargs
 
     def info(self, msg, *args, **kwargs):
         if self.logger.isEnabledFor(logging.INFO):
-            self.logger.info(self._prepare(msg, args), **kwargs)
+            msg, kwargs = self._prepare_exception(self._prepare(msg, args), kwargs)
+            self.logger.info(msg, **kwargs)
 
     def debug(self, msg, *args, **kwargs):
         if self.logger.isEnabledFor(logging.DEBUG):
-            self.logger.debug(self._prepare(msg, args), **kwargs)
+            msg, kwargs = self._prepare_exception(self._prepare(msg, args), kwargs)
+            self.logger.debug(msg, **kwargs)
 
     def warning(self, msg, *args, **kwargs):
         if self.logger.isEnabledFor(logging.WARNING):
-            self.logger.warning(self._prepare(msg, args), **kwargs)
+            msg, kwargs = self._prepare_exception(self._prepare(msg, args), kwargs)
+            self.logger.warning(msg, **kwargs)
 
     def error(self, msg, *args, **kwargs):
         if self.logger.isEnabledFor(logging.ERROR):
-            self.logger.error(self._prepare(msg, args, trim=False), **kwargs)
+            msg, kwargs = self._prepare_exception(
+                self._prepare(msg, args, trim=False), kwargs
+            )
+            self.logger.error(msg, **kwargs)
 
     def isEnabledFor(self, level: int):
         return self.logger.isEnabledFor(level=level)

--- a/python/composio/utils/logging.py
+++ b/python/composio/utils/logging.py
@@ -122,35 +122,8 @@ class _VerbosityWrapper:
             return msg, sanitized_kwargs
 
         exception_text = logging.Formatter().formatException(exc_info)
-        sanitized_exception = self._sanitize_exception(exception)
-        sanitized_kwargs["exc_info"] = (
-            type(sanitized_exception),
-            sanitized_exception,
-            None,
-        )
+        sanitized_kwargs["exc_info"] = None
         return f"{msg}\n{redact_sensitive_text(exception_text)}", sanitized_kwargs
-
-    @staticmethod
-    def _sanitize_exception(exception: BaseException) -> BaseException:
-        """Keep structured exception type metadata without re-rendering raw details."""
-        try:
-            if hasattr(exception, "exceptions"):
-                raise TypeError("exception groups require a generic sanitized wrapper")
-            sanitized = type(exception)("[details redacted]")
-            if hasattr(sanitized, "__dict__"):
-                sanitized.__dict__.clear()
-            sanitized.args = ("[details redacted]",)
-            sanitized.__cause__ = None
-            sanitized.__context__ = None
-            sanitized.__traceback__ = None
-            sanitized_text = str(sanitized)
-            if redact_sensitive_text(sanitized_text) != sanitized_text:
-                raise ValueError(
-                    "custom exception string still contains sensitive data"
-                )
-            return sanitized
-        except Exception:
-            return RuntimeError(f"{type(exception).__name__}: [details redacted]")
 
     def info(self, msg, *args, **kwargs):
         if self.logger.isEnabledFor(logging.INFO):

--- a/python/composio/utils/logging.py
+++ b/python/composio/utils/logging.py
@@ -116,15 +116,18 @@ class _VerbosityWrapper:
         elif not isinstance(exc_info, tuple):
             exc_info = sys.exc_info()
 
-        exception_text = logging.Formatter().formatException(exc_info)
         exception = exc_info[1]
-        if exception is not None:
-            sanitized_exception = self._sanitize_exception(exception)
-            sanitized_kwargs["exc_info"] = (
-                type(sanitized_exception),
-                sanitized_exception,
-                None,
-            )
+        if exception is None:
+            sanitized_kwargs["exc_info"] = None
+            return msg, sanitized_kwargs
+
+        exception_text = logging.Formatter().formatException(exc_info)
+        sanitized_exception = self._sanitize_exception(exception)
+        sanitized_kwargs["exc_info"] = (
+            type(sanitized_exception),
+            sanitized_exception,
+            None,
+        )
         return f"{msg}\n{redact_sensitive_text(exception_text)}", sanitized_kwargs
 
     @staticmethod

--- a/python/composio/utils/logging.py
+++ b/python/composio/utils/logging.py
@@ -2,13 +2,14 @@
 Logging utilities.
 """
 
+import copy
 import logging
 import os
 import sys
 import typing as t
 from enum import Enum
 
-from composio.utils.redaction import redact_sensitive_text
+from composio.utils.redaction import redact_sensitive_text, redact_sensitive_value
 
 ENV_COMPOSIO_LOGGING_LEVEL = "COMPOSIO_LOGGING_LEVEL"
 
@@ -101,9 +102,15 @@ class _VerbosityWrapper:
         return self._trim(msg) if trim else redact_sensitive_text(str(msg))
 
     def _prepare_exception(self, msg: str, kwargs):
-        exc_info = kwargs.get("exc_info")
+        sanitized_kwargs = dict(kwargs)
+        if "extra" in sanitized_kwargs:
+            sanitized_kwargs["extra"] = redact_sensitive_value(
+                sanitized_kwargs["extra"]
+            )
+
+        exc_info = sanitized_kwargs.get("exc_info")
         if not exc_info:
-            return msg, kwargs
+            return msg, sanitized_kwargs
 
         if isinstance(exc_info, BaseException):
             exc_info = (type(exc_info), exc_info, exc_info.__traceback__)
@@ -111,9 +118,34 @@ class _VerbosityWrapper:
             exc_info = sys.exc_info()
 
         exception_text = logging.Formatter().formatException(exc_info)
-        sanitized_kwargs = dict(kwargs)
-        sanitized_kwargs["exc_info"] = None
+        exception = exc_info[1]
+        if exception is not None:
+            sanitized_exception = self._sanitize_exception(exception)
+            sanitized_kwargs["exc_info"] = (
+                type(sanitized_exception),
+                sanitized_exception,
+                None,
+            )
         return f"{msg}\n{redact_sensitive_text(exception_text)}", sanitized_kwargs
+
+    @staticmethod
+    def _sanitize_exception(exception: BaseException) -> BaseException:
+        """Keep structured exception type metadata without re-rendering raw details."""
+        try:
+            if hasattr(exception, "exceptions"):
+                raise TypeError("exception groups require a generic sanitized wrapper")
+            sanitized = copy.copy(exception)
+            sanitized.args = ("[details redacted]",)
+            sanitized.__cause__ = None
+            sanitized.__context__ = None
+            sanitized.__traceback__ = None
+            if redact_sensitive_text(str(sanitized)) != str(sanitized):
+                raise ValueError(
+                    "custom exception string still contains sensitive data"
+                )
+            return sanitized
+        except (AttributeError, TypeError, ValueError):
+            return RuntimeError(f"{type(exception).__name__}: [details redacted]")
 
     def info(self, msg, *args, **kwargs):
         if self.logger.isEnabledFor(logging.INFO):

--- a/python/composio/utils/redaction.py
+++ b/python/composio/utils/redaction.py
@@ -23,6 +23,9 @@ _QUOTED_SECRET_KEY_PREFIX = (
     rf"([\"'])({_SECRET_KEY_WITH_PREFIX_PATTERN})\1(\s*[:=]+\s*)"
 )
 _BARE_SECRET_KEY_PREFIX = rf"(?<![A-Za-z0-9\"'])({_SECRET_KEY_PATTERN})\b(\s*[:=]+\s*)"
+_ESCAPED_SECRET_KEY_PREFIX = (
+    rf"(?<![A-Za-z0-9])({_SECRET_KEY_PATTERN})\b((?:\\[\"'])?\s*[:=]+\s*)"
+)
 _QUOTED_KEY_DOUBLE_QUOTED_VALUE = re.compile(
     rf'{_QUOTED_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"', re.IGNORECASE
 )
@@ -30,17 +33,97 @@ _QUOTED_KEY_SINGLE_QUOTED_VALUE = re.compile(
     rf"{_QUOTED_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'", re.IGNORECASE
 )
 _BARE_KEY_DOUBLE_QUOTED_VALUE = re.compile(
-    rf'{_BARE_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"(?=\s|[,;.!?:)}}\]]|$)',
+    rf'{_BARE_SECRET_KEY_PREFIX}"((?:\\.|[^"\\\r\n])*)"',
     re.IGNORECASE,
 )
 _BARE_KEY_SINGLE_QUOTED_VALUE = re.compile(
-    rf"{_BARE_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'(?=\s|[,;.!?:)}}\]]|$)",
+    rf"{_BARE_SECRET_KEY_PREFIX}'((?:\\.|[^'\\\r\n])*)'",
+    re.IGNORECASE,
+)
+_BARE_KEY_ESCAPED_DOUBLE_QUOTED_VALUE = re.compile(
+    rf'{_ESCAPED_SECRET_KEY_PREFIX}\\"((?:\\.|[^"\\\r\n])*)\\"',
+    re.IGNORECASE,
+)
+_BARE_KEY_ESCAPED_SINGLE_QUOTED_VALUE = re.compile(
+    rf"{_ESCAPED_SECRET_KEY_PREFIX}\\'((?:\\.|[^'\\\r\n])*)\\'",
     re.IGNORECASE,
 )
 _SECRET_PAIR_PREFIX = rf"(?<![A-Za-z0-9])({_SECRET_KEY_PATTERN})\b([\"']?\s*[:=]+\s*)"
 _SECRET_PAIR_UNQUOTED = re.compile(
-    rf"{_SECRET_PAIR_PREFIX}([^\s\"',}}&]+)", re.IGNORECASE
+    rf"{_SECRET_PAIR_PREFIX}(?!\\[\"'])([^\s\"',}}&]+)", re.IGNORECASE
 )
+_COMPLETES_DOUBLE_QUOTED_FIELD = re.compile(r'(?:\\.|[^"\\\r\n])*"\s*[:=]')
+_COMPLETES_SINGLE_QUOTED_FIELD = re.compile(r"(?:\\.|[^'\\\r\n])*'\s*[:=]")
+_CONTAINS_QUOTED_FIELD = re.compile(r"(?:^|[,{\s])([\"'])[^\"'\\\r\n]+\1\s*[:=]\s*$")
+
+
+def _active_quotes_at(value: str, offsets: set[int]) -> dict[int, str | None]:
+    active_quotes: dict[int, str | None] = {}
+    quote: str | None = None
+    escaped = False
+    last_offset = max(offsets)
+
+    for position, character in enumerate(value):
+        if position in offsets:
+            active_quotes[position] = quote
+            if position == last_offset:
+                break
+        if character in "\r\n":
+            quote = None
+            escaped = False
+            continue
+        previous = value[position - 1] if position > 0 else ""
+        if previous in "\r\n":
+            previous = ""
+        following = value[position + 1] if position + 1 < len(value) else ""
+        if quote is None:
+            if character == '"' or (
+                character == "'" and not (previous.isalnum() or previous == "_")
+            ):
+                quote = character
+            continue
+        if escaped:
+            escaped = False
+        elif character == "\\":
+            escaped = True
+        elif character == quote:
+            if (
+                quote == "'"
+                and (previous.isalnum() or previous == "_")
+                and (following.isalnum() or following == "_")
+            ):
+                continue
+            quote = None
+
+    return active_quotes
+
+
+def _redact_bare_quoted_value(value: str, pattern: re.Pattern[str], quote: str) -> str:
+    matches = list(pattern.finditer(value))
+    if not matches:
+        return value
+
+    active_quotes = _active_quotes_at(value, {match.start() for match in matches})
+    completes_field = (
+        _COMPLETES_DOUBLE_QUOTED_FIELD
+        if quote == '"'
+        else _COMPLETES_SINGLE_QUOTED_FIELD
+    )
+    parts: list[str] = []
+    cursor = 0
+    for match in matches:
+        parts.append(value[cursor : match.start()])
+        if active_quotes[match.start()] == quote and (
+            completes_field.match(value, match.end())
+            or _CONTAINS_QUOTED_FIELD.search(match.group(3))
+        ):
+            parts.append(match.group(0))
+        else:
+            parts.append(f"{match.group(1)}{match.group(2)}{quote}{_REDACTED}{quote}")
+        cursor = match.end()
+
+    parts.append(value[cursor:])
+    return "".join(parts)
 
 
 def redact_sensitive_text(value: str) -> str:
@@ -49,8 +132,10 @@ def redact_sensitive_text(value: str) -> str:
     value = _AUTHORIZATION.sub(rf"\1 {_REDACTED}", value)
     value = _QUOTED_KEY_DOUBLE_QUOTED_VALUE.sub(rf'\1\2\1\3"{_REDACTED}"', value)
     value = _QUOTED_KEY_SINGLE_QUOTED_VALUE.sub(rf"\1\2\1\3'{_REDACTED}'", value)
-    value = _BARE_KEY_DOUBLE_QUOTED_VALUE.sub(rf'\1\2"{_REDACTED}"', value)
-    value = _BARE_KEY_SINGLE_QUOTED_VALUE.sub(rf"\1\2'{_REDACTED}'", value)
+    value = _BARE_KEY_ESCAPED_DOUBLE_QUOTED_VALUE.sub(rf'\1\2\\"{_REDACTED}\\"', value)
+    value = _BARE_KEY_ESCAPED_SINGLE_QUOTED_VALUE.sub(rf"\1\2\\'{_REDACTED}\\'", value)
+    value = _redact_bare_quoted_value(value, _BARE_KEY_DOUBLE_QUOTED_VALUE, '"')
+    value = _redact_bare_quoted_value(value, _BARE_KEY_SINGLE_QUOTED_VALUE, "'")
     return _SECRET_PAIR_UNQUOTED.sub(rf"\1\2{_REDACTED}", value)
 
 

--- a/python/composio/utils/redaction.py
+++ b/python/composio/utils/redaction.py
@@ -3,18 +3,30 @@
 from __future__ import annotations
 
 import re
+import typing as t
+from collections.abc import Mapping
 
 _REDACTED = "[REDACTED]"
 _URL_QUERY = re.compile(r"(\bhttps?://[^\s?#'\"]+)\?[^\s'\"]*", re.IGNORECASE)
 _AUTHORIZATION = re.compile(r"\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+", re.IGNORECASE)
+_SECRET_KEY_PATTERN = (
+    r"authorization|auth|api[-_]?key|apikey|x-api-key|access[-_]?token|"
+    r"refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd"
+)
+_SECRET_KEY = re.compile(rf"(?:[A-Za-z0-9]+_)*(?:{_SECRET_KEY_PATTERN})", re.IGNORECASE)
 # The separator group allows a quote directly after the key name so JSON and
 # dict reprs are covered: in `{"api_key": "secret"}` the key's own closing quote
-# sits between the name and the colon.
-_SECRET_PAIR = re.compile(
-    # Leading lookbehind (not \\b) so env-style names like COMPOSIO_API_KEY still
-    # match: underscore is a word char, so \\b can't fire between COMPOSIO_ and API.
-    r"(?<![A-Za-z0-9])(authorization|api[-_]?key|apikey|x-api-key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd)\b([\"']?\s*[:=]+\s*)([\"']?)([^\s\"',}&]+)\3",
-    re.IGNORECASE,
+# sits between the name and the colon. Quoted rules run first so whitespace is
+# part of the redacted value instead of preventing a match.
+_SECRET_PAIR_PREFIX = rf"(?<![A-Za-z0-9])({_SECRET_KEY_PATTERN})\b([\"']?\s*[:=]+\s*)"
+_SECRET_PAIR_DOUBLE_QUOTED = re.compile(
+    rf'{_SECRET_PAIR_PREFIX}"(?:\\.|[^"\\\r\n])*"', re.IGNORECASE
+)
+_SECRET_PAIR_SINGLE_QUOTED = re.compile(
+    rf"{_SECRET_PAIR_PREFIX}'(?:\\.|[^'\\\r\n])*'", re.IGNORECASE
+)
+_SECRET_PAIR_UNQUOTED = re.compile(
+    rf"{_SECRET_PAIR_PREFIX}([^\s\"',}}&]+)", re.IGNORECASE
 )
 
 
@@ -22,4 +34,24 @@ def redact_sensitive_text(value: str) -> str:
     """Remove common URL, authorization, and key-value secret shapes."""
     value = _URL_QUERY.sub(rf"\1?{_REDACTED}", value)
     value = _AUTHORIZATION.sub(rf"\1 {_REDACTED}", value)
-    return _SECRET_PAIR.sub(rf"\1\2\3{_REDACTED}\3", value)
+    value = _SECRET_PAIR_DOUBLE_QUOTED.sub(rf'\1\2"{_REDACTED}"', value)
+    value = _SECRET_PAIR_SINGLE_QUOTED.sub(rf"\1\2'{_REDACTED}'", value)
+    return _SECRET_PAIR_UNQUOTED.sub(rf"\1\2{_REDACTED}", value)
+
+
+def redact_sensitive_value(value: t.Any) -> t.Any:
+    """Redact secrets in structured logging metadata without changing safe scalar types."""
+    if isinstance(value, Mapping):
+        return {
+            key: _REDACTED
+            if isinstance(key, str) and _SECRET_KEY.fullmatch(key)
+            else redact_sensitive_value(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_sensitive_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_sensitive_value(item) for item in value)
+    if isinstance(value, str):
+        return redact_sensitive_text(value)
+    return value

--- a/python/composio/utils/redaction.py
+++ b/python/composio/utils/redaction.py
@@ -30,11 +30,11 @@ _QUOTED_KEY_SINGLE_QUOTED_VALUE = re.compile(
     rf"{_QUOTED_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'", re.IGNORECASE
 )
 _BARE_KEY_DOUBLE_QUOTED_VALUE = re.compile(
-    rf'{_BARE_SECRET_KEY_PREFIX}"(?!\s*(?:,|}}|\]|\)|$))(?:\\.|[^"\\\r\n])*"',
+    rf'{_BARE_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"(?![A-Za-z0-9_])',
     re.IGNORECASE,
 )
 _BARE_KEY_SINGLE_QUOTED_VALUE = re.compile(
-    rf"{_BARE_SECRET_KEY_PREFIX}'(?!\s*(?:,|}}|\]|\)|$))(?:\\.|[^'\\\r\n])*'",
+    rf"{_BARE_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'(?![A-Za-z0-9_])",
     re.IGNORECASE,
 )
 _SECRET_PAIR_PREFIX = rf"(?<![A-Za-z0-9])({_SECRET_KEY_PATTERN})\b([\"']?\s*[:=]+\s*)"

--- a/python/composio/utils/redaction.py
+++ b/python/composio/utils/redaction.py
@@ -15,10 +15,13 @@ _SECRET_KEY_PATTERN = (
     r"authorization|auth|api[-_]?key|apikey|x-api-key|access[-_]?token|"
     r"refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd"
 )
-_SECRET_KEY = re.compile(rf"(?:[A-Za-z0-9]+_)*(?:{_SECRET_KEY_PATTERN})", re.IGNORECASE)
+_SECRET_KEY_WITH_PREFIX_PATTERN = rf"(?:[A-Za-z0-9]+_)*(?:{_SECRET_KEY_PATTERN})"
+_SECRET_KEY = re.compile(_SECRET_KEY_WITH_PREFIX_PATTERN, re.IGNORECASE)
 # Quoted keys are matched as a unit so a key-like word at the end of an error
 # string cannot treat the string's closing quote as the start of a secret value.
-_QUOTED_SECRET_KEY_PREFIX = rf"([\"'])({_SECRET_KEY_PATTERN})\1(\s*[:=]+\s*)"
+_QUOTED_SECRET_KEY_PREFIX = (
+    rf"([\"'])({_SECRET_KEY_WITH_PREFIX_PATTERN})\1(\s*[:=]+\s*)"
+)
 _BARE_SECRET_KEY_PREFIX = rf"(?<![A-Za-z0-9\"'])({_SECRET_KEY_PATTERN})\b(\s*[:=]+\s*)"
 _QUOTED_KEY_DOUBLE_QUOTED_VALUE = re.compile(
     rf'{_QUOTED_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"', re.IGNORECASE
@@ -73,11 +76,17 @@ def redact_sensitive_value(value: t.Any) -> t.Any:
                     for key, nested in item.items():
                         if remaining_nodes <= 0:
                             break
+                        if isinstance(key, str):
+                            redacted_key: t.Any = redact_sensitive_text(key)
+                        elif isinstance(key, (int, float, bool, type(None))):
+                            redacted_key = key
+                        else:
+                            redacted_key = _REDACTED
                         if isinstance(key, str) and _SECRET_KEY.fullmatch(key):
                             remaining_nodes -= 1
-                            redacted_mapping[key] = _REDACTED
+                            redacted_mapping[redacted_key] = _REDACTED
                         else:
-                            redacted_mapping[key] = redact(nested, depth + 1)
+                            redacted_mapping[redacted_key] = redact(nested, depth + 1)
                     return redacted_mapping
 
                 redacted_items: list[t.Any] = []

--- a/python/composio/utils/redaction.py
+++ b/python/composio/utils/redaction.py
@@ -16,17 +16,25 @@ _SECRET_KEY_PATTERN = (
     r"refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd"
 )
 _SECRET_KEY = re.compile(rf"(?:[A-Za-z0-9]+_)*(?:{_SECRET_KEY_PATTERN})", re.IGNORECASE)
-# The separator group allows a quote directly after the key name so JSON and
-# dict reprs are covered: in `{"api_key": "secret"}` the key's own closing quote
-# sits between the name and the colon. Quoted rules run first so whitespace is
-# part of the redacted value instead of preventing a match.
+# Quoted keys are matched as a unit so a key-like word at the end of an error
+# string cannot treat the string's closing quote as the start of a secret value.
+_QUOTED_SECRET_KEY_PREFIX = rf"([\"'])({_SECRET_KEY_PATTERN})\1(\s*[:=]+\s*)"
+_BARE_SECRET_KEY_PREFIX = rf"(?<![A-Za-z0-9\"'])({_SECRET_KEY_PATTERN})\b(\s*[:=]+\s*)"
+_QUOTED_KEY_DOUBLE_QUOTED_VALUE = re.compile(
+    rf'{_QUOTED_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"', re.IGNORECASE
+)
+_QUOTED_KEY_SINGLE_QUOTED_VALUE = re.compile(
+    rf"{_QUOTED_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'", re.IGNORECASE
+)
+_BARE_KEY_DOUBLE_QUOTED_VALUE = re.compile(
+    rf'{_BARE_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"(?=\s*(?:,|}}|\]|\)|$))',
+    re.IGNORECASE,
+)
+_BARE_KEY_SINGLE_QUOTED_VALUE = re.compile(
+    rf"{_BARE_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'(?=\s*(?:,|}}|\]|\)|$))",
+    re.IGNORECASE,
+)
 _SECRET_PAIR_PREFIX = rf"(?<![A-Za-z0-9])({_SECRET_KEY_PATTERN})\b([\"']?\s*[:=]+\s*)"
-_SECRET_PAIR_DOUBLE_QUOTED = re.compile(
-    rf'{_SECRET_PAIR_PREFIX}"(?:\\.|[^"\\\r\n])*"', re.IGNORECASE
-)
-_SECRET_PAIR_SINGLE_QUOTED = re.compile(
-    rf"{_SECRET_PAIR_PREFIX}'(?:\\.|[^'\\\r\n])*'", re.IGNORECASE
-)
 _SECRET_PAIR_UNQUOTED = re.compile(
     rf"{_SECRET_PAIR_PREFIX}([^\s\"',}}&]+)", re.IGNORECASE
 )
@@ -36,8 +44,10 @@ def redact_sensitive_text(value: str) -> str:
     """Remove common URL, authorization, and key-value secret shapes."""
     value = _URL_QUERY.sub(rf"\1?{_REDACTED}", value)
     value = _AUTHORIZATION.sub(rf"\1 {_REDACTED}", value)
-    value = _SECRET_PAIR_DOUBLE_QUOTED.sub(rf'\1\2"{_REDACTED}"', value)
-    value = _SECRET_PAIR_SINGLE_QUOTED.sub(rf"\1\2'{_REDACTED}'", value)
+    value = _QUOTED_KEY_DOUBLE_QUOTED_VALUE.sub(rf'\1\2\1\3"{_REDACTED}"', value)
+    value = _QUOTED_KEY_SINGLE_QUOTED_VALUE.sub(rf"\1\2\1\3'{_REDACTED}'", value)
+    value = _BARE_KEY_DOUBLE_QUOTED_VALUE.sub(rf'\1\2"{_REDACTED}"', value)
+    value = _BARE_KEY_SINGLE_QUOTED_VALUE.sub(rf"\1\2'{_REDACTED}'", value)
     return _SECRET_PAIR_UNQUOTED.sub(rf"\1\2{_REDACTED}", value)
 
 
@@ -59,20 +69,53 @@ def redact_sensitive_value(value: t.Any) -> t.Any:
             active_containers.add(identity)
             try:
                 if isinstance(item, Mapping):
-                    return {
-                        key: _REDACTED
-                        if isinstance(key, str) and _SECRET_KEY.fullmatch(key)
-                        else redact(nested, depth + 1)
-                        for key, nested in item.items()
-                    }
+                    redacted_mapping: dict[t.Any, t.Any] = {}
+                    for key, nested in item.items():
+                        if remaining_nodes <= 0:
+                            return _REDACTED
+                        if isinstance(key, str) and _SECRET_KEY.fullmatch(key):
+                            remaining_nodes -= 1
+                            redacted_mapping[key] = _REDACTED
+                        else:
+                            redacted_mapping[key] = redact(nested, depth + 1)
+                    return redacted_mapping
+
+                redacted_items: list[t.Any] = []
+                fields = getattr(item, "_fields", ()) if isinstance(item, tuple) else ()
+                for index, nested in enumerate(item):
+                    if remaining_nodes <= 0:
+                        return _REDACTED
+                    if (
+                        index < len(fields)
+                        and isinstance(fields[index], str)
+                        and _SECRET_KEY.fullmatch(fields[index])
+                    ):
+                        remaining_nodes -= 1
+                        redacted_items.append(_REDACTED)
+                    else:
+                        redacted_items.append(redact(nested, depth + 1))
                 if isinstance(item, list):
-                    return [redact(nested, depth + 1) for nested in item]
-                return tuple(redact(nested, depth + 1) for nested in item)
+                    if type(item) is list:
+                        return redacted_items
+                    try:
+                        return type(item)(redacted_items)
+                    except Exception:
+                        return redacted_items
+                if hasattr(item, "_fields"):
+                    try:
+                        return type(item)(*redacted_items)
+                    except Exception:
+                        pass
+                return tuple(redacted_items)
             finally:
                 active_containers.remove(identity)
 
         if isinstance(item, str):
             return redact_sensitive_text(item)
-        return item
+        if isinstance(item, (int, float, bool, type(None))):
+            return item
+        if isinstance(item, (bytes, bytearray, memoryview)):
+            return _REDACTED
+        return _REDACTED
 
     return redact(value, 0)

--- a/python/composio/utils/redaction.py
+++ b/python/composio/utils/redaction.py
@@ -30,11 +30,11 @@ _QUOTED_KEY_SINGLE_QUOTED_VALUE = re.compile(
     rf"{_QUOTED_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'", re.IGNORECASE
 )
 _BARE_KEY_DOUBLE_QUOTED_VALUE = re.compile(
-    rf'{_BARE_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"(?![A-Za-z0-9_])',
+    rf'{_BARE_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"(?=\s|[,;.!?:)}}\]]|$)',
     re.IGNORECASE,
 )
 _BARE_KEY_SINGLE_QUOTED_VALUE = re.compile(
-    rf"{_BARE_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'(?![A-Za-z0-9_])",
+    rf"{_BARE_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'(?=\s|[,;.!?:)}}\]]|$)",
     re.IGNORECASE,
 )
 _SECRET_PAIR_PREFIX = rf"(?<![A-Za-z0-9])({_SECRET_KEY_PATTERN})\b([\"']?\s*[:=]+\s*)"

--- a/python/composio/utils/redaction.py
+++ b/python/composio/utils/redaction.py
@@ -27,11 +27,11 @@ _QUOTED_KEY_SINGLE_QUOTED_VALUE = re.compile(
     rf"{_QUOTED_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'", re.IGNORECASE
 )
 _BARE_KEY_DOUBLE_QUOTED_VALUE = re.compile(
-    rf'{_BARE_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"(?=\s*(?:,|}}|\]|\)|$))',
+    rf'{_BARE_SECRET_KEY_PREFIX}"(?!\s*(?:,|}}|\]|\)|$))(?:\\.|[^"\\\r\n])*"',
     re.IGNORECASE,
 )
 _BARE_KEY_SINGLE_QUOTED_VALUE = re.compile(
-    rf"{_BARE_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'(?=\s*(?:,|}}|\]|\)|$))",
+    rf"{_BARE_SECRET_KEY_PREFIX}'(?!\s*(?:,|}}|\]|\)|$))(?:\\.|[^'\\\r\n])*'",
     re.IGNORECASE,
 )
 _SECRET_PAIR_PREFIX = rf"(?<![A-Za-z0-9])({_SECRET_KEY_PATTERN})\b([\"']?\s*[:=]+\s*)"
@@ -72,7 +72,7 @@ def redact_sensitive_value(value: t.Any) -> t.Any:
                     redacted_mapping: dict[t.Any, t.Any] = {}
                     for key, nested in item.items():
                         if remaining_nodes <= 0:
-                            return _REDACTED
+                            break
                         if isinstance(key, str) and _SECRET_KEY.fullmatch(key):
                             remaining_nodes -= 1
                             redacted_mapping[key] = _REDACTED

--- a/python/composio/utils/redaction.py
+++ b/python/composio/utils/redaction.py
@@ -7,6 +7,8 @@ import typing as t
 from collections.abc import Mapping
 
 _REDACTED = "[REDACTED]"
+_MAX_STRUCTURED_REDACTION_DEPTH = 32
+_MAX_STRUCTURED_REDACTION_NODES = 10_000
 _URL_QUERY = re.compile(r"(\bhttps?://[^\s?#'\"]+)\?[^\s'\"]*", re.IGNORECASE)
 _AUTHORIZATION = re.compile(r"\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+", re.IGNORECASE)
 _SECRET_KEY_PATTERN = (
@@ -41,17 +43,36 @@ def redact_sensitive_text(value: str) -> str:
 
 def redact_sensitive_value(value: t.Any) -> t.Any:
     """Redact secrets in structured logging metadata without changing safe scalar types."""
-    if isinstance(value, Mapping):
-        return {
-            key: _REDACTED
-            if isinstance(key, str) and _SECRET_KEY.fullmatch(key)
-            else redact_sensitive_value(item)
-            for key, item in value.items()
-        }
-    if isinstance(value, list):
-        return [redact_sensitive_value(item) for item in value]
-    if isinstance(value, tuple):
-        return tuple(redact_sensitive_value(item) for item in value)
-    if isinstance(value, str):
-        return redact_sensitive_text(value)
-    return value
+    active_containers: set[int] = set()
+    remaining_nodes = _MAX_STRUCTURED_REDACTION_NODES
+
+    def redact(item: t.Any, depth: int) -> t.Any:
+        nonlocal remaining_nodes
+        if depth >= _MAX_STRUCTURED_REDACTION_DEPTH or remaining_nodes <= 0:
+            return _REDACTED
+        remaining_nodes -= 1
+
+        if isinstance(item, (Mapping, list, tuple)):
+            identity = id(item)
+            if identity in active_containers:
+                return _REDACTED
+            active_containers.add(identity)
+            try:
+                if isinstance(item, Mapping):
+                    return {
+                        key: _REDACTED
+                        if isinstance(key, str) and _SECRET_KEY.fullmatch(key)
+                        else redact(nested, depth + 1)
+                        for key, nested in item.items()
+                    }
+                if isinstance(item, list):
+                    return [redact(nested, depth + 1) for nested in item]
+                return tuple(redact(nested, depth + 1) for nested in item)
+            finally:
+                active_containers.remove(identity)
+
+        if isinstance(item, str):
+            return redact_sensitive_text(item)
+        return item
+
+    return redact(value, 0)

--- a/python/tests/test_logging_redaction.py
+++ b/python/tests/test_logging_redaction.py
@@ -59,7 +59,11 @@ def test_sdk_logger_redacts_extra_metadata_before_formatting() -> None:
         "request metadata",
         extra={
             "api_key": "uak_test_secret",
-            "context": {"access_token": "oauth_test_secret", "safe": "visible"},
+            "context": {
+                "access_token": "oauth_test_secret",
+                "api_key=nested_key_test_secret": "hidden key",
+                "safe": "visible",
+            },
             "binary": b"api_key=binary_test_secret",
         },
     )
@@ -67,8 +71,9 @@ def test_sdk_logger_redacts_extra_metadata_before_formatting() -> None:
     logged = output.getvalue()
     assert "uak_test_secret" not in logged
     assert "oauth_test_secret" not in logged
+    assert "nested_key_test_secret" not in logged
     assert "binary_test_secret" not in logged
-    assert logged.count("[REDACTED]") == 3
+    assert logged.count("[REDACTED]") == 4
     assert "visible" in logged
 
 

--- a/python/tests/test_logging_redaction.py
+++ b/python/tests/test_logging_redaction.py
@@ -72,6 +72,21 @@ def test_sdk_logger_redacts_extra_metadata_before_formatting() -> None:
     assert "visible" in logged
 
 
+def test_sdk_logger_keeps_wide_extra_metadata_mapping_compatible() -> None:
+    output = io.StringIO()
+    logger = logging.getLogger("composio-test-wide-extra-redaction")
+    logger.handlers = [logging.StreamHandler(output)]
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+    wrapped = _VerbosityWrapper(logger, verbosity_level=3)
+
+    wrapped.info(
+        "wide metadata", extra={f"field_{index}": index for index in range(10_001)}
+    )
+
+    assert "wide metadata" in output.getvalue()
+
+
 def test_sdk_logger_redacts_errors_without_truncating_them() -> None:
     output = io.StringIO()
     logger = logging.getLogger("composio-test-error-redaction")

--- a/python/tests/test_logging_redaction.py
+++ b/python/tests/test_logging_redaction.py
@@ -4,6 +4,16 @@ import logging
 from composio.utils.logging import _VerbosityWrapper
 
 
+class _CaptureHandler(logging.StreamHandler):
+    def __init__(self, stream: io.StringIO) -> None:
+        super().__init__(stream)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+        super().emit(record)
+
+
 def test_sdk_logger_redacts_structured_and_interpolated_credentials() -> None:
     output = io.StringIO()
     logger = logging.getLogger("composio-test-credential-redaction")
@@ -19,6 +29,31 @@ def test_sdk_logger_redacts_structured_and_interpolated_credentials() -> None:
     assert "uak_test_secret" not in logged
     assert "oauth_test_secret" not in logged
     assert "[REDACTED]" in logged
+    assert "visible" in logged
+
+
+def test_sdk_logger_redacts_extra_metadata_before_formatting() -> None:
+    output = io.StringIO()
+    logger = logging.getLogger("composio-test-extra-redaction")
+    handler = logging.StreamHandler(output)
+    handler.setFormatter(logging.Formatter("%(message)s %(api_key)s %(context)s"))
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+    wrapped = _VerbosityWrapper(logger, verbosity_level=3)
+
+    wrapped.info(
+        "request metadata",
+        extra={
+            "api_key": "uak_test_secret",
+            "context": {"access_token": "oauth_test_secret", "safe": "visible"},
+        },
+    )
+
+    logged = output.getvalue()
+    assert "uak_test_secret" not in logged
+    assert "oauth_test_secret" not in logged
+    assert logged.count("[REDACTED]") == 2
     assert "visible" in logged
 
 
@@ -41,7 +76,8 @@ def test_sdk_logger_redacts_errors_without_truncating_them() -> None:
 def test_sdk_logger_redacts_exception_tracebacks() -> None:
     output = io.StringIO()
     logger = logging.getLogger("composio-test-exception-redaction")
-    logger.handlers = [logging.StreamHandler(output)]
+    handler = _CaptureHandler(output)
+    logger.handlers = [handler]
     logger.propagate = False
     logger.setLevel(logging.ERROR)
     wrapped = _VerbosityWrapper(logger, verbosity_level=3)
@@ -56,6 +92,9 @@ def test_sdk_logger_redacts_exception_tracebacks() -> None:
     assert "Traceback (most recent call last)" in logged
     assert "RuntimeError" in logged
     assert "[REDACTED]" in logged
+    assert handler.records[0].exc_info is not None
+    assert isinstance(handler.records[0].exc_info[1], RuntimeError)
+    assert "oauth_test_secret" not in str(handler.records[0].exc_info[1])
 
 
 def test_sdk_logger_omits_arguments_when_placeholder_formatting_fails() -> None:

--- a/python/tests/test_logging_redaction.py
+++ b/python/tests/test_logging_redaction.py
@@ -38,6 +38,41 @@ def test_sdk_logger_redacts_errors_without_truncating_them() -> None:
     assert logged.rstrip().endswith("tail")
 
 
+def test_sdk_logger_redacts_exception_tracebacks() -> None:
+    output = io.StringIO()
+    logger = logging.getLogger("composio-test-exception-redaction")
+    logger.handlers = [logging.StreamHandler(output)]
+    logger.propagate = False
+    logger.setLevel(logging.ERROR)
+    wrapped = _VerbosityWrapper(logger, verbosity_level=3)
+
+    try:
+        raise RuntimeError("Authorization: Bearer oauth_test_secret")
+    except RuntimeError:
+        wrapped.error("request failed", exc_info=True)
+
+    logged = output.getvalue()
+    assert "oauth_test_secret" not in logged
+    assert "Traceback (most recent call last)" in logged
+    assert "RuntimeError" in logged
+    assert "[REDACTED]" in logged
+
+
+def test_sdk_logger_omits_arguments_when_placeholder_formatting_fails() -> None:
+    output = io.StringIO()
+    logger = logging.getLogger("composio-test-placeholder-redaction")
+    logger.handlers = [logging.StreamHandler(output)]
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+    wrapped = _VerbosityWrapper(logger, verbosity_level=3)
+
+    wrapped.info("api_key=%d", "uak_test_secret")
+
+    logged = output.getvalue()
+    assert "uak_test_secret" not in logged
+    assert "logging arguments omitted" in logged
+
+
 def test_sdk_logger_tolerates_bad_placeholders_and_skips_disabled_levels() -> None:
     class RaisesOnString:
         def __str__(self) -> str:

--- a/python/tests/test_logging_redaction.py
+++ b/python/tests/test_logging_redaction.py
@@ -1,0 +1,56 @@
+import io
+import logging
+
+from composio.utils.logging import _VerbosityWrapper
+
+
+def test_sdk_logger_redacts_structured_and_interpolated_credentials() -> None:
+    output = io.StringIO()
+    logger = logging.getLogger("composio-test-credential-redaction")
+    logger.handlers = [logging.StreamHandler(output)]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    wrapped = _VerbosityWrapper(logger, verbosity_level=3)
+
+    wrapped.debug("api_key=%s", "uak_test_secret")
+    wrapped.error({"nested": {"access_token": "oauth_test_secret"}, "safe": "visible"})
+
+    logged = output.getvalue()
+    assert "uak_test_secret" not in logged
+    assert "oauth_test_secret" not in logged
+    assert "[REDACTED]" in logged
+    assert "visible" in logged
+
+
+def test_sdk_logger_redacts_errors_without_truncating_them() -> None:
+    output = io.StringIO()
+    logger = logging.getLogger("composio-test-error-redaction")
+    logger.handlers = [logging.StreamHandler(output)]
+    logger.propagate = False
+    logger.setLevel(logging.ERROR)
+    wrapped = _VerbosityWrapper(logger, verbosity_level=0)
+
+    wrapped.error("api_key=%s %s", "uak_test_secret", "tail" * 100)
+
+    logged = output.getvalue()
+    assert "uak_test_secret" not in logged
+    assert "[REDACTED]" in logged
+    assert logged.rstrip().endswith("tail")
+
+
+def test_sdk_logger_tolerates_bad_placeholders_and_skips_disabled_levels() -> None:
+    class RaisesOnString:
+        def __str__(self) -> str:
+            raise AssertionError("disabled log arguments must remain lazy")
+
+    output = io.StringIO()
+    logger = logging.getLogger("composio-test-logging-compatibility")
+    logger.handlers = [logging.StreamHandler(output)]
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+    wrapped = _VerbosityWrapper(logger, verbosity_level=3)
+
+    wrapped.info("missing=%(missing)s", {"present": "safe"})
+    wrapped.debug("api_key=%s", RaisesOnString())
+
+    assert "missing" in output.getvalue()

--- a/python/tests/test_logging_redaction.py
+++ b/python/tests/test_logging_redaction.py
@@ -127,9 +127,8 @@ def test_sdk_logger_redacts_exception_tracebacks() -> None:
     assert "Traceback (most recent call last)" in logged
     assert "RuntimeError" in logged
     assert "[REDACTED]" in logged
-    assert handler.records[0].exc_info is not None
-    assert isinstance(handler.records[0].exc_info[1], RuntimeError)
-    assert "oauth_test_secret" not in str(handler.records[0].exc_info[1])
+    assert logged.count("Traceback (most recent call last)") == 1
+    assert handler.records[0].exc_info is None
 
 
 def test_sdk_logger_ignores_empty_implicit_exception_metadata() -> None:
@@ -147,7 +146,7 @@ def test_sdk_logger_ignores_empty_implicit_exception_metadata() -> None:
     assert handler.records[0].exc_info is None
 
 
-def test_sdk_logger_rebuilds_exception_metadata_without_original_state() -> None:
+def test_sdk_logger_omits_exception_metadata_and_original_state() -> None:
     output = io.StringIO()
     logger = logging.getLogger("composio-test-exception-state-redaction")
     handler = _CaptureHandler(output)
@@ -161,21 +160,16 @@ def test_sdk_logger_rebuilds_exception_metadata_without_original_state() -> None
     wrapped.error("request failed", exc_info=error)
 
     logged = output.getvalue()
-    sanitized = handler.records[0].exc_info
-    assert sanitized is not None
-    assert sanitized[0] is _TokenError
-    assert type(sanitized[1]) is _TokenError
-    assert vars(sanitized[1]) == {}
+    assert handler.records[0].exc_info is None
     for secret in (
         "message_test_secret",
         "attribute_test_secret",
         "note_test_secret",
     ):
         assert secret not in logged
-        assert secret not in str(sanitized[1])
 
 
-def test_sdk_logger_falls_back_when_exception_type_cannot_be_rebuilt() -> None:
+def test_sdk_logger_does_not_rebuild_custom_exception_types() -> None:
     output = io.StringIO()
     logger = logging.getLogger("composio-test-exception-constructor-fallback")
     handler = _CaptureHandler(output)
@@ -187,12 +181,8 @@ def test_sdk_logger_falls_back_when_exception_type_cannot_be_rebuilt() -> None:
     wrapped.error("request failed", exc_info=_ConstructorSensitiveError("known"))
 
     logged = output.getvalue()
-    sanitized = handler.records[0].exc_info
-    assert sanitized is not None
-    assert sanitized[0] is RuntimeError
-    assert isinstance(sanitized[1], RuntimeError)
+    assert handler.records[0].exc_info is None
     assert "constructor-secret" not in logged
-    assert "constructor-secret" not in str(sanitized[1])
 
 
 def test_sdk_logger_omits_arguments_when_placeholder_formatting_fails() -> None:

--- a/python/tests/test_logging_redaction.py
+++ b/python/tests/test_logging_redaction.py
@@ -155,7 +155,8 @@ def test_sdk_logger_omits_exception_metadata_and_original_state() -> None:
     logger.setLevel(logging.ERROR)
     wrapped = _VerbosityWrapper(logger, verbosity_level=3)
     error = _TokenError("api_key=message_test_secret", "attribute_test_secret")
-    error.add_note("password=note_test_secret")
+    # ``BaseException.add_note`` is 3.11+; ``__notes__`` is what traceback reads.
+    error.__notes__ = ["password=note_test_secret"]
 
     wrapped.error("request failed", exc_info=error)
 

--- a/python/tests/test_logging_redaction.py
+++ b/python/tests/test_logging_redaction.py
@@ -132,6 +132,21 @@ def test_sdk_logger_redacts_exception_tracebacks() -> None:
     assert "oauth_test_secret" not in str(handler.records[0].exc_info[1])
 
 
+def test_sdk_logger_ignores_empty_implicit_exception_metadata() -> None:
+    output = io.StringIO()
+    logger = logging.getLogger("composio-test-empty-exception-metadata")
+    handler = _CaptureHandler(output)
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.ERROR)
+    wrapped = _VerbosityWrapper(logger, verbosity_level=3)
+
+    wrapped.error("request failed", exc_info=True)
+
+    assert output.getvalue() == "request failed\n"
+    assert handler.records[0].exc_info is None
+
+
 def test_sdk_logger_rebuilds_exception_metadata_without_original_state() -> None:
     output = io.StringIO()
     logger = logging.getLogger("composio-test-exception-state-redaction")

--- a/python/tests/test_logging_redaction.py
+++ b/python/tests/test_logging_redaction.py
@@ -14,6 +14,17 @@ class _CaptureHandler(logging.StreamHandler):
         super().emit(record)
 
 
+class _TokenError(ValueError):
+    def __init__(self, message: str, token: str | None = None) -> None:
+        self.token = token
+        super().__init__(message)
+
+
+class _ConstructorSensitiveError(Exception):
+    def __init__(self, key: str) -> None:
+        super().__init__({"known": "api_key=constructor-secret"}[key])
+
+
 def test_sdk_logger_redacts_structured_and_interpolated_credentials() -> None:
     output = io.StringIO()
     logger = logging.getLogger("composio-test-credential-redaction")
@@ -36,7 +47,9 @@ def test_sdk_logger_redacts_extra_metadata_before_formatting() -> None:
     output = io.StringIO()
     logger = logging.getLogger("composio-test-extra-redaction")
     handler = logging.StreamHandler(output)
-    handler.setFormatter(logging.Formatter("%(message)s %(api_key)s %(context)s"))
+    handler.setFormatter(
+        logging.Formatter("%(message)s %(api_key)s %(context)s %(binary)s")
+    )
     logger.handlers = [handler]
     logger.propagate = False
     logger.setLevel(logging.INFO)
@@ -47,13 +60,15 @@ def test_sdk_logger_redacts_extra_metadata_before_formatting() -> None:
         extra={
             "api_key": "uak_test_secret",
             "context": {"access_token": "oauth_test_secret", "safe": "visible"},
+            "binary": b"api_key=binary_test_secret",
         },
     )
 
     logged = output.getvalue()
     assert "uak_test_secret" not in logged
     assert "oauth_test_secret" not in logged
-    assert logged.count("[REDACTED]") == 2
+    assert "binary_test_secret" not in logged
+    assert logged.count("[REDACTED]") == 3
     assert "visible" in logged
 
 
@@ -95,6 +110,54 @@ def test_sdk_logger_redacts_exception_tracebacks() -> None:
     assert handler.records[0].exc_info is not None
     assert isinstance(handler.records[0].exc_info[1], RuntimeError)
     assert "oauth_test_secret" not in str(handler.records[0].exc_info[1])
+
+
+def test_sdk_logger_rebuilds_exception_metadata_without_original_state() -> None:
+    output = io.StringIO()
+    logger = logging.getLogger("composio-test-exception-state-redaction")
+    handler = _CaptureHandler(output)
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.ERROR)
+    wrapped = _VerbosityWrapper(logger, verbosity_level=3)
+    error = _TokenError("api_key=message_test_secret", "attribute_test_secret")
+    error.add_note("password=note_test_secret")
+
+    wrapped.error("request failed", exc_info=error)
+
+    logged = output.getvalue()
+    sanitized = handler.records[0].exc_info
+    assert sanitized is not None
+    assert sanitized[0] is _TokenError
+    assert type(sanitized[1]) is _TokenError
+    assert vars(sanitized[1]) == {}
+    for secret in (
+        "message_test_secret",
+        "attribute_test_secret",
+        "note_test_secret",
+    ):
+        assert secret not in logged
+        assert secret not in str(sanitized[1])
+
+
+def test_sdk_logger_falls_back_when_exception_type_cannot_be_rebuilt() -> None:
+    output = io.StringIO()
+    logger = logging.getLogger("composio-test-exception-constructor-fallback")
+    handler = _CaptureHandler(output)
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.ERROR)
+    wrapped = _VerbosityWrapper(logger, verbosity_level=3)
+
+    wrapped.error("request failed", exc_info=_ConstructorSensitiveError("known"))
+
+    logged = output.getvalue()
+    sanitized = handler.records[0].exc_info
+    assert sanitized is not None
+    assert sanitized[0] is RuntimeError
+    assert isinstance(sanitized[1], RuntimeError)
+    assert "constructor-secret" not in logged
+    assert "constructor-secret" not in str(sanitized[1])
 
 
 def test_sdk_logger_omits_arguments_when_placeholder_formatting_fails() -> None:

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -1,7 +1,6 @@
 """Tests for telemetry secret redaction."""
 
 import pytest
-
 from composio.utils.redaction import redact_sensitive_text
 
 
@@ -24,9 +23,15 @@ def test_redacts_url_queries_authorization_and_secret_pairs() -> None:
         ('{"api_key":"sk-live-abc123"}', "sk-live-abc123"),
         ('{"api_key" : "sk-live-abc123"}', "sk-live-abc123"),
         ('{"refresh_token":"rt-abc.def-123"}', "rt-abc.def-123"),
+        ('{"auth":"app-key:pusher-secret"}', "app-key:pusher-secret"),
         ('{"x-api-key":"sk-hdr","user":"bob"}', "sk-hdr"),
         ("{'client_secret': 'cs-live-abc123'}", "cs-live-abc123"),
         ('{"password": "hunter2"}', "hunter2"),
+        (
+            '{"password": "correct horse battery staple"}',
+            "correct horse battery staple",
+        ),
+        ("{'client_secret': 'multi word secret'}", "multi word secret"),
     ],
 )
 def test_redacts_secrets_in_json_and_dict_reprs(text: str, secret: str) -> None:

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -1,7 +1,7 @@
 """Tests for telemetry secret redaction."""
 
 import pytest
-from composio.utils.redaction import redact_sensitive_text
+from composio.utils.redaction import redact_sensitive_text, redact_sensitive_value
 
 
 def test_redacts_url_queries_authorization_and_secret_pairs() -> None:
@@ -99,3 +99,15 @@ def test_redacts_env_style_prefixed_api_keys(text: str, secret: str) -> None:
 def test_does_not_match_secret_name_embedded_in_letters() -> None:
     """Lookbehind still refuses letter-prefixed collisions like myapikey=x."""
     assert redact_sensitive_text("myapikey=sk_live_9f3c") == "myapikey=sk_live_9f3c"
+
+
+def test_structured_redaction_bounds_recursive_metadata() -> None:
+    cyclic: dict[str, object] = {}
+    cyclic["self"] = cyclic
+
+    deeply_nested: object = "safe"
+    for _ in range(40):
+        deeply_nested = {"next": deeply_nested}
+
+    assert redact_sensitive_value(cyclic) == {"self": "[REDACTED]"}
+    assert "[REDACTED]" in str(redact_sensitive_value(deeply_nested))

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -128,6 +128,9 @@ def test_does_not_match_secret_name_embedded_in_letters() -> None:
     [
         '{"error": "unknown field auth:", "user": "bob"}',
         "{'note': 'unknown field auth:', \"user\": 'bob'}",
+        '{"error": "unknown field auth:", "$schema": "safe"}',
+        '{"error": "unknown field auth:", "@type": "safe"}',
+        '{"error": "unknown field auth:", "üser": "safe"}',
     ],
 )
 def test_does_not_consume_adjacent_fields_after_key_like_text(text: str) -> None:

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -37,6 +37,8 @@ def test_redacts_url_queries_authorization_and_secret_pairs() -> None:
         ('{"api_key" : "sk-live-abc123"}', "sk-live-abc123"),
         ('{"refresh_token":"rt-abc.def-123"}', "rt-abc.def-123"),
         ('{"auth":"app-key:pusher-secret"}', "app-key:pusher-secret"),
+        ('{"COMPOSIO_API_KEY":"prefixed-double-secret"}', "prefixed-double-secret"),
+        ("{'OPENAI_API_KEY': 'prefixed single secret'}", "prefixed single secret"),
         ('{"x-api-key":"sk-hdr","user":"bob"}', "sk-hdr"),
         ("{'client_secret': 'cs-live-abc123'}", "cs-live-abc123"),
         ('{"password": "hunter2"}', "hunter2"),

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -1,7 +1,20 @@
 """Tests for telemetry secret redaction."""
 
+from typing import NamedTuple
+
 import pytest
+
 from composio.utils.redaction import redact_sensitive_text, redact_sensitive_value
+
+
+class _RequestContext(NamedTuple):
+    request_id: str
+    api_key: str
+
+
+class _RenderedContext:
+    def __repr__(self) -> str:
+        return "RenderedContext(api_key='object_test_secret')"
 
 
 def test_redacts_url_queries_authorization_and_secret_pairs() -> None:
@@ -101,6 +114,17 @@ def test_does_not_match_secret_name_embedded_in_letters() -> None:
     assert redact_sensitive_text("myapikey=sk_live_9f3c") == "myapikey=sk_live_9f3c"
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        '{"error": "unknown field auth:", "user": "bob"}',
+        "{'note': 'unknown field auth:', \"user\": 'bob'}",
+    ],
+)
+def test_does_not_consume_adjacent_fields_after_key_like_text(text: str) -> None:
+    assert redact_sensitive_text(text) == text
+
+
 def test_structured_redaction_bounds_recursive_metadata() -> None:
     cyclic: dict[str, object] = {}
     cyclic["self"] = cyclic
@@ -111,3 +135,32 @@ def test_structured_redaction_bounds_recursive_metadata() -> None:
 
     assert redact_sensitive_value(cyclic) == {"self": "[REDACTED]"}
     assert "[REDACTED]" in str(redact_sensitive_value(deeply_nested))
+
+
+def test_structured_redaction_handles_sequences_and_rendered_objects() -> None:
+    context = _RequestContext("request-1", "namedtuple_test_secret")
+    redacted = redact_sensitive_value(
+        {
+            "items": [{"access_token": "list_test_secret"}],
+            "tuple": ("Authorization: Bearer bearer_value_secret",),
+            "context": context,
+            "rendered": _RenderedContext(),
+            "binary": b"api_key=binary_test_secret",
+        }
+    )
+
+    assert isinstance(redacted["context"], _RequestContext)
+    assert redacted["context"].request_id == "request-1"
+    rendered = str(redacted)
+    for secret in (
+        "list_test_secret",
+        "bearer_value_secret",
+        "namedtuple_test_secret",
+        "object_test_secret",
+        "binary_test_secret",
+    ):
+        assert secret not in rendered
+
+
+def test_structured_redaction_stops_at_the_node_budget() -> None:
+    assert redact_sensitive_value(list(range(10_001))) == "[REDACTED]"

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -1,5 +1,6 @@
 """Tests for telemetry secret redaction."""
 
+import json
 from typing import NamedTuple
 
 import pytest
@@ -89,6 +90,42 @@ def test_redacts_secret_without_consuming_the_adjacent_field() -> None:
     )
 
 
+def test_redacts_escaped_quoted_secret_in_serialized_message() -> None:
+    source = json.dumps({"error": 'password: "secret"'})
+    expected = json.dumps({"error": 'password: "[REDACTED]"'})
+
+    assert redact_sensitive_text(source) == expected
+    assert redact_sensitive_text("password: \\'secret\\'") == (
+        "password: \\'[REDACTED]\\'"
+    )
+
+    double_encoded = json.dumps({"body": json.dumps({"api_key": "secret"})})
+    double_encoded_expected = json.dumps(
+        {"body": json.dumps({"api_key": "[REDACTED]"})}
+    )
+    assert redact_sensitive_text(double_encoded) == double_encoded_expected
+
+
+def test_preserves_serialized_adjacent_keys_with_escapes() -> None:
+    source = json.dumps(
+        {"error": "unknown field auth:", 'quoted"key': "safe", "path\\key": "safe"}
+    )
+
+    assert redact_sensitive_text(source) == source
+
+
+def test_redacts_unquoted_secrets_containing_backslashes() -> None:
+    assert redact_sensitive_text("password=abc\\def") == "password=[REDACTED]"
+    assert redact_sensitive_text("password=\\leading") == "password=[REDACTED]"
+
+
+def test_redacts_many_quoted_secrets_in_one_pass() -> None:
+    source = " ".join(f'password: "secret-{index}"' for index in range(1_000))
+    expected = " ".join('password: "[REDACTED]"' for _ in range(1_000))
+
+    assert redact_sensitive_text(source) == expected
+
+
 @pytest.mark.parametrize(
     "text",
     [
@@ -131,6 +168,9 @@ def test_does_not_match_secret_name_embedded_in_letters() -> None:
         '{"error": "unknown field auth:", "$schema": "safe"}',
         '{"error": "unknown field auth:", "@type": "safe"}',
         '{"error": "unknown field auth:", "üser": "safe"}',
+        '{"error": "unknown field auth:", ".well-known": "safe"}',
+        '{"error": "unknown field auth:", ":type": "safe"}',
+        '{"error": "unknown field auth:", "?field": "safe"}',
     ],
 )
 def test_does_not_consume_adjacent_fields_after_key_like_text(text: str) -> None:
@@ -144,6 +184,14 @@ def test_does_not_consume_adjacent_fields_after_key_like_text(text: str) -> None
         ("client_secret='period secret'.", "period secret"),
         ('api_key = "prose secret" followed by context', "prose secret"),
         ('password: "escaped \\"secret\\" value"', 'escaped \\"secret\\" value'),
+        ('can\'t connect password: "secret"', "secret"),
+        ('users\' password: "secret"', "secret"),
+        ('Chris\' password: "secret"', "secret"),
+        ('Andrés\' password: "secret"', "secret"),
+        ('{"error":"request failed password: \'secret\'"}', "secret"),
+        ('5" from target password: "secret"', "secret"),
+        ('unmatched " before password: "secret"', "secret"),
+        ("unmatched ' before password: 'secret'", "secret"),
         ('password: "}abc"', "}abc"),
         ('api_key: ",abc"', ",abc"),
     ],

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -125,6 +125,24 @@ def test_does_not_consume_adjacent_fields_after_key_like_text(text: str) -> None
     assert redact_sensitive_text(text) == text
 
 
+@pytest.mark.parametrize(
+    ("text", "secret"),
+    [
+        ('password: "punctuated secret";', "punctuated secret"),
+        ("client_secret='period secret'.", "period secret"),
+        ('api_key = "prose secret" followed by context', "prose secret"),
+        ('password: "escaped \\"secret\\" value"', 'escaped \\"secret\\" value'),
+    ],
+)
+def test_redacts_bare_quoted_values_before_punctuation_or_prose(
+    text: str, secret: str
+) -> None:
+    redacted = redact_sensitive_text(text)
+
+    assert secret not in redacted
+    assert "[REDACTED]" in redacted
+
+
 def test_structured_redaction_bounds_recursive_metadata() -> None:
     cyclic: dict[str, object] = {}
     cyclic["self"] = cyclic
@@ -164,3 +182,8 @@ def test_structured_redaction_handles_sequences_and_rendered_objects() -> None:
 
 def test_structured_redaction_stops_at_the_node_budget() -> None:
     assert redact_sensitive_value(list(range(10_001))) == "[REDACTED]"
+    wide_mapping = redact_sensitive_value(
+        {f"field_{index}": index for index in range(10_001)}
+    )
+    assert isinstance(wide_mapping, dict)
+    assert len(wide_mapping) < 10_001

--- a/python/tests/test_redaction.py
+++ b/python/tests/test_redaction.py
@@ -82,6 +82,13 @@ def test_json_keys_are_preserved() -> None:
     )
 
 
+def test_redacts_secret_without_consuming_the_adjacent_field() -> None:
+    assert (
+        redact_sensitive_text('{"api_key":"secret","user":"bob"}')
+        == '{"api_key":"[REDACTED]","user":"bob"}'
+    )
+
+
 @pytest.mark.parametrize(
     "text",
     [
@@ -134,6 +141,8 @@ def test_does_not_consume_adjacent_fields_after_key_like_text(text: str) -> None
         ("client_secret='period secret'.", "period secret"),
         ('api_key = "prose secret" followed by context', "prose secret"),
         ('password: "escaped \\"secret\\" value"', 'escaped \\"secret\\" value'),
+        ('password: "}abc"', "}abc"),
+        ('api_key: ",abc"', ",abc"),
     ],
 )
 def test_redacts_bare_quoted_values_before_punctuation_or_prose(

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -16,6 +16,7 @@ import { commandHintStep } from 'src/services/command-hints';
 import { runOrgSelection } from 'src/effects/select-org-project';
 import { linkAnalyticsIdentityForOrg } from 'src/effects/link-analytics-identity';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
+import { atomicWritePrivateFileString } from 'src/utils/atomic-write';
 import { primeConsumerConnectedToolkitsCacheInBackground } from 'src/services/consumer-short-term-cache';
 import { inferSkillReleaseChannel, installSkillSafe } from 'src/effects/install-skill';
 import { handleAgentAuthError } from 'src/effects/handle-agent-auth-error';
@@ -131,7 +132,11 @@ const writePendingLoginSession = (session: Omit<PendingLoginSession, 'cachedAt'>
       ...session,
       cachedAt: new Date().toISOString(),
     };
-    yield* fs.writeFileString(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+    yield* atomicWritePrivateFileString({
+      fs,
+      target: filePath,
+      contents: `${JSON.stringify(payload, null, 2)}\n`,
+    });
   });
 
 const clearPendingLoginSession = Effect.gen(function* () {

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -16,7 +16,7 @@ import { commandHintStep } from 'src/services/command-hints';
 import { runOrgSelection } from 'src/effects/select-org-project';
 import { linkAnalyticsIdentityForOrg } from 'src/effects/link-analytics-identity';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
-import { atomicWritePrivateFileString } from 'src/utils/atomic-write';
+import { atomicWritePrivateFileString, ensurePrivateFileMode } from 'src/utils/atomic-write';
 import { primeConsumerConnectedToolkitsCacheInBackground } from 'src/services/consumer-short-term-cache';
 import { inferSkillReleaseChannel, installSkillSafe } from 'src/effects/install-skill';
 import { handleAgentAuthError } from 'src/effects/handle-agent-auth-error';
@@ -156,7 +156,8 @@ const readPendingLoginSession = Effect.gen(function* () {
     });
   }
 
-  const rawSession = yield* fs.readFileString(filePath, 'utf8').pipe(
+  const rawSession = yield* ensurePrivateFileMode({ fs, target: filePath }).pipe(
+    Effect.andThen(fs.readFileString(filePath, 'utf8')),
     Effect.mapError(
       cause =>
         new PendingLoginError({

--- a/ts/packages/cli/src/services/agents.ts
+++ b/ts/packages/cli/src/services/agents.ts
@@ -3,7 +3,7 @@ import { Data, Effect, Either, Option, Predicate, Schema } from 'effect';
 import { APP_CONFIG } from 'src/effects/app-config';
 import { JsonRecordSchema } from 'src/effects/json';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
-import { atomicWritePrivateFileString } from 'src/utils/atomic-write';
+import { atomicWritePrivateFileString, ensurePrivateFileMode } from 'src/utils/atomic-write';
 import { ComposioUserContext } from 'src/services/user-context';
 import { getSessionInfoByUserApiKey } from 'src/services/composio-clients';
 import { primeConsumerConnectedToolkitsCacheInBackground } from 'src/services/consumer-short-term-cache';
@@ -175,7 +175,8 @@ export const readStoredAgentIdentity = Effect.gen(function* () {
   const exists = yield* fs.exists(configPath);
   if (!exists) return Option.none<AgentIdentity>();
 
-  return yield* fs.readFileString(configPath, 'utf8').pipe(
+  return yield* ensurePrivateFileMode({ fs, target: configPath }).pipe(
+    Effect.andThen(fs.readFileString(configPath, 'utf8')),
     Effect.flatMap(Schema.decodeUnknown(Schema.parseJson(AgentIdentity))),
     Effect.map(normalizeDecodedAgentIdentity),
     Effect.tapError(error => Effect.logDebug('Failed to read agent identity:', error)),

--- a/ts/packages/cli/src/services/agents.ts
+++ b/ts/packages/cli/src/services/agents.ts
@@ -3,6 +3,7 @@ import { Data, Effect, Either, Option, Predicate, Schema } from 'effect';
 import { APP_CONFIG } from 'src/effects/app-config';
 import { JsonRecordSchema } from 'src/effects/json';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
+import { atomicWritePrivateFileString } from 'src/utils/atomic-write';
 import { ComposioUserContext } from 'src/services/user-context';
 import { getSessionInfoByUserApiKey } from 'src/services/composio-clients';
 import { primeConsumerConnectedToolkitsCacheInBackground } from 'src/services/consumer-short-term-cache';
@@ -187,7 +188,11 @@ export const writeStoredAgentIdentity = (identity: AgentIdentity) =>
     const fs = yield* FileSystem.FileSystem;
     const configPath = yield* agentConfigPath;
     const normalized = normalizeDecodedAgentIdentity(identity);
-    yield* fs.writeFileString(configPath, `${JSON.stringify(normalized, null, 2)}\n`);
+    yield* atomicWritePrivateFileString({
+      fs,
+      target: configPath,
+      contents: `${JSON.stringify(normalized, null, 2)}\n`,
+    });
     return normalized;
   });
 

--- a/ts/packages/cli/src/services/user-context.ts
+++ b/ts/packages/cli/src/services/user-context.ts
@@ -16,6 +16,8 @@ import { KeyringService, KeyringLiveWithBackend } from '@composio/cli-keyring/ef
 import type { KeyringServiceShape } from '@composio/cli-keyring/effect';
 import { KeyringError, type MacOSBackend } from '@composio/cli-keyring';
 import { ComposioCliUserConfig, ComposioCliUserConfigLive } from 'src/services/cli-user-config';
+import { atomicWritePrivateFileString } from 'src/utils/atomic-write';
+import { redactSensitiveLogValue } from 'src/utils/redact-sensitive';
 
 /**
  * Keyring specifier for the Composio API key. `service` is a reverse
@@ -195,8 +197,12 @@ export const rawComposioUserContextLive = Layer.effect(
           : { ...snapshot, apiKey: Option.none() };
         const encoded = yield* userDataToJSON(onDisk);
         const normalized = yield* normalizeEncodedUserData(encoded, !useLegacyStorage);
-        yield* Effect.logDebug('Saving user data:', normalized);
-        yield* fs.writeFileString(jsonUserConfigPath, normalized);
+        yield* Effect.logDebug('Saving user data:', redactSensitiveLogValue(onDisk));
+        yield* atomicWritePrivateFileString({
+          fs,
+          target: jsonUserConfigPath,
+          contents: normalized,
+        });
       });
 
     const logout = Effect.gen(function* () {
@@ -238,8 +244,15 @@ export const rawComposioUserContextLive = Layer.effect(
           // temporarily writing with the legacy-storage codepath.
           const onDisk = yield* userDataToJSON(next);
           const normalized = yield* normalizeEncodedUserData(onDisk, false);
-          yield* Effect.logDebug('Saving user data (keyring fallback):', normalized);
-          yield* fs.writeFileString(jsonUserConfigPath, normalized);
+          yield* Effect.logDebug(
+            'Saving user data (keyring fallback):',
+            redactSensitiveLogValue(next)
+          );
+          yield* atomicWritePrivateFileString({
+            fs,
+            target: jsonUserConfigPath,
+            contents: normalized,
+          });
         }
       });
 
@@ -248,15 +261,14 @@ export const rawComposioUserContextLive = Layer.effect(
         const nextUserData = { ...userData, ...data } satisfies UserData;
         userData = nextUserData;
         yield* writeJson(nextUserData);
-        yield* Effect.logDebug('User data updated:', userData);
+        yield* Effect.logDebug('User data updated:', redactSensitiveLogValue(userData));
       });
 
     const load = Effect.gen(function* () {
       yield* Effect.logDebug('Loading user data from', jsonUserConfigPath);
       const userDataJson = yield* fs.readFileString(jsonUserConfigPath, 'utf8');
-      yield* Effect.logDebug('User data (raw):', userDataJson);
       const parsedUserData = (yield* userDataFromJSON(userDataJson)) satisfies UserData;
-      yield* Effect.logDebug('User data (parsed):', parsedUserData);
+      yield* Effect.logDebug('User data (parsed):', redactSensitiveLogValue(parsedUserData));
 
       const overriddenUserData = {
         ...userData,
@@ -269,7 +281,10 @@ export const rawComposioUserContextLive = Layer.effect(
         testUserId: parsedUserData.testUserId,
       } satisfies UserData;
 
-      yield* Effect.logDebug('User data (overridden from env vars):', overriddenUserData);
+      yield* Effect.logDebug(
+        'User data (overridden from env vars):',
+        redactSensitiveLogValue(overriddenUserData)
+      );
       userData = overriddenUserData;
       return userData;
     });

--- a/ts/packages/cli/src/services/user-context.ts
+++ b/ts/packages/cli/src/services/user-context.ts
@@ -16,7 +16,7 @@ import { KeyringService, KeyringLiveWithBackend } from '@composio/cli-keyring/ef
 import type { KeyringServiceShape } from '@composio/cli-keyring/effect';
 import { KeyringError, type MacOSBackend } from '@composio/cli-keyring';
 import { ComposioCliUserConfig, ComposioCliUserConfigLive } from 'src/services/cli-user-config';
-import { atomicWritePrivateFileString } from 'src/utils/atomic-write';
+import { atomicWritePrivateFileString, ensurePrivateFileMode } from 'src/utils/atomic-write';
 import { redactSensitiveLogValue } from 'src/utils/redact-sensitive';
 
 /**
@@ -266,6 +266,7 @@ export const rawComposioUserContextLive = Layer.effect(
 
     const load = Effect.gen(function* () {
       yield* Effect.logDebug('Loading user data from', jsonUserConfigPath);
+      yield* ensurePrivateFileMode({ fs, target: jsonUserConfigPath });
       const userDataJson = yield* fs.readFileString(jsonUserConfigPath, 'utf8');
       const parsedUserData = (yield* userDataFromJSON(userDataJson)) satisfies UserData;
       yield* Effect.logDebug('User data (parsed):', redactSensitiveLogValue(parsedUserData));

--- a/ts/packages/cli/src/utils/atomic-write.ts
+++ b/ts/packages/cli/src/utils/atomic-write.ts
@@ -42,7 +42,7 @@ export const atomicWriteFileString = (params: {
       ? Option.map(yield* fs.stat(target).pipe(Effect.option), info => info.mode & 0o7777)
       : Option.none<number>();
     const targetMode = Option.fromNullable(params.mode).pipe(Option.orElse(() => preservedMode));
-    const writeAndPromote = (attempt: number): Effect.Effect<void, PlatformError> =>
+    const stage = (attempt: number): Effect.Effect<string, PlatformError> =>
       Effect.gen(function* () {
         const tmpPath = atomicTmpPath(target);
         const created = yield* Option.match(targetMode, {
@@ -55,7 +55,7 @@ export const atomicWriteFileString = (params: {
             Predicate.isTagged('SystemError')(created.left) &&
             created.left.reason === 'AlreadyExists';
           if (isCollision && attempt < MAX_ATOMIC_WRITE_ATTEMPTS) {
-            return yield* writeAndPromote(attempt + 1);
+            return yield* stage(attempt + 1);
           }
           if (!isCollision) {
             yield* fs.remove(tmpPath, { force: true }).pipe(Effect.ignore);
@@ -63,16 +63,24 @@ export const atomicWriteFileString = (params: {
           return yield* Effect.fail(created.left);
         }
 
-        yield* Effect.gen(function* () {
+        return tmpPath;
+      });
+
+    // Effect keeps acquisition and release uninterruptible. The promotion stays
+    // interruptible, but cancellation cannot occur between staging and the
+    // cleanup responsibility being registered.
+    yield* Effect.acquireUseRelease(
+      stage(1),
+      tmpPath =>
+        Effect.gen(function* () {
           yield* Option.match(targetMode, {
             onNone: () => Effect.void,
             onSome: mode => fs.chmod(tmpPath, mode),
           });
           yield* fs.rename(tmpPath, target);
-        }).pipe(Effect.onError(() => fs.remove(tmpPath, { force: true }).pipe(Effect.ignore)));
-      });
-
-    yield* writeAndPromote(1);
+        }),
+      tmpPath => fs.remove(tmpPath, { force: true }).pipe(Effect.ignore)
+    );
   });
 
 export const atomicWritePrivateFileString = (params: {

--- a/ts/packages/cli/src/utils/atomic-write.ts
+++ b/ts/packages/cli/src/utils/atomic-write.ts
@@ -4,18 +4,21 @@
  *
  * The tmp file lives next to the target so the final rename(2) stays on one
  * filesystem and is atomic: readers observe either the old or the new
- * contents, never a partial write. The tmp name embeds the pid so concurrent
- * CLI processes writing the same target never share (and clobber) one tmp
- * file. On any failure — including a failure of the initial write itself,
+ * contents, never a partial write. The tmp name contains a random UUID and is
+ * created exclusively so concurrent or hostile processes cannot share,
+ * replace, or redirect it. On any failure — including a failure of the initial write itself,
  * e.g. ENOSPC mid-write — the tmp file is removed best-effort before the
  * original error propagates, so no tmp litter is left next to the target.
  */
 
 import type { FileSystem } from '@effect/platform';
 import type { PlatformError } from '@effect/platform/Error';
-import { Effect, Option } from 'effect';
+import { Effect, Either, Option, Predicate } from 'effect';
 
-export const atomicTmpPath = (target: string): string => `${target}.composio-tmp.${process.pid}`;
+const MAX_ATOMIC_WRITE_ATTEMPTS = 5;
+
+export const atomicTmpPath = (target: string): string =>
+  `${target}.composio-tmp.${crypto.randomUUID()}`;
 
 export const atomicWriteFileString = (params: {
   readonly fs: FileSystem.FileSystem;
@@ -39,23 +42,37 @@ export const atomicWriteFileString = (params: {
       ? Option.map(yield* fs.stat(target).pipe(Effect.option), info => info.mode & 0o7777)
       : Option.none<number>();
     const targetMode = Option.fromNullable(params.mode).pipe(Option.orElse(() => preservedMode));
-    const tmpPath = atomicTmpPath(target);
+    const writeAndPromote = (attempt: number): Effect.Effect<void, PlatformError> =>
+      Effect.gen(function* () {
+        const tmpPath = atomicTmpPath(target);
+        const created = yield* Option.match(targetMode, {
+          onNone: () => fs.writeFileString(tmpPath, contents, { flag: 'wx' }),
+          onSome: mode => fs.writeFileString(tmpPath, contents, { flag: 'wx', mode }),
+        }).pipe(Effect.either);
 
-    const writeAndPromote = Effect.gen(function* () {
-      yield* Option.match(targetMode, {
-        onNone: () => fs.writeFileString(tmpPath, contents),
-        onSome: mode => fs.writeFileString(tmpPath, contents, { mode }),
-      });
-      yield* Option.match(targetMode, {
-        onNone: () => Effect.void,
-        onSome: mode => fs.chmod(tmpPath, mode),
-      });
-      yield* fs.rename(tmpPath, target);
-    });
+        if (Either.isLeft(created)) {
+          const isCollision =
+            Predicate.isTagged('SystemError')(created.left) &&
+            created.left.reason === 'AlreadyExists';
+          if (isCollision && attempt < MAX_ATOMIC_WRITE_ATTEMPTS) {
+            return yield* writeAndPromote(attempt + 1);
+          }
+          if (!isCollision) {
+            yield* fs.remove(tmpPath, { force: true }).pipe(Effect.ignore);
+          }
+          return yield* Effect.fail(created.left);
+        }
 
-    yield* writeAndPromote.pipe(
-      Effect.onError(() => fs.remove(tmpPath, { force: true }).pipe(Effect.ignore))
-    );
+        yield* Effect.gen(function* () {
+          yield* Option.match(targetMode, {
+            onNone: () => Effect.void,
+            onSome: mode => fs.chmod(tmpPath, mode),
+          });
+          yield* fs.rename(tmpPath, target);
+        }).pipe(Effect.onError(() => fs.remove(tmpPath, { force: true }).pipe(Effect.ignore)));
+      });
+
+    yield* writeAndPromote(1);
   });
 
 export const atomicWritePrivateFileString = (params: {

--- a/ts/packages/cli/src/utils/atomic-write.ts
+++ b/ts/packages/cli/src/utils/atomic-write.ts
@@ -72,4 +72,26 @@ export const atomicWritePrivateFileString = (params: {
 export const ensurePrivateFileMode = (params: {
   readonly fs: FileSystem.FileSystem;
   readonly target: string;
-}): Effect.Effect<void, PlatformError> => params.fs.chmod(params.target, 0o600);
+}): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const fileInfo = yield* params.fs.stat(params.target).pipe(
+      Effect.tapError(error =>
+        Effect.logWarning(
+          `Could not inspect permissions for credential file at ${params.target}; continuing with the read: ${String(error)}`
+        )
+      ),
+      Effect.option
+    );
+
+    if (Option.isNone(fileInfo) || (fileInfo.value.mode & 0o077) === 0) return;
+
+    yield* params.fs
+      .chmod(params.target, 0o600)
+      .pipe(
+        Effect.catchAll(error =>
+          Effect.logWarning(
+            `Could not tighten permissions for credential file at ${params.target}; continuing with the read: ${String(error)}`
+          )
+        )
+      );
+  });

--- a/ts/packages/cli/src/utils/atomic-write.ts
+++ b/ts/packages/cli/src/utils/atomic-write.ts
@@ -21,6 +21,8 @@ export const atomicWriteFileString = (params: {
   readonly fs: FileSystem.FileSystem;
   readonly target: string;
   readonly contents: string;
+  /** Create the replacement with this exact mode, including over an existing target. */
+  readonly mode?: number;
   /**
    * Preserve an existing target's file mode across the replacement: the tmp
    * copy is created with the target's mode from the start so private contents
@@ -36,14 +38,15 @@ export const atomicWriteFileString = (params: {
     const preservedMode = params.preserveMode
       ? Option.map(yield* fs.stat(target).pipe(Effect.option), info => info.mode & 0o7777)
       : Option.none<number>();
+    const targetMode = Option.fromNullable(params.mode).pipe(Option.orElse(() => preservedMode));
     const tmpPath = atomicTmpPath(target);
 
     const writeAndPromote = Effect.gen(function* () {
-      yield* Option.match(preservedMode, {
+      yield* Option.match(targetMode, {
         onNone: () => fs.writeFileString(tmpPath, contents),
         onSome: mode => fs.writeFileString(tmpPath, contents, { mode }),
       });
-      yield* Option.match(preservedMode, {
+      yield* Option.match(targetMode, {
         onNone: () => Effect.void,
         onSome: mode => fs.chmod(tmpPath, mode),
       });
@@ -54,3 +57,9 @@ export const atomicWriteFileString = (params: {
       Effect.onError(() => fs.remove(tmpPath, { force: true }).pipe(Effect.ignore))
     );
   });
+
+export const atomicWritePrivateFileString = (params: {
+  readonly fs: FileSystem.FileSystem;
+  readonly target: string;
+  readonly contents: string;
+}): Effect.Effect<void, PlatformError> => atomicWriteFileString({ ...params, mode: 0o600 });

--- a/ts/packages/cli/src/utils/atomic-write.ts
+++ b/ts/packages/cli/src/utils/atomic-write.ts
@@ -63,3 +63,13 @@ export const atomicWritePrivateFileString = (params: {
   readonly target: string;
   readonly contents: string;
 }): Effect.Effect<void, PlatformError> => atomicWriteFileString({ ...params, mode: 0o600 });
+
+/**
+ * Tighten a credential-bearing file written by an older CLI before reading it.
+ * This repairs existing files because a write mode only applies when creating
+ * a new file and cannot remove permissions from an existing one.
+ */
+export const ensurePrivateFileMode = (params: {
+  readonly fs: FileSystem.FileSystem;
+  readonly target: string;
+}): Effect.Effect<void, PlatformError> => params.fs.chmod(params.target, 0o600);

--- a/ts/packages/cli/src/utils/redact-sensitive.ts
+++ b/ts/packages/cli/src/utils/redact-sensitive.ts
@@ -1,0 +1,38 @@
+const REDACTED = '[REDACTED]';
+
+const SENSITIVE_KEYS = new Set([
+  'access_token',
+  'api_key',
+  'apikey',
+  'authorization',
+  'client_secret',
+  'composio_agent_key',
+  'password',
+  'refresh_token',
+  'secret',
+  'token',
+  'user_api_key',
+]);
+
+const normalizeKey = (key: string): string =>
+  key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/-/g, '_')
+    .toLowerCase();
+
+const redactStructuredValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(redactStructuredValue);
+  if (value === null || typeof value !== 'object') return value;
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nested]) => [
+      key,
+      SENSITIVE_KEYS.has(normalizeKey(key)) ? REDACTED : redactStructuredValue(nested),
+    ])
+  );
+};
+
+/** Redact credential-shaped fields from structured values before logging. */
+export const redactSensitiveLogValue = (value: unknown): unknown => {
+  return redactStructuredValue(value);
+};

--- a/ts/packages/cli/test/src/commands/agent.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/agent.cmd.test.ts
@@ -133,6 +133,9 @@ describe('CLI: composio agent', () => {
     it.scoped('agent inbox prints only JSON', () =>
       Effect.gen(function* () {
         yield* writeStoredAgentIdentity(agentSignupResponse);
+        const fs = yield* FileSystem.FileSystem;
+        const cacheDir = yield* setupCacheDir;
+        expect((yield* fs.stat(path.join(cacheDir, 'agent.json'))).mode & 0o777).toBe(0o600);
         vi.spyOn(globalThis, 'fetch').mockImplementation(async (requestInput, init) => {
           const url =
             typeof requestInput === 'string'

--- a/ts/packages/cli/test/src/commands/agent.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/agent.cmd.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { afterEach, vi } from 'vitest';
 import * as constants from 'src/constants';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
-import { writeStoredAgentIdentity } from 'src/services/agents';
+import { readStoredAgentIdentity, writeStoredAgentIdentity } from 'src/services/agents';
 import { ComposioUserContext } from 'src/services/user-context';
 import { cli, MockConsole, TestLive } from 'test/__utils__';
 
@@ -29,6 +29,24 @@ describe('CLI: composio agent', () => {
   });
 
   layer(TestLive())(it => {
+    it.scoped('repairs permissions on an existing agent identity before reading it', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const cacheDir = yield* setupCacheDir;
+        const agentConfigPath = path.join(cacheDir, 'agent.json');
+        const encodedIdentity = `${JSON.stringify(agentSignupResponse, null, 2)}\n`;
+        yield* fs.writeFileString(agentConfigPath, encodedIdentity);
+        yield* fs.chmod(agentConfigPath, 0o644);
+        expect((yield* fs.stat(agentConfigPath)).mode & 0o777).toBe(0o644);
+
+        const identity = yield* readStoredAgentIdentity;
+
+        expect(Option.getOrUndefined(identity)?.composio_agent_key).toBe('cak_test_agent');
+        expect(yield* fs.readFileString(agentConfigPath, 'utf8')).toBe(encodedIdentity);
+        expect((yield* fs.stat(agentConfigPath)).mode & 0o777).toBe(0o600);
+      })
+    );
+
     it.scoped('exposes agent signup as a subcommand', () =>
       Effect.gen(function* () {
         yield* cli(['agent', '--help']);

--- a/ts/packages/cli/test/src/commands/login.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/login.cmd.test.ts
@@ -360,6 +360,41 @@ describe('CLI: composio login', () => {
     );
   });
 
+  const stopBeforeSessionPollUI = TerminalUI.of({
+    ...headlessStdinUI,
+    useMakeSpinner: () => Effect.die(new Error('test: stop before session poll')),
+  });
+
+  layer(TestLive({ terminalUI: stopBeforeSessionPollUI }))(it => {
+    it.scoped('repairs permissions on an existing pending login session before reading it', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const cacheDir = yield* setupCacheDir;
+        const pendingPath = path.join(cacheDir, 'pending-login-session.json');
+        const cachedAt = new Date().toISOString();
+        const pendingLogin = `${JSON.stringify(
+          {
+            key: 'legacy-session-id',
+            loginUrl: 'https://dashboard.composio.dev/?cliKey=legacy-session-id',
+            expiresAt: cachedAt,
+            cachedAt,
+          },
+          null,
+          2
+        )}\n`;
+        yield* fs.writeFileString(pendingPath, pendingLogin);
+        yield* fs.chmod(pendingPath, 0o644);
+        expect((yield* fs.stat(pendingPath)).mode & 0o777).toBe(0o644);
+
+        const exit = yield* Effect.exit(cli(['login', '--poll']));
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(yield* fs.readFileString(pendingPath, 'utf8')).toBe(pendingLogin);
+        expect((yield* fs.stat(pendingPath)).mode & 0o777).toBe(0o600);
+      })
+    );
+  });
+
   layer(TestLive())(it => {
     it.scoped('[When] logging in with --user-api-key --org [Then] stores the chosen org', () =>
       Effect.gen(function* () {

--- a/ts/packages/cli/test/src/commands/login.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/login.cmd.test.ts
@@ -163,6 +163,9 @@ describe('CLI: composio login', () => {
         );
         const pendingLogin = JSON.parse(pendingLoginRaw) as Record<string, unknown>;
         expect(pendingLogin.key).toBe('te00st11-d0c4-4efa-8117-c638886063e0');
+        expect(
+          (yield* fs.stat(path.join(cacheDir, 'pending-login-session.json'))).mode & 0o777
+        ).toBe(0o600);
 
         expect(output).not.toContain('-- composio login --');
         expect(output).not.toContain('Please login using the following URL');
@@ -428,6 +431,7 @@ describe('CLI: composio login', () => {
         // `~/.composio/config.json`.
         expect(userConfig.api_key).toBe('uak_direct_key');
         expect(userConfig.org_id).toBe('org_selected');
+        expect((yield* fs.stat(userConfigPath)).mode & 0o777).toBe(0o600);
 
         // ComposioUserContext also exposes the resolved key in-memory
         // for subsequent API calls in this process.

--- a/ts/packages/cli/test/src/services/user-context.test.ts
+++ b/ts/packages/cli/test/src/services/user-context.test.ts
@@ -180,8 +180,11 @@ describe('ComposioUserContext', () => {
           const userDataAsJson = yield* userDataToJSON(expectedUserData);
 
           const fs = yield* FileSystem.FileSystem;
+          const userDataPath = path.join(cwd, '.composio', 'user_data.json');
           yield* fs.makeDirectory(path.join(cwd, '.composio'), { recursive: true });
-          yield* fs.writeFileString(path.join(cwd, '.composio', 'user_data.json'), userDataAsJson);
+          yield* fs.writeFileString(userDataPath, userDataAsJson);
+          yield* fs.chmod(userDataPath, 0o644);
+          assertEquals((yield* fs.stat(userDataPath)).mode & 0o777, 0o644);
 
           const ctx = yield* ComposioUserContext;
           assertEquals(
@@ -193,6 +196,8 @@ describe('ComposioUserContext', () => {
             })
           );
           assertEquals(ctx.isLoggedIn(), true);
+          assertEquals(yield* fs.readFileString(userDataPath, 'utf8'), userDataAsJson);
+          assertEquals((yield* fs.stat(userDataPath)).mode & 0o777, 0o600);
         }).pipe(Effect.provide(ComposioUserContextTest));
       });
     });

--- a/ts/packages/cli/test/src/utils/atomic-write.test.ts
+++ b/ts/packages/cli/test/src/utils/atomic-write.test.ts
@@ -2,7 +2,7 @@ import { FileSystem, Path } from '@effect/platform';
 import * as PlatformError from '@effect/platform/Error';
 import { BunFileSystem, BunPath } from '@effect/platform-bun';
 import { describe, expect, layer } from '@effect/vitest';
-import { Effect, Layer } from 'effect';
+import { Deferred, Effect, Fiber, Layer } from 'effect';
 import { atomicWritePrivateFileString, ensurePrivateFileMode } from 'src/utils/atomic-write';
 
 const TestPlatform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
@@ -28,11 +28,12 @@ const failChmod = (fs: FileSystem.FileSystem, onAttempt: () => void): FileSystem
     },
   });
 
-const collideWithFirstTmpWrite = (
+const collideWithTmpWrites = (
   fs: FileSystem.FileSystem,
+  maxCollisions: number,
   onCollision: (path: string) => void
 ): FileSystem.FileSystem => {
-  let collided = false;
+  let collisions = 0;
 
   return new Proxy(fs, {
     get(target, property, receiver) {
@@ -41,11 +42,11 @@ const collideWithFirstTmpWrite = (
       }
 
       return (path: string, contents: string, options?: FileSystem.WriteFileOptions) => {
-        if (collided || !path.includes('.composio-tmp.')) {
+        if (collisions >= maxCollisions || !path.includes('.composio-tmp.')) {
           return target.writeFileString(path, contents, options);
         }
 
-        collided = true;
+        collisions += 1;
         onCollision(path);
         return target
           .writeFileString(path, 'pre-existing contents')
@@ -54,6 +55,25 @@ const collideWithFirstTmpWrite = (
     },
   });
 };
+
+const delayAfterTmpWrite = (
+  fs: FileSystem.FileSystem,
+  onStaged: Effect.Effect<void>,
+  release: Effect.Effect<void>
+): FileSystem.FileSystem =>
+  new Proxy(fs, {
+    get(target, property, receiver) {
+      if (property !== 'writeFileString') {
+        return Reflect.get(target, property, receiver);
+      }
+
+      return (path: string, contents: string, options?: FileSystem.WriteFileOptions) =>
+        target.writeFileString(path, contents, options).pipe(
+          Effect.tap(() => onStaged),
+          Effect.andThen(release)
+        );
+    },
+  });
 
 describe('atomicWritePrivateFileString', () => {
   layer(TestPlatform)(it => {
@@ -64,7 +84,7 @@ describe('atomicWritePrivateFileString', () => {
         const directory = yield* fs.makeTempDirectoryScoped();
         const target = path.join(directory, 'credentials.json');
         let collisionPath: string | undefined;
-        const collidingFs = collideWithFirstTmpWrite(fs, collidedPath => {
+        const collidingFs = collideWithTmpWrites(fs, 1, collidedPath => {
           collisionPath = collidedPath;
         });
 
@@ -78,6 +98,68 @@ describe('atomicWritePrivateFileString', () => {
         expect(yield* fs.readFileString(collisionPath!, 'utf8')).toBe('pre-existing contents');
         expect(yield* fs.readFileString(target, 'utf8')).toBe('{"api_key":"valid"}\n');
         expect((yield* fs.stat(target)).mode & 0o777).toBe(0o600);
+      })
+    );
+
+    it.scoped('stops after bounded collisions without deleting foreign files', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fs.makeTempDirectoryScoped();
+        const target = path.join(directory, 'credentials.json');
+        const collisionPaths: string[] = [];
+        const collidingFs = collideWithTmpWrites(fs, Number.POSITIVE_INFINITY, collisionPath => {
+          collisionPaths.push(collisionPath);
+        });
+
+        const error = yield* atomicWritePrivateFileString({
+          fs: collidingFs,
+          target,
+          contents: '{"api_key":"valid"}\n',
+        }).pipe(Effect.flip);
+
+        expect(error).toMatchObject({ _tag: 'SystemError', reason: 'AlreadyExists' });
+        expect(collisionPaths).toHaveLength(5);
+        expect(new Set(collisionPaths)).toHaveLength(5);
+        expect(yield* fs.exists(target)).toBe(false);
+        for (const collisionPath of collisionPaths) {
+          expect(yield* fs.readFileString(collisionPath, 'utf8')).toBe('pre-existing contents');
+        }
+      })
+    );
+
+    it.scoped('cleans staging before honoring interruption', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fs.makeTempDirectoryScoped();
+        const target = path.join(directory, 'credentials.json');
+        yield* fs.writeFileString(target, '{"api_key":"old"}\n');
+        yield* fs.chmod(target, 0o600);
+        const staged = yield* Deferred.make<void>();
+        const release = yield* Deferred.make<void>();
+        const delayedFs = delayAfterTmpWrite(
+          fs,
+          Deferred.succeed(staged, undefined),
+          Deferred.await(release)
+        );
+        const fiber = yield* atomicWritePrivateFileString({
+          fs: delayedFs,
+          target,
+          contents: '{"api_key":"valid"}\n',
+        }).pipe(Effect.fork);
+
+        yield* Deferred.await(staged);
+        const interruptFiber = yield* Fiber.interrupt(fiber).pipe(Effect.fork);
+        yield* Effect.yieldNow();
+        yield* Deferred.succeed(release, undefined);
+        yield* Fiber.join(interruptFiber);
+
+        expect(yield* fs.readFileString(target, 'utf8')).toBe('{"api_key":"old"}\n');
+        expect((yield* fs.stat(target)).mode & 0o777).toBe(0o600);
+        expect(
+          (yield* fs.readDirectory(directory)).filter(name => name.includes('.composio-tmp.'))
+        ).toEqual([]);
       })
     );
   });

--- a/ts/packages/cli/test/src/utils/atomic-write.test.ts
+++ b/ts/packages/cli/test/src/utils/atomic-write.test.ts
@@ -3,7 +3,7 @@ import * as PlatformError from '@effect/platform/Error';
 import { BunFileSystem, BunPath } from '@effect/platform-bun';
 import { describe, expect, layer } from '@effect/vitest';
 import { Effect, Layer } from 'effect';
-import { ensurePrivateFileMode } from 'src/utils/atomic-write';
+import { atomicWritePrivateFileString, ensurePrivateFileMode } from 'src/utils/atomic-write';
 
 const TestPlatform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
 
@@ -27,6 +27,61 @@ const failChmod = (fs: FileSystem.FileSystem, onAttempt: () => void): FileSystem
       };
     },
   });
+
+const collideWithFirstTmpWrite = (
+  fs: FileSystem.FileSystem,
+  onCollision: (path: string) => void
+): FileSystem.FileSystem => {
+  let collided = false;
+
+  return new Proxy(fs, {
+    get(target, property, receiver) {
+      if (property !== 'writeFileString') {
+        return Reflect.get(target, property, receiver);
+      }
+
+      return (path: string, contents: string, options?: FileSystem.WriteFileOptions) => {
+        if (collided || !path.includes('.composio-tmp.')) {
+          return target.writeFileString(path, contents, options);
+        }
+
+        collided = true;
+        onCollision(path);
+        return target
+          .writeFileString(path, 'pre-existing contents')
+          .pipe(Effect.andThen(target.writeFileString(path, contents, options)));
+      };
+    },
+  });
+};
+
+describe('atomicWritePrivateFileString', () => {
+  layer(TestPlatform)(it => {
+    it.scoped('retries an exclusive random staging path without touching a collision', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fs.makeTempDirectoryScoped();
+        const target = path.join(directory, 'credentials.json');
+        let collisionPath: string | undefined;
+        const collidingFs = collideWithFirstTmpWrite(fs, collidedPath => {
+          collisionPath = collidedPath;
+        });
+
+        yield* atomicWritePrivateFileString({
+          fs: collidingFs,
+          target,
+          contents: '{"api_key":"valid"}\n',
+        });
+
+        expect(collisionPath).toBeDefined();
+        expect(yield* fs.readFileString(collisionPath!, 'utf8')).toBe('pre-existing contents');
+        expect(yield* fs.readFileString(target, 'utf8')).toBe('{"api_key":"valid"}\n');
+        expect((yield* fs.stat(target)).mode & 0o777).toBe(0o600);
+      })
+    );
+  });
+});
 
 describe('ensurePrivateFileMode', () => {
   layer(TestPlatform)(it => {

--- a/ts/packages/cli/test/src/utils/atomic-write.test.ts
+++ b/ts/packages/cli/test/src/utils/atomic-write.test.ts
@@ -1,0 +1,76 @@
+import { FileSystem, Path } from '@effect/platform';
+import * as PlatformError from '@effect/platform/Error';
+import { BunFileSystem, BunPath } from '@effect/platform-bun';
+import { describe, expect, layer } from '@effect/vitest';
+import { Effect, Layer } from 'effect';
+import { ensurePrivateFileMode } from 'src/utils/atomic-write';
+
+const TestPlatform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+
+const failChmod = (fs: FileSystem.FileSystem, onAttempt: () => void): FileSystem.FileSystem =>
+  new Proxy(fs, {
+    get(target, property, receiver) {
+      if (property !== 'chmod') {
+        return Reflect.get(target, property, receiver);
+      }
+
+      return (path: string) => {
+        onAttempt();
+        return Effect.fail(
+          new PlatformError.SystemError({
+            reason: 'PermissionDenied',
+            module: 'FileSystem',
+            method: 'chmod',
+            pathOrDescriptor: path,
+          })
+        );
+      };
+    },
+  });
+
+describe('ensurePrivateFileMode', () => {
+  layer(TestPlatform)(it => {
+    it.scoped('keeps valid contents readable when chmod fails', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fs.makeTempDirectoryScoped();
+        const target = path.join(directory, 'credentials.json');
+        const contents = '{"api_key":"valid"}\n';
+        yield* fs.writeFileString(target, contents);
+        yield* fs.chmod(target, 0o644);
+
+        let chmodAttempts = 0;
+        const failingFs = failChmod(fs, () => {
+          chmodAttempts += 1;
+        });
+        const readContents = yield* ensurePrivateFileMode({ fs: failingFs, target }).pipe(
+          Effect.andThen(failingFs.readFileString(target, 'utf8'))
+        );
+
+        expect(chmodAttempts).toBe(1);
+        expect(readContents).toBe(contents);
+        expect((yield* fs.stat(target)).mode & 0o777).toBe(0o644);
+      })
+    );
+
+    it.scoped('does not call chmod for an already-private file', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fs.makeTempDirectoryScoped();
+        const target = path.join(directory, 'credentials.json');
+        yield* fs.writeFileString(target, '{"api_key":"valid"}\n');
+        yield* fs.chmod(target, 0o600);
+
+        let chmodAttempts = 0;
+        const failingFs = failChmod(fs, () => {
+          chmodAttempts += 1;
+        });
+        yield* ensurePrivateFileMode({ fs: failingFs, target });
+
+        expect(chmodAttempts).toBe(0);
+      })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/utils/atomic-write.test.ts
+++ b/ts/packages/cli/test/src/utils/atomic-write.test.ts
@@ -75,6 +75,34 @@ const delayAfterTmpWrite = (
     },
   });
 
+const failAfterTmpWrite = (fs: FileSystem.FileSystem): FileSystem.FileSystem =>
+  new Proxy(fs, {
+    get(target, property, receiver) {
+      if (property !== 'writeFileString') {
+        return Reflect.get(target, property, receiver);
+      }
+
+      return (path: string, contents: string, options?: FileSystem.WriteFileOptions) => {
+        if (!path.includes('.composio-tmp.')) {
+          return target.writeFileString(path, contents, options);
+        }
+
+        return target.writeFileString(path, contents, options).pipe(
+          Effect.andThen(
+            Effect.fail(
+              new PlatformError.SystemError({
+                reason: 'PermissionDenied',
+                module: 'FileSystem',
+                method: 'writeFileString',
+                pathOrDescriptor: path,
+              })
+            )
+          )
+        );
+      };
+    },
+  });
+
 describe('atomicWritePrivateFileString', () => {
   layer(TestPlatform)(it => {
     it.scoped('retries an exclusive random staging path without touching a collision', () =>
@@ -157,6 +185,29 @@ describe('atomicWritePrivateFileString', () => {
 
         expect(yield* fs.readFileString(target, 'utf8')).toBe('{"api_key":"old"}\n');
         expect((yield* fs.stat(target)).mode & 0o777).toBe(0o600);
+        expect(
+          (yield* fs.readDirectory(directory)).filter(name => name.includes('.composio-tmp.'))
+        ).toEqual([]);
+      })
+    );
+
+    it.scoped('cleans a partially written staging file on non-collision failure', () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fs.makeTempDirectoryScoped();
+        const target = path.join(directory, 'credentials.json');
+        yield* fs.writeFileString(target, '{"api_key":"old"}\n');
+        yield* fs.chmod(target, 0o600);
+
+        const error = yield* atomicWritePrivateFileString({
+          fs: failAfterTmpWrite(fs),
+          target,
+          contents: '{"api_key":"new"}\n',
+        }).pipe(Effect.flip);
+
+        expect(error).toMatchObject({ _tag: 'SystemError', reason: 'PermissionDenied' });
+        expect(yield* fs.readFileString(target, 'utf8')).toBe('{"api_key":"old"}\n');
         expect(
           (yield* fs.readDirectory(directory)).filter(name => name.includes('.composio-tmp.'))
         ).toEqual([]);

--- a/ts/packages/cli/test/src/utils/credential-hygiene.test.ts
+++ b/ts/packages/cli/test/src/utils/credential-hygiene.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { redactSensitiveLogValue } from 'src/utils/redact-sensitive';
+
+describe('credential hygiene', () => {
+  it('redacts nested credential keys in structured values', () => {
+    const value = {
+      apiKey: 'uak_test_secret',
+      nested: { user_api_key: 'agent_test_secret' },
+      safe: 'visible',
+    };
+
+    const redactedObject = redactSensitiveLogValue(value);
+
+    expect(JSON.stringify(redactedObject)).not.toContain('uak_test_secret');
+    expect(JSON.stringify(redactedObject)).not.toContain('agent_test_secret');
+    expect(JSON.stringify(redactedObject)).toContain('visible');
+  });
+});

--- a/ts/packages/core/src/telemetry/redact.ts
+++ b/ts/packages/core/src/telemetry/redact.ts
@@ -38,17 +38,11 @@ const REDACTION_RULES: ReadonlyArray<readonly [RegExp, string]> = [
     `$1$2$1$3'${REDACTED}'`,
   ],
   [
-    new RegExp(
-      String.raw`${BARE_SECRET_KEY_PREFIX}"(?!\s*(?:,|}|\]|\)|$))(?:\\.|[^"\\\r\n])*"`,
-      'gi'
-    ),
+    new RegExp(String.raw`${BARE_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"(?![A-Za-z0-9_])`, 'gi'),
     `$1$2"${REDACTED}"`,
   ],
   [
-    new RegExp(
-      String.raw`${BARE_SECRET_KEY_PREFIX}'(?!\s*(?:,|}|\]|\)|$))(?:\\.|[^'\\\r\n])*'`,
-      'gi'
-    ),
+    new RegExp(String.raw`${BARE_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'(?![A-Za-z0-9_])`, 'gi'),
     `$1$2'${REDACTED}'`,
   ],
   [new RegExp(String.raw`${SECRET_PAIR_PREFIX}([^\s"',}&]+)`, 'gi'), `$1$2${REDACTED}`],

--- a/ts/packages/core/src/telemetry/redact.ts
+++ b/ts/packages/core/src/telemetry/redact.ts
@@ -14,6 +14,8 @@
 
 const REDACTED = '[REDACTED]';
 const SECRET_KEY_PATTERN = String.raw`authorization|auth|api[-_]?key|apikey|x-api-key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd`;
+const QUOTED_SECRET_KEY_PREFIX = String.raw`(["'])(${SECRET_KEY_PATTERN})\1(\s*[:=]+\s*)`;
+const BARE_SECRET_KEY_PREFIX = String.raw`(?<![A-Za-z0-9"'])(${SECRET_KEY_PATTERN})\b(\s*[:=]+\s*)`;
 const SECRET_PAIR_PREFIX = String.raw`(?<![A-Za-z0-9])(${SECRET_KEY_PATTERN})\b(["']?\s*[:=]+\s*)`;
 
 const REDACTION_RULES: ReadonlyArray<readonly [RegExp, string]> = [
@@ -22,14 +24,32 @@ const REDACTION_RULES: ReadonlyArray<readonly [RegExp, string]> = [
   // Authorization scheme + credential: `Bearer <token>`, `Basic <token>`.
   [/\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+/gi, `$1 ${REDACTED}`],
   // Secret-ish `key: value` / `key=value` / `key: "value"` / `key: 'value'` pairs.
-  // The separator group allows a quote directly after the key name so JSON is
-  // covered: in `{"api_key": "secret"}` the key's own closing quote sits
-  // between the name and the colon. Quoted rules run first so whitespace is
-  // part of the redacted value instead of preventing a match.
+  // Match quoted keys separately so key-like prose cannot treat an enclosing
+  // string's closing quote as the start of a secret value.
   // Leading lookbehind (not \b) so env-style names like COMPOSIO_API_KEY still
   // match: underscore is a word char, so \b can't fire between COMPOSIO_ and API.
-  [new RegExp(String.raw`${SECRET_PAIR_PREFIX}"(?:\\.|[^"\\\r\n])*"`, 'gi'), `$1$2"${REDACTED}"`],
-  [new RegExp(String.raw`${SECRET_PAIR_PREFIX}'(?:\\.|[^'\\\r\n])*'`, 'gi'), `$1$2'${REDACTED}'`],
+  [
+    new RegExp(String.raw`${QUOTED_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"`, 'gi'),
+    `$1$2$1$3"${REDACTED}"`,
+  ],
+  [
+    new RegExp(String.raw`${QUOTED_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'`, 'gi'),
+    `$1$2$1$3'${REDACTED}'`,
+  ],
+  [
+    new RegExp(
+      String.raw`${BARE_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"(?=\s*(?:,|}|\]|\)|$))`,
+      'gi'
+    ),
+    `$1$2"${REDACTED}"`,
+  ],
+  [
+    new RegExp(
+      String.raw`${BARE_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'(?=\s*(?:,|}|\]|\)|$))`,
+      'gi'
+    ),
+    `$1$2'${REDACTED}'`,
+  ],
   [new RegExp(String.raw`${SECRET_PAIR_PREFIX}([^\s"',}&]+)`, 'gi'), `$1$2${REDACTED}`],
 ];
 

--- a/ts/packages/core/src/telemetry/redact.ts
+++ b/ts/packages/core/src/telemetry/redact.ts
@@ -38,14 +38,14 @@ const REDACTION_RULES: ReadonlyArray<readonly [RegExp, string]> = [
   ],
   [
     new RegExp(
-      String.raw`${BARE_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"(?=\s*(?:,|}|\]|\)|$))`,
+      String.raw`${BARE_SECRET_KEY_PREFIX}"(?!\s*(?:,|}|\]|\)|$))(?:\\.|[^"\\\r\n])*"`,
       'gi'
     ),
     `$1$2"${REDACTED}"`,
   ],
   [
     new RegExp(
-      String.raw`${BARE_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'(?=\s*(?:,|}|\]|\)|$))`,
+      String.raw`${BARE_SECRET_KEY_PREFIX}'(?!\s*(?:,|}|\]|\)|$))(?:\\.|[^'\\\r\n])*'`,
       'gi'
     ),
     `$1$2'${REDACTED}'`,

--- a/ts/packages/core/src/telemetry/redact.ts
+++ b/ts/packages/core/src/telemetry/redact.ts
@@ -26,7 +26,7 @@ const REDACTION_RULES: ReadonlyArray<readonly [RegExp, string]> = [
   // Leading lookbehind (not \b) so env-style names like COMPOSIO_API_KEY still
   // match: underscore is a word char, so \b can't fire between COMPOSIO_ and API.
   [
-    /(?<![A-Za-z0-9])(authorization|api[-_]?key|apikey|x-api-key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd)\b(["']?\s*[:=]+\s*)(["']?)([^\s"',}&]+)\3/gi,
+    /(?<![A-Za-z0-9])(authorization|auth|api[-_]?key|apikey|x-api-key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd)\b(["']?\s*[:=]+\s*)(["']?)([^\s"',}&]+)\3/gi,
     `$1$2$3${REDACTED}$3`,
   ],
 ];

--- a/ts/packages/core/src/telemetry/redact.ts
+++ b/ts/packages/core/src/telemetry/redact.ts
@@ -17,7 +17,29 @@ const SECRET_KEY_PATTERN = String.raw`authorization|auth|api[-_]?key|apikey|x-ap
 const SECRET_KEY_WITH_PREFIX_PATTERN = String.raw`(?:[A-Za-z0-9]+_)*(?:${SECRET_KEY_PATTERN})`;
 const QUOTED_SECRET_KEY_PREFIX = String.raw`(["'])(${SECRET_KEY_WITH_PREFIX_PATTERN})\1(\s*[:=]+\s*)`;
 const BARE_SECRET_KEY_PREFIX = String.raw`(?<![A-Za-z0-9"'])(${SECRET_KEY_PATTERN})\b(\s*[:=]+\s*)`;
+const ESCAPED_SECRET_KEY_PREFIX = String.raw`(?<![A-Za-z0-9])(${SECRET_KEY_PATTERN})\b((?:\\["'])?\s*[:=]+\s*)`;
 const SECRET_PAIR_PREFIX = String.raw`(?<![A-Za-z0-9])(${SECRET_KEY_PATTERN})\b(["']?\s*[:=]+\s*)`;
+const BARE_KEY_DOUBLE_QUOTED_VALUE = new RegExp(
+  String.raw`${BARE_SECRET_KEY_PREFIX}"((?:\\.|[^"\\\r\n])*)"`,
+  'gi'
+);
+const BARE_KEY_SINGLE_QUOTED_VALUE = new RegExp(
+  String.raw`${BARE_SECRET_KEY_PREFIX}'((?:\\.|[^'\\\r\n])*)'`,
+  'gi'
+);
+const BARE_KEY_ESCAPED_DOUBLE_QUOTED_VALUE = new RegExp(
+  String.raw`${ESCAPED_SECRET_KEY_PREFIX}\\"((?:\\.|[^"\\\r\n])*)\\"`,
+  'gi'
+);
+const BARE_KEY_ESCAPED_SINGLE_QUOTED_VALUE = new RegExp(
+  String.raw`${ESCAPED_SECRET_KEY_PREFIX}\\'((?:\\.|[^'\\\r\n])*)\\'`,
+  'gi'
+);
+const SECRET_PAIR_UNQUOTED = new RegExp(
+  String.raw`${SECRET_PAIR_PREFIX}(?!\\["'])([^\s"',}&]+)`,
+  'gi'
+);
+const CONTAINS_QUOTED_FIELD = /(?:^|[,{\s])(["'])[^"'\\\r\n]+\1\s*[:=]\s*$/;
 
 const REDACTION_RULES: ReadonlyArray<readonly [RegExp, string]> = [
   // URL query strings — tokens, presigned signatures, one-time codes.
@@ -37,22 +59,100 @@ const REDACTION_RULES: ReadonlyArray<readonly [RegExp, string]> = [
     new RegExp(String.raw`${QUOTED_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'`, 'gi'),
     `$1$2$1$3'${REDACTED}'`,
   ],
-  [
-    new RegExp(
-      String.raw`${BARE_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"(?=\s|[,;.!?:)}\]]|$)`,
-      'gi'
-    ),
-    `$1$2"${REDACTED}"`,
-  ],
-  [
-    new RegExp(
-      String.raw`${BARE_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'(?=\s|[,;.!?:)}\]]|$)`,
-      'gi'
-    ),
-    `$1$2'${REDACTED}'`,
-  ],
-  [new RegExp(String.raw`${SECRET_PAIR_PREFIX}([^\s"',}&]+)`, 'gi'), `$1$2${REDACTED}`],
 ];
+
+const isWordCharacter = (character: string): boolean => /[\p{L}\p{N}_]/u.test(character);
+
+const activeQuotesAt = (
+  input: string,
+  offsets: ReadonlySet<number>
+): ReadonlyMap<number, '"' | "'" | undefined> => {
+  const activeQuotes = new Map<number, '"' | "'" | undefined>();
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+  let lastOffset = -1;
+  for (const offset of offsets) lastOffset = Math.max(lastOffset, offset);
+
+  for (let position = 0; position < input.length; position += 1) {
+    const character = input[position];
+    if (offsets.has(position)) {
+      activeQuotes.set(position, quote);
+      if (position === lastOffset) break;
+    }
+    if (character === '\n' || character === '\r') {
+      quote = undefined;
+      escaped = false;
+      continue;
+    }
+    const previous =
+      position > 0 && !['\n', '\r'].includes(input[position - 1]) ? input[position - 1] : '';
+    const following = input[position + 1] ?? '';
+    if (!quote) {
+      if (character === '"' || (character === "'" && !isWordCharacter(previous))) {
+        quote = character;
+      }
+      continue;
+    }
+    if (escaped) escaped = false;
+    else if (character === '\\') escaped = true;
+    else if (character === quote) {
+      if (quote === "'" && isWordCharacter(previous) && isWordCharacter(following)) continue;
+      quote = undefined;
+    }
+  }
+
+  return activeQuotes;
+};
+
+const completesQuotedFieldAt = (input: string, index: number, quote: '"' | "'"): boolean => {
+  let escaped = false;
+  for (let position = index; position < input.length; position += 1) {
+    const character = input[position];
+    if (character === '\n' || character === '\r') return false;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (character !== quote) continue;
+
+    let separator = position + 1;
+    while (separator < input.length && /\s/.test(input[separator])) separator += 1;
+    return input[separator] === ':' || input[separator] === '=';
+  }
+  return false;
+};
+
+const redactBareQuotedValue = (input: string, pattern: RegExp, quote: '"' | "'"): string => {
+  pattern.lastIndex = 0;
+  const matches = Array.from(input.matchAll(pattern));
+  if (matches.length === 0) return input;
+
+  const activeQuotes = activeQuotesAt(input, new Set(matches.map(match => match.index)));
+  const parts: string[] = [];
+  let cursor = 0;
+
+  for (const match of matches) {
+    const offset = match.index;
+    parts.push(input.slice(cursor, offset));
+    if (
+      activeQuotes.get(offset) === quote &&
+      (completesQuotedFieldAt(input, offset + match[0].length, quote) ||
+        CONTAINS_QUOTED_FIELD.test(match[3]))
+    ) {
+      parts.push(match[0]);
+    } else {
+      parts.push(`${match[1]}${match[2]}${quote}${REDACTED}${quote}`);
+    }
+    cursor = offset + match[0].length;
+  }
+
+  parts.push(input.slice(cursor));
+  return parts.join('');
+};
 
 /**
  * Redact common secret shapes from a free-form string. Returns the input
@@ -64,5 +164,9 @@ export const redactSensitiveText = (input: string | undefined): string | undefin
   for (const [pattern, replacement] of REDACTION_RULES) {
     output = output.replace(pattern, replacement);
   }
-  return output;
+  output = output.replace(BARE_KEY_ESCAPED_DOUBLE_QUOTED_VALUE, `$1$2\\"${REDACTED}\\"`);
+  output = output.replace(BARE_KEY_ESCAPED_SINGLE_QUOTED_VALUE, `$1$2\\'${REDACTED}\\'`);
+  output = redactBareQuotedValue(output, BARE_KEY_DOUBLE_QUOTED_VALUE, '"');
+  output = redactBareQuotedValue(output, BARE_KEY_SINGLE_QUOTED_VALUE, "'");
+  return output.replace(SECRET_PAIR_UNQUOTED, `$1$2${REDACTED}`);
 };

--- a/ts/packages/core/src/telemetry/redact.ts
+++ b/ts/packages/core/src/telemetry/redact.ts
@@ -14,7 +14,8 @@
 
 const REDACTED = '[REDACTED]';
 const SECRET_KEY_PATTERN = String.raw`authorization|auth|api[-_]?key|apikey|x-api-key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd`;
-const QUOTED_SECRET_KEY_PREFIX = String.raw`(["'])(${SECRET_KEY_PATTERN})\1(\s*[:=]+\s*)`;
+const SECRET_KEY_WITH_PREFIX_PATTERN = String.raw`(?:[A-Za-z0-9]+_)*(?:${SECRET_KEY_PATTERN})`;
+const QUOTED_SECRET_KEY_PREFIX = String.raw`(["'])(${SECRET_KEY_WITH_PREFIX_PATTERN})\1(\s*[:=]+\s*)`;
 const BARE_SECRET_KEY_PREFIX = String.raw`(?<![A-Za-z0-9"'])(${SECRET_KEY_PATTERN})\b(\s*[:=]+\s*)`;
 const SECRET_PAIR_PREFIX = String.raw`(?<![A-Za-z0-9])(${SECRET_KEY_PATTERN})\b(["']?\s*[:=]+\s*)`;
 

--- a/ts/packages/core/src/telemetry/redact.ts
+++ b/ts/packages/core/src/telemetry/redact.ts
@@ -13,6 +13,8 @@
  */
 
 const REDACTED = '[REDACTED]';
+const SECRET_KEY_PATTERN = String.raw`authorization|auth|api[-_]?key|apikey|x-api-key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd`;
+const SECRET_PAIR_PREFIX = String.raw`(?<![A-Za-z0-9])(${SECRET_KEY_PATTERN})\b(["']?\s*[:=]+\s*)`;
 
 const REDACTION_RULES: ReadonlyArray<readonly [RegExp, string]> = [
   // URL query strings — tokens, presigned signatures, one-time codes.
@@ -22,13 +24,13 @@ const REDACTION_RULES: ReadonlyArray<readonly [RegExp, string]> = [
   // Secret-ish `key: value` / `key=value` / `key: "value"` / `key: 'value'` pairs.
   // The separator group allows a quote directly after the key name so JSON is
   // covered: in `{"api_key": "secret"}` the key's own closing quote sits
-  // between the name and the colon.
+  // between the name and the colon. Quoted rules run first so whitespace is
+  // part of the redacted value instead of preventing a match.
   // Leading lookbehind (not \b) so env-style names like COMPOSIO_API_KEY still
   // match: underscore is a word char, so \b can't fire between COMPOSIO_ and API.
-  [
-    /(?<![A-Za-z0-9])(authorization|auth|api[-_]?key|apikey|x-api-key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd)\b(["']?\s*[:=]+\s*)(["']?)([^\s"',}&]+)\3/gi,
-    `$1$2$3${REDACTED}$3`,
-  ],
+  [new RegExp(String.raw`${SECRET_PAIR_PREFIX}"(?:\\.|[^"\\\r\n])*"`, 'gi'), `$1$2"${REDACTED}"`],
+  [new RegExp(String.raw`${SECRET_PAIR_PREFIX}'(?:\\.|[^'\\\r\n])*'`, 'gi'), `$1$2'${REDACTED}'`],
+  [new RegExp(String.raw`${SECRET_PAIR_PREFIX}([^\s"',}&]+)`, 'gi'), `$1$2${REDACTED}`],
 ];
 
 /**

--- a/ts/packages/core/src/telemetry/redact.ts
+++ b/ts/packages/core/src/telemetry/redact.ts
@@ -38,11 +38,17 @@ const REDACTION_RULES: ReadonlyArray<readonly [RegExp, string]> = [
     `$1$2$1$3'${REDACTED}'`,
   ],
   [
-    new RegExp(String.raw`${BARE_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"(?![A-Za-z0-9_])`, 'gi'),
+    new RegExp(
+      String.raw`${BARE_SECRET_KEY_PREFIX}"(?:\\.|[^"\\\r\n])*"(?=\s|[,;.!?:)}\]]|$)`,
+      'gi'
+    ),
     `$1$2"${REDACTED}"`,
   ],
   [
-    new RegExp(String.raw`${BARE_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'(?![A-Za-z0-9_])`, 'gi'),
+    new RegExp(
+      String.raw`${BARE_SECRET_KEY_PREFIX}'(?:\\.|[^'\\\r\n])*'(?=\s|[,;.!?:)}\]]|$)`,
+      'gi'
+    ),
     `$1$2'${REDACTED}'`,
   ],
   [new RegExp(String.raw`${SECRET_PAIR_PREFIX}([^\s"',}&]+)`, 'gi'), `$1$2${REDACTED}`],

--- a/ts/packages/core/src/utils/logger.ts
+++ b/ts/packages/core/src/utils/logger.ts
@@ -1,6 +1,6 @@
 import pc from 'picocolors';
-import { getEnvVariable } from './env';
 import { COMPOSIO_LOG_LEVEL } from './constants';
+import { redactSensitiveText } from '../telemetry/redact';
 
 // Define log levels with corresponding priorities
 export const LOG_LEVELS = {
@@ -28,7 +28,7 @@ interface LoggerOptions {
   includeTimestamp?: boolean;
 }
 
-class Logger {
+export class Logger {
   private readonly level: LogLevel;
   private readonly includeTimestamp: boolean;
   private readonly console: Console;
@@ -57,12 +57,12 @@ class Logger {
       })
       .join('\n');
 
-    if (!this.includeTimestamp) {
-      return formattedArgs;
-    }
+    const redactedArgs = redactSensitiveText(formattedArgs) ?? formattedArgs;
+
+    if (!this.includeTimestamp) return redactedArgs;
 
     const timestamp = new Date().toISOString();
-    return `${pc.gray(timestamp)} - ${formattedArgs}`;
+    return `${pc.gray(timestamp)} - ${redactedArgs}`;
   }
 
   private shouldLog(level: LogLevel): boolean {

--- a/ts/packages/core/src/utils/sdk.ts
+++ b/ts/packages/core/src/utils/sdk.ts
@@ -53,7 +53,7 @@ export function getSDKConfig(baseUrl?: string | null, apiKey?: string | null) {
     ComposioError.handleAndThrow(new ComposioNoAPIKeyError());
   }
 
-  logger.debug('Environment', `API Key: ${apiKeyParsed}`);
+  logger.debug('Environment', 'API Key: [REDACTED]');
   logger.debug('Environment', `Base URL: ${baseURLParsed}`);
 
   return { baseURL: baseURLParsed, apiKey: apiKeyParsed };

--- a/ts/packages/core/test/telemetry/redact.test.ts
+++ b/ts/packages/core/test/telemetry/redact.test.ts
@@ -77,6 +77,9 @@ describe('redactSensitiveText', () => {
 
   it('preserves JSON keys and quoting, replacing only the value', () => {
     expect(redactSensitiveText('{"api_key": "ck_live_abc123"}')).toBe('{"api_key": "[REDACTED]"}');
+    expect(redactSensitiveText('{"api_key":"secret","user":"bob"}')).toBe(
+      '{"api_key":"[REDACTED]","user":"bob"}'
+    );
   });
 
   it('leaves a key name with no attached value untouched', () => {
@@ -125,6 +128,8 @@ describe('redactSensitiveText', () => {
       ["client_secret='period secret'.", 'period secret'],
       ['api_key = "prose secret" followed by context', 'prose secret'],
       ['password: "escaped \\"secret\\" value"', 'escaped \\"secret\\" value'],
+      ['password: "}abc"', '}abc'],
+      ['api_key: ",abc"', ',abc'],
     ] as const) {
       const out = redactSensitiveText(sample)!;
       expect(out, sample).toContain('[REDACTED]');

--- a/ts/packages/core/test/telemetry/redact.test.ts
+++ b/ts/packages/core/test/telemetry/redact.test.ts
@@ -117,6 +117,9 @@ describe('redactSensitiveText', () => {
     for (const benign of [
       '{"error": "unknown field auth:", "user": "bob"}',
       `{'note': 'unknown field auth:', "user": 'bob'}`,
+      '{"error": "unknown field auth:", "$schema": "safe"}',
+      '{"error": "unknown field auth:", "@type": "safe"}',
+      '{"error": "unknown field auth:", "üser": "safe"}',
     ]) {
       expect(redactSensitiveText(benign), benign).toBe(benign);
     }

--- a/ts/packages/core/test/telemetry/redact.test.ts
+++ b/ts/packages/core/test/telemetry/redact.test.ts
@@ -107,4 +107,13 @@ describe('redactSensitiveText', () => {
   it('does not match a secret name embedded in letters', () => {
     expect(redactSensitiveText('myapikey=sk_live_9f3c')).toBe('myapikey=sk_live_9f3c');
   });
+
+  it('does not consume adjacent fields after key-like text', () => {
+    for (const benign of [
+      '{"error": "unknown field auth:", "user": "bob"}',
+      `{'note': 'unknown field auth:', "user": 'bob'}`,
+    ]) {
+      expect(redactSensitiveText(benign), benign).toBe(benign);
+    }
+  });
 });

--- a/ts/packages/core/test/telemetry/redact.test.ts
+++ b/ts/packages/core/test/telemetry/redact.test.ts
@@ -55,6 +55,8 @@ describe('redactSensitiveText', () => {
       ['{"x-api-key":"ck_hdr","user":"bob"}', 'ck_hdr'],
       [`{'client_secret': 'cs_live_abc123'}`, 'cs_live_abc123'],
       ['{"password": "hunter2"}', 'hunter2'],
+      ['{"password": "correct horse battery staple"}', 'correct horse battery staple'],
+      [`{'client_secret': 'multi word secret'}`, 'multi word secret'],
     ] as const) {
       const out = redactSensitiveText(sample)!;
       expect(out, sample).toContain('[REDACTED]');

--- a/ts/packages/core/test/telemetry/redact.test.ts
+++ b/ts/packages/core/test/telemetry/redact.test.ts
@@ -116,4 +116,17 @@ describe('redactSensitiveText', () => {
       expect(redactSensitiveText(benign), benign).toBe(benign);
     }
   });
+
+  it('redacts bare quoted values before punctuation or prose', () => {
+    for (const [sample, secret] of [
+      ['password: "punctuated secret";', 'punctuated secret'],
+      ["client_secret='period secret'.", 'period secret'],
+      ['api_key = "prose secret" followed by context', 'prose secret'],
+      ['password: "escaped \\"secret\\" value"', 'escaped \\"secret\\" value'],
+    ] as const) {
+      const out = redactSensitiveText(sample)!;
+      expect(out, sample).toContain('[REDACTED]');
+      expect(out, sample).not.toContain(secret);
+    }
+  });
 });

--- a/ts/packages/core/test/telemetry/redact.test.ts
+++ b/ts/packages/core/test/telemetry/redact.test.ts
@@ -82,6 +82,41 @@ describe('redactSensitiveText', () => {
     );
   });
 
+  it('redacts escaped quoted secrets in serialized messages', () => {
+    const source = JSON.stringify({ error: 'password: "secret"' });
+    const expected = JSON.stringify({ error: 'password: "[REDACTED]"' });
+    expect(redactSensitiveText(source)).toBe(expected);
+    expect(redactSensitiveText("password: \\'secret\\'")).toBe("password: \\'[REDACTED]\\'");
+
+    const doubleEncoded = JSON.stringify({ body: JSON.stringify({ api_key: 'secret' }) });
+    const doubleEncodedExpected = JSON.stringify({
+      body: JSON.stringify({ api_key: '[REDACTED]' }),
+    });
+    expect(redactSensitiveText(doubleEncoded)).toBe(doubleEncodedExpected);
+  });
+
+  it('preserves serialized adjacent keys with escapes', () => {
+    const source = JSON.stringify({
+      error: 'unknown field auth:',
+      'quoted"key': 'safe',
+      'path\\key': 'safe',
+    });
+    expect(redactSensitiveText(source)).toBe(source);
+  });
+
+  it('redacts unquoted secrets containing backslashes', () => {
+    expect(redactSensitiveText('password=abc\\def')).toBe('password=[REDACTED]');
+    expect(redactSensitiveText('password=\\leading')).toBe('password=[REDACTED]');
+  });
+
+  it('redacts many quoted secrets in one pass', () => {
+    const source = Array.from({ length: 1_000 }, (_, index) => `password: "secret-${index}"`).join(
+      ' '
+    );
+    const expected = Array.from({ length: 1_000 }, () => 'password: "[REDACTED]"').join(' ');
+    expect(redactSensitiveText(source)).toBe(expected);
+  });
+
   it('leaves a key name with no attached value untouched', () => {
     for (const benign of [
       'the password field is required',
@@ -120,6 +155,9 @@ describe('redactSensitiveText', () => {
       '{"error": "unknown field auth:", "$schema": "safe"}',
       '{"error": "unknown field auth:", "@type": "safe"}',
       '{"error": "unknown field auth:", "üser": "safe"}',
+      '{"error": "unknown field auth:", ".well-known": "safe"}',
+      '{"error": "unknown field auth:", ":type": "safe"}',
+      '{"error": "unknown field auth:", "?field": "safe"}',
     ]) {
       expect(redactSensitiveText(benign), benign).toBe(benign);
     }
@@ -131,6 +169,14 @@ describe('redactSensitiveText', () => {
       ["client_secret='period secret'.", 'period secret'],
       ['api_key = "prose secret" followed by context', 'prose secret'],
       ['password: "escaped \\"secret\\" value"', 'escaped \\"secret\\" value'],
+      [`can't connect password: "secret"`, 'secret'],
+      [`users' password: "secret"`, 'secret'],
+      [`Chris' password: "secret"`, 'secret'],
+      [`Andrés' password: "secret"`, 'secret'],
+      [`{"error":"request failed password: 'secret'"}`, 'secret'],
+      ['5" from target password: "secret"', 'secret'],
+      ['unmatched " before password: "secret"', 'secret'],
+      ["unmatched ' before password: 'secret'", 'secret'],
       ['password: "}abc"', '}abc'],
       ['api_key: ",abc"', ',abc'],
     ] as const) {

--- a/ts/packages/core/test/telemetry/redact.test.ts
+++ b/ts/packages/core/test/telemetry/redact.test.ts
@@ -52,6 +52,8 @@ describe('redactSensitiveText', () => {
       ['{"api_key" : "ck_live_abc123"}', 'ck_live_abc123'],
       ['{"refresh_token":"rt-abc.def-123"}', 'rt-abc.def-123'],
       ['{"auth":"app_key:pusher_signature"}', 'app_key:pusher_signature'],
+      ['{"COMPOSIO_API_KEY":"prefixed-double-secret"}', 'prefixed-double-secret'],
+      [`{'OPENAI_API_KEY': 'prefixed single secret'}`, 'prefixed single secret'],
       ['{"x-api-key":"ck_hdr","user":"bob"}', 'ck_hdr'],
       [`{'client_secret': 'cs_live_abc123'}`, 'cs_live_abc123'],
       ['{"password": "hunter2"}', 'hunter2'],

--- a/ts/packages/core/test/telemetry/redact.test.ts
+++ b/ts/packages/core/test/telemetry/redact.test.ts
@@ -30,6 +30,7 @@ describe('redactSensitiveText', () => {
       "client_secret: 'topsecret'",
       'password=hunter2',
       'access_token=ya29.a0Afoobar',
+      'auth=app_key:pusher_signature',
     ]) {
       const out = redactSensitiveText(sample)!;
       expect(out, sample).toContain('[REDACTED]');
@@ -50,6 +51,7 @@ describe('redactSensitiveText', () => {
       ['{"api_key":"ck_live_abc123"}', 'ck_live_abc123'],
       ['{"api_key" : "ck_live_abc123"}', 'ck_live_abc123'],
       ['{"refresh_token":"rt-abc.def-123"}', 'rt-abc.def-123'],
+      ['{"auth":"app_key:pusher_signature"}', 'app_key:pusher_signature'],
       ['{"x-api-key":"ck_hdr","user":"bob"}', 'ck_hdr'],
       [`{'client_secret': 'cs_live_abc123'}`, 'cs_live_abc123'],
       ['{"password": "hunter2"}', 'hunter2'],

--- a/ts/packages/core/test/utils/logger.test.ts
+++ b/ts/packages/core/test/utils/logger.test.ts
@@ -11,6 +11,7 @@ describe('Logger credential redaction', () => {
     logger.debug('credentials', {
       apiKey: 'uak_test_secret',
       auth: 'app_key:pusher_signature',
+      password: 'correct horse battery staple',
       nested: { access_token: 'oauth_test_secret' },
       safe: 'visible',
     });
@@ -18,6 +19,7 @@ describe('Logger credential redaction', () => {
     const output = String(debug.mock.calls[0]?.[0]);
     expect(output).not.toContain('uak_test_secret');
     expect(output).not.toContain('pusher_signature');
+    expect(output).not.toContain('correct horse battery staple');
     expect(output).not.toContain('oauth_test_secret');
     expect(output).toContain('[REDACTED]');
     expect(output).toContain('visible');

--- a/ts/packages/core/test/utils/logger.test.ts
+++ b/ts/packages/core/test/utils/logger.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Logger } from '../../src/utils/logger';
+
+describe('Logger credential redaction', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('redacts secret-shaped fields at the output boundary', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+    const logger = new Logger({ level: 'debug', includeTimestamp: false });
+
+    logger.debug('credentials', {
+      apiKey: 'uak_test_secret',
+      nested: { access_token: 'oauth_test_secret' },
+      safe: 'visible',
+    });
+
+    const output = String(debug.mock.calls[0]?.[0]);
+    expect(output).not.toContain('uak_test_secret');
+    expect(output).not.toContain('oauth_test_secret');
+    expect(output).toContain('[REDACTED]');
+    expect(output).toContain('visible');
+  });
+});

--- a/ts/packages/core/test/utils/logger.test.ts
+++ b/ts/packages/core/test/utils/logger.test.ts
@@ -10,12 +10,14 @@ describe('Logger credential redaction', () => {
 
     logger.debug('credentials', {
       apiKey: 'uak_test_secret',
+      auth: 'app_key:pusher_signature',
       nested: { access_token: 'oauth_test_secret' },
       safe: 'visible',
     });
 
     const output = String(debug.mock.calls[0]?.[0]);
     expect(output).not.toContain('uak_test_secret');
+    expect(output).not.toContain('pusher_signature');
     expect(output).not.toContain('oauth_test_secret');
     expect(output).toContain('[REDACTED]');
     expect(output).toContain('visible');


### PR DESCRIPTION
## Summary

- write CLI user data, pending login sessions, and agent identities through one atomic `0600` helper
- repair `0644` credential files created by older CLI versions before reading them
- redact credential-shaped structured values from CLI user-context diagnostics
- redact secret-shaped text at both TypeScript and Python SDK log-output boundaries, including Pusher `auth` responses and exception tracebacks
- preserve Python logger compatibility: errors remain untruncated, disabled levels remain lazy, and malformed placeholders cannot expose arguments

## Local reproduction

Under the normal `022` umask, `next` created a plaintext credential file with mode `0644`. The pre-fix CLI user-context and TypeScript SDK debug paths also emitted sentinel credentials. The private atomic writer changes an existing `0644` target to `0600`, and the upgrade tests now prove all three legacy credential files are tightened without changing their contents.

## Verification

- CLI permission upgrade tests: 31 passed across user data, pending login, and agent identity paths
- CLI source and test typechecks passed
- TypeScript core logging, redaction, and Pusher tests: 17 passed
- TypeScript core source and type-test typechecks passed
- Python logging regression tests: 5 passed
- focused Ruff, Prettier, Oxlint, and `git diff --check` passed

The focused CLI runner needed a temporary local alias for the pre-existing missing `#ssrf_guard` mapping in the CLI Vitest config. The alias was removed after verification and is not part of this PR.

## Contributor context

Credit to **Syed Anas Mohiuddin**, independent security researcher, for reporting the legacy CLI credential-file permission issue.

Supersedes [#4300](https://github.com/ComposioHQ/composio/pull/4300) · [Glen review](https://app.tryglen.com/ComposioHQ/composio/pull/4300). The implementation also covers agent credentials, retains atomic writes, and applies redaction at the shared SDK logging boundary.