### PR TITLE
fix: change license classifier from Apache-2.0 to MIT in composio-langchain

### DIFF
--- a/python/providers/langchain/pyproject.toml
+++ b/python/providers/langchain/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/python/providers/langchain/setup.py
+++ b/python/providers/langchain/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/ComposioHQ/composio",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10,<4",


### PR DESCRIPTION
## Summary

The LICENSE file is MIT but the `composio-langchain` package classifiers incorrectly declared Apache Software License. This caused issues when packaging for conda-forge (downstream had to pick which one to trust).

## Changes

- `python/providers/langchain/setup.py`: Changed classifier from `"License :: OSI Approved :: Apache Software License"` to `"License :: OSI Approved :: MIT License"`
- `python/providers/langchain/pyproject.toml`: Same change

## Fixes #4261