### PR TITLE
Fix .jpg resolving to non-standard image/jpg instead of image/jpeg

### DIFF
--- a/python/composio/utils/mimetypes.py
+++ b/python/composio/utils/mimetypes.py
@@ -160,7 +160,7 @@ _types = {
     ".jfif-bnl": "image/jpeg",
     ".jpe": "image/jpeg",
     ".jpeg": "image/jpeg",
-    ".jpg": "image/jpg",
+    ".jpg": "image/jpeg",
     ".jps": "image/x-jps",
     ".js": "application/javascript",
     ".json": "application/json",

--- a/python/tests/test_mimetypes.py
+++ b/python/tests/test_mimetypes.py
@@ -24,6 +24,8 @@ class TestGuess:
             ("a.css", "text/css"),
             ("a.js", "application/javascript"),
             ("a.png", "image/png"),
+            ("a.jpg", "image/jpeg"),
+            ("a.jpeg", "image/jpeg"),
             ("a.gif", "image/gif"),
             ("a.mp4", "video/mp4"),
             ("a.zip", "application/zip"),
@@ -32,6 +34,16 @@ class TestGuess:
     def test_known_extensions(self, filename: str, expected: str) -> None:
         """A known extension resolves to its MIME type."""
         assert guess(filename) == expected
+
+    def test_jpg_uses_the_standard_mime_type(self) -> None:
+        """``.jpg`` resolves to the IANA-registered ``image/jpeg``, matching
+        its ``.jpeg``/``.jpe`` siblings and ``mimetypes.guess_type`` in the
+        standard library, rather than the non-standard ``image/jpg``. The
+        reverse ``_MIME_TO_EXT`` map still accepts ``image/jpg`` from servers
+        that send it."""
+        assert guess("a.jpg") == "image/jpeg"
+        assert guess("a.jpeg") == "image/jpeg"
+        assert guess("a.jpe") == "image/jpeg"
 
     def test_extension_lookup_is_case_insensitive(self) -> None:
         """Suffixes are normalized to lower case, matching the sibling


### PR DESCRIPTION
## Problem

`composio.utils.mimetypes.guess()` maps `.jpg` to `"image/jpg"`:

```python
".jpe": "image/jpeg",
".jpeg": "image/jpeg",
".jpg": "image/jpg",   # <- non-standard
```

`image/jpg` is not a registered IANA media type. It is inconsistent with:

- its own sibling extensions `.jpe`, `.jpeg`, and `.jfif-bnl`, which all map to `image/jpeg`
- Python's standard library: `mimetypes.guess_type("x.jpg")` returns `image/jpeg`
- IANA, which registers `image/jpeg`

`guess()` feeds the `Content-Type` used for presigned uploads (`_upload_to_presigned_url`), so `.jpg` files are uploaded and stored with a non-standard content type.

## Fix

Map `.jpg` to `image/jpeg`. One line.

The reverse `_MIME_TO_EXT` map keeps its `"image/jpg": "jpg"` entry on purpose: the SDK should still accept `image/jpg` when a server sends it in a `Content-Type` header (liberal in what it accepts, strict in what it produces).

## Tests

Added coverage in `tests/test_mimetypes.py`: `.jpg`/`.jpeg` in the known-extensions table plus a dedicated test documenting that `.jpg` resolves to `image/jpeg`. Verified the new tests fail on the old value and pass after the fix; the full `test_mimetypes.py` (35 tests) passes.