### PR TITLE
security: fix Parameter finding #91 (CWE-94) - identifier guard in ts-builders codegen

### DIFF
--- a/ts/packages/ts-builders/src/PropertyValue.test.ts
+++ b/ts/packages/ts-builders/src/PropertyValue.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from 'vitest';
+
+import { objectValue } from './ObjectValue';
+import { propertyValue } from './PropertyValue';
+import { stringify } from './stringify';
+import { stringLiteral } from './StringLiteralType';
+import { toStringTag } from './WellKnownSymbol';
+
+test('name and value', () => {
+  const prop = propertyValue('SEND', stringLiteral('SLACK_SEND').asValue());
+
+  expect(stringify(prop)).toMatchInlineSnapshot(`"SEND: "SLACK_SEND""`);
+});
+
+test('well-known symbol', () => {
+  const prop = propertyValue(toStringTag, stringLiteral('x').asValue());
+
+  expect(stringify(prop)).toMatchInlineSnapshot(`"[Symbol.toStringTag]: "x""`);
+});
+
+test('optional', () => {
+  const prop = propertyValue('SEND', stringLiteral('x').asValue()).optional();
+
+  expect(stringify(prop)).toMatchInlineSnapshot(`"SEND?: "x""`);
+});
+
+// A slug reaches this builder as an object-literal key. Written verbatim it can
+// close the key and inject code that runs when the generated SDK is imported.
+// Non-identifier names must become quoted computed keys, as Property already does.
+test('a crafted slug cannot break out of the key position', () => {
+  const malicious = '["k"]: (() => { globalThis.__PWNED__ = 1; })(), ["SEND"]';
+
+  const out = stringify(propertyValue(malicious, stringLiteral('SLACK_SEND').asValue()));
+
+  expect(out).toBe(`[${JSON.stringify(malicious)}]: "SLACK_SEND"`);
+
+  // The payload text survives inside the quoted key; what matters is that
+  // evaluating the generated literal does not execute it.
+  const evaluated = new Function(`return { ${out} };`)() as Record<string, unknown>;
+  expect(Object.keys(evaluated)).toEqual([malicious]);
+  expect((globalThis as Record<string, unknown>).__PWNED__).toBeUndefined();
+});
+
+test('injected slug stays inert inside a generated object literal', () => {
+  const malicious = 'a": 1, "__proto__';
+
+  const out = stringify(
+    objectValue()
+      .add(propertyValue(malicious, stringLiteral('v').asValue()))
+      .formatInline()
+  );
+
+  expect(out).toBe(`{ [${JSON.stringify(malicious)}]: "v" }`);
+});
+
+test('a slug that is not a valid identifier is quoted, not dropped', () => {
+  const out = stringify(propertyValue('123FOO', stringLiteral('T_123FOO').asValue()));
+
+  expect(out).toBe('["123FOO"]: "T_123FOO"');
+});

--- a/ts/packages/ts-builders/src/PropertyValue.ts
+++ b/ts/packages/ts-builders/src/PropertyValue.ts
@@ -1,4 +1,5 @@
 import { DocComment } from './DocComment';
+import { isValidJsIdentifier } from './isValidJsIdentifier';
 import { WellKnownSymbol } from './WellKnownSymbol';
 import { ValueBuilder } from './ValueBuilder';
 import { Writer } from './Writer';
@@ -29,7 +30,11 @@ export class PropertyValue implements BasicBuilder {
     }
 
     if (typeof this.name === 'string') {
-      writer.write(this.name);
+      if (isValidJsIdentifier(this.name)) {
+        writer.write(this.name);
+      } else {
+        writer.write('[').write(JSON.stringify(this.name)).write(']');
+      }
     } else {
       writer.write('[').write(this.name).write(']');
     }

--- a/ts/packages/ts-builders/src/TypeDeclaration.test.ts
+++ b/ts/packages/ts-builders/src/TypeDeclaration.test.ts
@@ -33,3 +33,26 @@ test('with multiple generic parameters', () => {
     .addGenericParameter(genericParameter('U'));
   expect(stringify(decl)).toMatchInlineSnapshot(`"type B<T, U> = A"`);
 });
+
+// A slug reaches this builder as a type-declaration name. Written verbatim it can
+// terminate the declaration and inject top-level statements that run at import.
+// A type name has no computed-key form, so the only safe response is to refuse.
+test('refuses a type name that is not a valid identifier', () => {
+  const malicious = 'X = any;\nconst __pwned = (() => { globalThis.__PWNED__ = 1; })();\ntype Y';
+
+  expect(() => stringify(typeDeclaration(malicious, A))).toThrow(
+    /not a valid TypeScript identifier/
+  );
+});
+
+test('refuses a type name with a dash', () => {
+  expect(() => stringify(typeDeclaration('FOO-BAR', A))).toThrow(
+    /not a valid TypeScript identifier/
+  );
+});
+
+test('a string type body still short-circuits without touching the name', () => {
+  expect(stringify(typeDeclaration('B', 'export type B = A'))).toMatchInlineSnapshot(
+    `"export type B = A"`
+  );
+});

