### PR TITLE
fix(docs): remove unavailable Go SDK setup

### DIFF
--- a/docs/content/examples/harness-integration.mdx
+++ b/docs/content/examples/harness-integration.mdx
@@ -59,19 +59,12 @@ Read [What is a session?](/docs/how-composio-works) instead if you'd rather Comp
 
 You need a [Composio API key](https://dashboard.composio.dev/~/project/settings/api-keys?utm_source=docs&utm_medium=content&utm_campaign=examples-agent-harness) to list the catalog and drive sessions. Listing apps does not need a user id; creating a session and connecting accounts does. There's no model provider in this example: your harness already has one.
 
-<Tabs groupId="language" items={['Python', 'TypeScript', 'Go']} persist>
+<Tabs groupId="language" items={['Python', 'TypeScript']} persist>
 <Tab value="Python">
 <PackageInstall packages="composio" ecosystem="python" />
 </Tab>
 <Tab value="TypeScript">
 <PackageInstall packages="@composio/core" />
-</Tab>
-<Tab value="Go">
-```bash
-go get github.com/ComposioHQ/composio-go
-```
-
-See the [Go SDK usage example](https://github.com/ComposioHQ/composio-go#usage-example).
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
This PR:
- closes #4323
- removes the unsupported Go SDK setup from the harness integration example
- removes the dead `ComposioHQ/composio-go` link that breaks the nightly external-link sweep
- verifies both internal and external docs link validation