### PR TITLE
fix(sdk): map streamed file transport failures

### DIFF
--- a/.changeset/tidy-files-stream-errors.md
+++ b/.changeset/tidy-files-stream-errors.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Map file-download transport failures to the SDK error contract and bound streamed response bodies.

--- a/python/composio/core/models/_files.py
+++ b/python/composio/core/models/_files.py
@@ -456,11 +456,15 @@ def _fetch_file_from_url(
             if chunk:
                 total_bytes += len(chunk)
                 if total_bytes > max_size:
-                    response.close()
                     raise ResponseTooLargeError(
                         f"Response size exceeds maximum allowed size ({max_size} bytes)"
                     )
                 chunks.append(chunk)
+    except requests.exceptions.RequestException as e:
+        raise ErrorUploadingFile(
+            f"Failed to fetch file from URL: {_sanitize_url_for_logging(url)}. "
+            f"Error: {e}"
+        ) from e
     finally:
         response.close()
 

--- a/python/composio/core/models/tool_router_session_files.py
+++ b/python/composio/core/models/tool_router_session_files.py
@@ -99,38 +99,39 @@ def _fetch_url_bytes(url: str) -> t.Tuple[bytes, str]:
     except requests.exceptions.RequestException as e:
         raise _UrlFetchError(cause=e) from e
 
-    if response.status_code in (301, 302, 303, 307, 308):
-        response.close()
-        raise _UrlFetchError(redirected=True)
+    try:
+        if response.status_code in (301, 302, 303, 307, 308):
+            raise _UrlFetchError(redirected=True)
 
-    if not response.ok:
-        response.close()
-        raise _UrlFetchError(
-            status_code=response.status_code, status_text=response.reason
-        )
-
-    content_length = parse_content_length(response.headers.get("Content-Length"))
-    if content_length is not None and content_length > _MAX_RESPONSE_SIZE:
-        response.close()
-        raise _UrlFetchError(
-            size_detail=(
-                f"File size ({content_length} bytes) exceeds maximum allowed "
-                f"size ({_MAX_RESPONSE_SIZE} bytes)"
+        if not response.ok:
+            raise _UrlFetchError(
+                status_code=response.status_code, status_text=response.reason
             )
-        )
 
-    chunks: t.List[bytes] = []
-    total_bytes = 0
-    for chunk in response.iter_content(chunk_size=8192):
-        if chunk:
-            total_bytes += len(chunk)
-            if total_bytes > _MAX_RESPONSE_SIZE:
-                response.close()
-                raise _UrlFetchError(
-                    size_detail="Response size exceeds maximum allowed size"
+        content_length = parse_content_length(response.headers.get("Content-Length"))
+        if content_length is not None and content_length > _MAX_RESPONSE_SIZE:
+            raise _UrlFetchError(
+                size_detail=(
+                    f"File size ({content_length} bytes) exceeds maximum allowed "
+                    f"size ({_MAX_RESPONSE_SIZE} bytes)"
                 )
-            chunks.append(chunk)
-    response.close()
+            )
+
+        chunks: t.List[bytes] = []
+        total_bytes = 0
+        try:
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:
+                    total_bytes += len(chunk)
+                    if total_bytes > _MAX_RESPONSE_SIZE:
+                        raise _UrlFetchError(
+                            size_detail="Response size exceeds maximum allowed size"
+                        )
+                    chunks.append(chunk)
+        except requests.exceptions.RequestException as e:
+            raise _UrlFetchError(cause=e) from e
+    finally:
+        response.close()
 
     mimetype = response.headers.get("content-type", "application/octet-stream")
     mimetype = mimetype.split(";")[0].strip()

--- a/python/tests/test_files.py
+++ b/python/tests/test_files.py
@@ -1907,6 +1907,24 @@ class TestFetchFileFromUrl:
         assert "404" in str(exc_info.value)
 
     @patch("composio.core.models._files.safe_get")
+    def test_fetch_file_from_url_maps_midstream_failure(self, mock_get):
+        def failing_stream(chunk_size=None):
+            yield b"partial"
+            raise requests.exceptions.ConnectionError("peer reset mid-stream")
+
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/plain"}
+        mock_response.iter_content.side_effect = failing_stream
+        mock_get.return_value = mock_response
+
+        with pytest.raises(ErrorUploadingFile, match="peer reset mid-stream"):
+            _fetch_file_from_url("https://example.com/file.txt")
+
+        mock_response.close.assert_called_once()
+
+    @patch("composio.core.models._files.safe_get")
     def test_fetch_file_from_url_decodes_percent_encoded_filename(self, mock_get):
         """Test that percent-encoded characters in URL filenames are decoded."""
         mock_response = MagicMock()

--- a/python/tests/test_tool_router_session_files.py
+++ b/python/tests/test_tool_router_session_files.py
@@ -408,6 +408,38 @@ class TestResponseDerivedUrlsAreGuarded:
                 with pytest.raises(RemoteFileDownloadError, match="exceeds maximum"):
                     rf.buffer()
 
+    def test_buffer_maps_midstream_failure_and_closes_response(self):
+        rf = self._remote_file("https://s3.example.com/download")
+        response = mock_stream_response()
+
+        def failing_stream(chunk_size=None):
+            yield b"partial"
+            raise requests.exceptions.ConnectionError("peer reset mid-stream")
+
+        response.iter_content = failing_stream
+
+        with patch(SAFE_GET, return_value=response):
+            with pytest.raises(RemoteFileDownloadError) as exc_info:
+                rf.buffer()
+
+        assert isinstance(exc_info.value.__cause__, requests.exceptions.ConnectionError)
+        response.close.assert_called_once()
+
+    def test_url_upload_maps_midstream_failure_and_closes_response(self, files_mount):
+        response = mock_stream_response()
+
+        def failing_stream(chunk_size=None):
+            yield b"partial"
+            raise requests.exceptions.ConnectionError("peer reset mid-stream")
+
+        response.iter_content = failing_stream
+
+        with patch(SAFE_GET, return_value=response):
+            with pytest.raises(ValidationError, match="peer reset mid-stream"):
+                files_mount.upload("https://files.example/input.txt")
+
+        response.close.assert_called_once()
+
     def test_text_and_save_inherit_the_guard(self, tmp_path):
         """`text()` and `save()` read through `buffer()`, so they are covered."""
         rf = self._remote_file("http://127.0.0.1:9000/download")

--- a/ts/packages/core/src/models/RemoteFile.ts
+++ b/ts/packages/core/src/models/RemoteFile.ts
@@ -8,7 +8,12 @@ function getParentDir(filePath: string): string {
   return filePath.slice(0, lastSep);
 }
 import { RemoteFileData, RemoteFileDataSchema } from '../types/ToolRouterSessionFilesMount.types';
-import { RemoteFileDownloadError, ValidationError } from '../errors';
+import {
+  ComposioBlockedInternalUrlError,
+  RemoteFileDownloadError,
+  ValidationError,
+} from '../errors';
+import { readResponseBodyWithLimit } from '../utils/readResponseBody';
 
 /**
  * Represents a file stored in a tool router session's file mount.
@@ -77,31 +82,58 @@ export class RemoteFile {
     return platform.basename(this.mountRelativePath);
   }
 
+  private downloadError(message: string, cause: unknown, response?: Response) {
+    return new RemoteFileDownloadError(message, {
+      statusCode: response?.status,
+      statusText: response?.statusText,
+      downloadUrl: this.downloadUrl,
+      mountRelativePath: this.mountRelativePath,
+      filename: this.filename,
+      cause,
+    });
+  }
+
+  private async downloadBytes(): Promise<{ content: Uint8Array; contentType: string }> {
+    let response: Response;
+    try {
+      response = await ssrfSafeFetchWhereSupported(this.downloadUrl);
+    } catch (error) {
+      if (error instanceof ComposioBlockedInternalUrlError) {
+        throw error;
+      }
+      throw this.downloadError('Failed to download file', error);
+    }
+
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
+      throw this.downloadError(
+        `Failed to download file: ${response.status} ${response.statusText}`,
+        new Error(`HTTP ${response.status}: ${response.statusText}`),
+        response
+      );
+    }
+
+    try {
+      const content = response.body
+        ? await readResponseBodyWithLimit(response)
+        : new Uint8Array(await response.arrayBuffer());
+      return {
+        content,
+        contentType: response.headers?.get?.('content-type') ?? '',
+      };
+    } catch (error) {
+      await response.body?.cancel().catch(() => undefined);
+      throw this.downloadError('Failed to read downloaded file', error, response);
+    }
+  }
+
   /**
    * Fetches the file content as a buffer.
    * @returns The file content as a Uint8Array
    * @throws RemoteFileDownloadError if the fetch fails
    */
   async buffer(): Promise<Uint8Array> {
-    // SSRF guard: `downloadUrl` is set from an API response, so it is untrusted
-    // input like every other response field, and its bytes are handed straight
-    // back to the caller. See ssrfGuard.node.ts.
-    const response = await ssrfSafeFetchWhereSupported(this.downloadUrl);
-    if (!response.ok) {
-      throw new RemoteFileDownloadError(
-        `Failed to download file: ${response.status} ${response.statusText}`,
-        {
-          statusCode: response.status,
-          statusText: response.statusText,
-          downloadUrl: this.downloadUrl,
-          mountRelativePath: this.mountRelativePath,
-          filename: this.filename,
-          cause: new Error(`HTTP ${response.status}: ${response.statusText}`),
-        }
-      );
-    }
-    const arrayBuffer = await response.arrayBuffer();
-    return new Uint8Array(arrayBuffer);
+    return (await this.downloadBytes()).content;
   }
 
   /**
@@ -120,22 +152,8 @@ export class RemoteFile {
    * @throws RemoteFileDownloadError if the fetch fails
    */
   async blob(): Promise<Blob> {
-    // SSRF guard: see `buffer()`.
-    const response = await ssrfSafeFetchWhereSupported(this.downloadUrl);
-    if (!response.ok) {
-      throw new RemoteFileDownloadError(
-        `Failed to download file: ${response.status} ${response.statusText}`,
-        {
-          statusCode: response.status,
-          statusText: response.statusText,
-          downloadUrl: this.downloadUrl,
-          mountRelativePath: this.mountRelativePath,
-          filename: this.filename,
-          cause: new Error(`HTTP ${response.status}: ${response.statusText}`),
-        }
-      );
-    }
-    return response.blob();
+    const { content, contentType } = await this.downloadBytes();
+    return new Blob([content as BlobPart], { type: contentType });
   }
 
   /**

--- a/ts/packages/core/test/models/RemoteFile.test.ts
+++ b/ts/packages/core/test/models/RemoteFile.test.ts
@@ -124,6 +124,57 @@ describe('RemoteFile', () => {
         message: expect.stringContaining('404'),
       });
     });
+
+    it('should map a mid-stream transport failure and retain its cause', async () => {
+      const cause = new TypeError('peer reset mid-stream');
+      let pulls = 0;
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response(
+          new ReadableStream({
+            pull(controller) {
+              if (pulls++ === 0) {
+                controller.enqueue(new Uint8Array([1, 2, 3]));
+              } else {
+                controller.error(cause);
+              }
+            },
+          })
+        )
+      );
+
+      const file = new RemoteFile(validCamelCaseData);
+      await expect(file.buffer()).rejects.toMatchObject({
+        name: 'RemoteFileDownloadError',
+        cause,
+      });
+    });
+
+    it('should map a transport failure before response headers arrive', async () => {
+      const cause = new TypeError('connection refused');
+      globalThis.fetch = vi.fn().mockRejectedValue(cause);
+
+      const file = new RemoteFile(validCamelCaseData);
+      await expect(file.buffer()).rejects.toMatchObject({
+        name: 'RemoteFileDownloadError',
+        cause,
+      });
+    });
+
+    it('should reject a declared body larger than the shared download limit', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response('ignored', {
+          headers: { 'content-length': String(101 * 1024 * 1024) },
+        })
+      );
+
+      const file = new RemoteFile(validCamelCaseData);
+      await expect(file.buffer()).rejects.toMatchObject({
+        name: 'RemoteFileDownloadError',
+        cause: expect.objectContaining({
+          message: expect.stringContaining('exceeds maximum allowed size'),
+        }),
+      });
+    });
   });
 
   describe('text', () => {
@@ -143,16 +194,20 @@ describe('RemoteFile', () => {
 
   describe('blob', () => {
     it('should fetch and return file content as Blob', async () => {
-      const blob = new Blob(['data']);
+      const blob = new Blob(['data'], { type: 'text/plain' });
       globalThis.fetch = vi.fn().mockResolvedValue({
         ok: true,
-        blob: () => Promise.resolve(blob),
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-type': blob.type }),
+        body: blob.stream(),
       });
 
       const file = new RemoteFile(validCamelCaseData);
       const result = await file.blob();
 
-      expect(result).toBe(blob);
+      expect(result.type).toBe(blob.type);
+      expect(await result.text()).toBe(await blob.text());
     });
 
     it('should throw RemoteFileDownloadError when fetch fails', async () => {


### PR DESCRIPTION
## Summary

- map Python file-fetch failures that occur after response headers into the documented upload and download errors
- map TypeScript RemoteFile connection and streamed-body failures into RemoteFileDownloadError while preserving blocked-URL errors
- close or cancel response bodies on every exit and apply the shared 100 MiB response limit to TypeScript RemoteFile downloads

This supersedes the Python-only proposal in #4305 and carries the same failure category across both SDKs.

## Independent reproduction

A response double returned one chunk and then raised a connection-reset error. On current next:

- Python _fetch_file_from_url leaked ConnectionError, although it did close the response
- Python Tool Router URL fetch leaked ConnectionError and left the response open
- TypeScript RemoteFile leaked the native fetch/body TypeError instead of RemoteFileDownloadError

## Verification

- Python make chk
- Python make tst: 1,490 passed
- TypeScript core typecheck
- TypeScript core tests: 1,245 passed, 2 expected failures
- TypeScript package build: 19 packages
- focused Python regression tests: 3 passed
- focused TypeScript RemoteFile tests: 17 passed