--- a/ts/packages/ts-builders/src/TypeDeclaration.ts
+++ b/ts/packages/ts-builders/src/TypeDeclaration.ts
@@ -1,6 +1,7 @@
 import type { BasicBuilder } from './BasicBuilder';
 import { DocComment } from './DocComment';
 import { GenericParameter } from './GenericParameter';
+import { isValidJsIdentifier } from './isValidJsIdentifier';
 import { TypeBuilder } from './TypeBuilder';
 import { Writer } from './Writer';
 
@@ -40,6 +41,13 @@ export class TypeDeclaration<InnerType extends TypeBuilder = TypeBuilder> implem
     if (typeof this.type === 'string') {
       writer.write(this.type);
       return;
+    }
+
+    // A type name has no quoted form, so a non-identifier cannot be emitted safely.
+    if (!isValidJsIdentifier(this.name)) {
+      throw new TypeError(
+        `Type declaration name is not a valid TypeScript identifier: ${JSON.stringify(this.name)}`
+      );
     }
 
     writer.write('type ').write(this.name);


### PR DESCRIPTION
## What the vulnerability was

The CLI's TypeScript generator wrote API-supplied tool and trigger slugs straight into generated `.ts` files at two places where the slug becomes **code**, not data:

- **object-literal property keys** (`PropertyValue.write`), and
- **type-declaration names** (`TypeDeclaration.write`).

Slugs are unconstrained strings (`ToolAsEnum = Schema.String`, no character allowlist) and the threat model treats API responses as untrusted. So a crafted slug could close the key and inject arbitrary top-level TypeScript, which then executes when the generated SDK is imported or built. That is remote code execution on the developer or CI host running `composio ts generate`.

The sibling `Property` builder already got this right: it tests `isValidJsIdentifier` and falls back to a JSON-encoded computed key. `PropertyValue` and `TypeDeclaration` simply lacked the same guard.

## Why this change addresses it

- `PropertyValue` now applies the exact guard `Property` uses. A name that is not a valid identifier becomes a quoted computed key (`["..."]`), so everything it contains is parsed as a string, never as an expression.
- `TypeDeclaration` refuses a non-identifier name with a `TypeError`. A type name has no quoted or computed form, so quoting is not available and failing loudly is the only safe option. The guard sits after the existing early return for a string type body, which never writes the name.

Output is byte-identical for every name that is already a valid identifier, so no existing generation changes. The CLI codegen snapshots contain only identifier-shaped slugs (`GITHUB_ACCEPT_A_REPOSITORY_INVITATION_INPUT`) and no computed keys, and they are unchanged.

Worth noting on the throw: the two sinks differ in exposure. `typeDeclaration` receives the full `tool.slug` (for example `GITHUB_FOO`), which is identifier-shaped in practice. `propertyValue` receives `stripPrefix(tool.slug)`, which can plausibly start with a digit for real data and now gets safely quoted rather than throwing. Any name that would now throw was already producing syntactically invalid TypeScript, so this converts a confusing downstream compile error into a clear codegen error.

## Tests

**Exploit tests**, not behaviour-pinning. Nine new tests across the two files.

The key one builds the generated object literal from a malicious slug, evaluates it, and asserts the injected IIFE did not run:

```ts
const evaluated = new Function(`return { ${out} };`)() as Record<string, unknown>;
expect(Object.keys(evaluated)).toEqual([malicious]);
expect((globalThis as Record<string, unknown>).__PWNED__).toBeUndefined();
```

Each test was confirmed to fail against the unpatched builders and pass after the change. On the vulnerable code the generator emits `["k"]: (() => { globalThis.__PWNED__ = 1; })(), ["SEND"]: "SLACK_SEND"`, which is the payload as live code.

Existing behaviour is also pinned: valid identifier keys, well-known symbols, optional properties, generic parameters, doc comments, and the string-type-body short circuit.

## What was not verified

- **No end-to-end run of `composio ts generate` against a real or malicious API response.** The fix and its tests are at the builder layer. The call sites in `ts/packages/cli/src/generation/typescript/generate-toolkit-sources.ts` were read to confirm they pass attacker-controlled slugs into these builders, but were not exercised.
- **No model-layer slug validation was added.** The finding also suggests validating slugs against `^[A-Za-z0-9_]+$` at the model layer. That is deliberately out of scope here: it would change what the CLI accepts from the API and belongs in a separate, human-reviewed change. This PR closes the two injection sinks only.
- **The `TypeDeclaration` throw is a new failure mode.** If any live toolkit ships a slug that is not a valid identifier, codegen will now fail loudly for it instead of emitting broken TypeScript. No such slug appears in the repo's fixtures, but the full set of production slugs was not enumerated.
- Python codegen was not reviewed. This finding and fix are TypeScript-only.

## Testing performed

Clean-HEAD baseline captured before any edit: full monorepo `pnpm run test` green, 26/26 turbo tasks, exit 0.

After the change, the same full suite is green, 26/26 tasks, exit 0. `@composio/ts-builders` goes from 131 to 140 tests, all passing. `@composio/cli` unchanged at 1304 passed. 20 example packages validated. No new failures and no snapshot churn.

## Finding

Parameter finding #91 (CWE-94), validated live at `abc8e038218305cab7f3373b82a37144fa15e630`.
Linear: https://linear.app/composio/issue/SEC-579

parameter-finding: kcy19unq784bp2z34b3299w0
