### PR TITLE
fix(docs): accept Mercury data refresh events

### DIFF
--- a/.github/workflows/docs-update-data.yml
+++ b/.github/workflows/docs-update-data.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 */5 * * *'
   repository_dispatch:
-    types: [apollo-production-deploy]
+    types: [apollo-production-deploy, mercury-production-deploy]
   workflow_dispatch:
 
 permissions:
@@ -71,13 +71,21 @@ jobs:
       - name: Log trigger source
         env:
           EVENT_NAME: ${{ github.event_name }}
-          HERMES_COMMIT: ${{ github.event.client_payload.hermes_commit }}
+          DISPATCH_ACTION: ${{ github.event.action }}
+          APOLLO_COMMIT: ${{ github.event.client_payload.apollo_commit || github.event.client_payload.hermes_commit }}
+          MERCURY_COMMIT: ${{ github.event.client_payload.mercury_commit }}
           DEPLOY_TIMESTAMP: ${{ github.event.client_payload.timestamp }}
         run: |
           echo "Workflow triggered by: $EVENT_NAME"
           if [ "$EVENT_NAME" = "repository_dispatch" ]; then
-            echo "Triggered by Apollo production deployment"
-            echo "Hermes commit: $HERMES_COMMIT"
+            echo "Repository dispatch action: $DISPATCH_ACTION"
+            if [ "$DISPATCH_ACTION" = "mercury-production-deploy" ]; then
+              echo "Triggered by Mercury production registry sync"
+              echo "Mercury commit: $MERCURY_COMMIT"
+            else
+              echo "Triggered by Apollo production deployment"
+              echo "Apollo commit: $APOLLO_COMMIT"
+            fi
             echo "Timestamp: $DEPLOY_TIMESTAMP"
           fi
 
@@ -159,7 +167,11 @@ jobs:
           title: 'docs: update toolkits, API spec, and meta tools data'
           body: |
             ## Summary
-            Automated sync of backend data into the docs site. Triggered by: `${{ github.event_name }}`${{ github.event_name == 'repository_dispatch' && format(' (Hermes commit: {0})', github.event.client_payload.hermes_commit) || '' }}.
+            Automated sync of backend data into the docs site.
+
+            - Trigger: `${{ github.event_name }}`
+            - Dispatch action: `${{ github.event.action || 'n/a' }}`
+            - Source commit: `${{ github.event.client_payload.mercury_commit || github.event.client_payload.apollo_commit || github.event.client_payload.hermes_commit || 'n/a' }}`
 
             ## What changed
             - **Toolkit catalog** (`docs/public/data/toolkits.json`, `toolkits-list.json`) — refreshed list of available toolkits, auth schemes, and tools from the backend API

--- a/docs/tests/static/docs-data-workflow.test.ts
+++ b/docs/tests/static/docs-data-workflow.test.ts
@@ -21,6 +21,16 @@ const workflowStepSchema = z
 
 const workflowSchema = z
   .object({
+    on: z
+      .object({
+        repository_dispatch: z
+          .object({
+            types: z.array(z.string()),
+          })
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
     jobs: z
       .record(
         z.string(),
@@ -36,11 +46,6 @@ const workflowSchema = z
 
 type WorkflowStep = z.infer<typeof workflowStepSchema>;
 
-function workflowSteps(path: string, job: string): WorkflowStep[] {
-  const workflow = workflowSchema.parse(Bun.YAML.parse(readFileSync(path, 'utf8')));
-  return workflow.jobs?.[job]?.steps ?? [];
-}
-
 function stepNamed(steps: WorkflowStep[], name: string): WorkflowStep {
   const step = steps.find(candidate => candidate.name === name);
   expect(step, `Expected workflow step "${name}"`).toBeDefined();
@@ -48,7 +53,22 @@ function stepNamed(steps: WorkflowStep[], name: string): WorkflowStep {
 }
 
 describe('docs data update workflow', () => {
-  const steps = workflowSteps(workflowPath, 'update-data');
+  const workflow = workflowSchema.parse(Bun.YAML.parse(readFileSync(workflowPath, 'utf8')));
+  const steps = workflow.jobs?.['update-data']?.steps ?? [];
+
+  test('refreshes data after Apollo and Mercury production changes', () => {
+    expect(workflow.on?.repository_dispatch?.types).toEqual([
+      'apollo-production-deploy',
+      'mercury-production-deploy',
+    ]);
+
+    const logTrigger = stepNamed(steps, 'Log trigger source');
+    expect(logTrigger.env?.APOLLO_COMMIT).toContain('client_payload.hermes_commit');
+    expect(logTrigger.env?.MERCURY_COMMIT).toBe(
+      '${{ github.event.client_payload.mercury_commit }}'
+    );
+    expect(logTrigger.run).toContain('Triggered by Mercury production registry sync');
+  });
 
   test('keeps the release-bot token scoped to data sync and PR creation', () => {
     const appToken = stepNamed(steps, 'Generate GitHub App token');


### PR DESCRIPTION
## Summary

- accept `mercury-production-deploy` alongside the Apollo deployment event
- log the correct source commit for Apollo and Mercury dispatches
- preserve compatibility with Apollo’s legacy `hermes_commit` payload
- show the dispatch action and source commit in generated data PRs

## Companion PR

- ComposioHQ/mercury#26701 sends the event after a successful production registry sync.

## Verification

- `bun test tests/static/docs-data-workflow.test.ts` (6 passed)
- `bunx oxlint tests/static/docs-data-workflow.test.ts`
- `bunx prettier --check ../.github/workflows/docs-update-data.yml tests/static/docs-data-workflow.test.ts`
- `actionlint .github/workflows/docs-update-data.yml`
- `bun test tests/static` reached 541 passes. One unrelated analytics test failed because Bun could not bind its ephemeral local server with `EADDRINUSE`; rerunning that test reproduced the same local environment failure.