### PR TITLE
fix(docs): isolate product theme from next-themes storage, switcher link fixes

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -91,7 +91,7 @@ export default async function Layout({ children }: LayoutProps<'/'>) {
             __html: `try{document.documentElement.classList.remove('light','dark');document.documentElement.classList.add('${initialTheme}');document.documentElement.style.colorScheme='${initialTheme}'}catch{}`,
           }}
         />
-        <meta name="theme-color" content={initialTheme === 'dark' ? '#131211' : '#ffffff'} />
+        <meta name="theme-color" content={DOCS_PRODUCTS[initialProduct].themeColor} />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
@@ -131,10 +131,12 @@ export default async function Layout({ children }: LayoutProps<'/'>) {
         <ProductTransitionLoader />
         <Analytics />
         <PostHogProvider>
+          {/* DocsProductProvider owns the rendered theme; useTheme().resolvedTheme is not a product-theme signal. */}
           <RootProvider
             theme={{
               defaultTheme: 'system',
               forcedTheme: initialTheme,
+              storageKey: 'composio-docs-theme',
               attribute: 'class',
               enableSystem: true,
               hotKey: false,

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -88,11 +88,10 @@ export default async function Layout({ children }: LayoutProps<'/'>) {
       <head>
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{localStorage.setItem('theme','${initialTheme}')}catch{}document.documentElement.classList.remove('light','dark');document.documentElement.classList.add('${initialTheme}');document.documentElement.style.colorScheme='${initialTheme}'`,
+            __html: `try{document.documentElement.classList.remove('light','dark');document.documentElement.classList.add('${initialTheme}');document.documentElement.style.colorScheme='${initialTheme}'}catch{}`,
           }}
         />
-        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
-        <meta name="theme-color" content="#131211" media="(prefers-color-scheme: dark)" />
+        <meta name="theme-color" content={initialTheme === 'dark' ? '#131211' : '#ffffff'} />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
@@ -135,6 +134,7 @@ export default async function Layout({ children }: LayoutProps<'/'>) {
           <RootProvider
             theme={{
               defaultTheme: 'system',
+              forcedTheme: initialTheme,
               attribute: 'class',
               enableSystem: true,
               hotKey: false,

--- a/docs/components/docs-product-context.tsx
+++ b/docs/components/docs-product-context.tsx
@@ -12,7 +12,6 @@ import {
 } from 'react';
 import { flushSync } from 'react-dom';
 import { usePathname, useRouter } from 'next/navigation';
-import { useTheme } from 'fumadocs-ui/provider/base';
 import {
   classifyDocsProduct,
   DOCS_PRODUCTS,
@@ -47,6 +46,20 @@ function writeProductCookie(product: DocsProduct): void {
   document.cookie = serializeDocsProductCookie(product);
 }
 
+/**
+ * The product theme is derived state, not a user preference: apply it directly
+ * to the document element instead of routing it through next-themes' shared
+ * `theme` localStorage key, whose cross-tab storage events would repaint other
+ * tabs that are viewing the other product.
+ */
+function applyProductTheme(product: DocsProduct): void {
+  const theme = DOCS_PRODUCTS[product].theme;
+  const root = document.documentElement;
+  root.classList.remove('light', 'dark');
+  root.classList.add(theme);
+  root.style.colorScheme = theme;
+}
+
 export function DocsProductProvider({
   initialProduct,
   children,
@@ -56,7 +69,6 @@ export function DocsProductProvider({
 }) {
   const pathname = usePathname();
   const router = useRouter();
-  const { setTheme } = useTheme();
   const [persistedProduct, setPersistedProduct] = useState(initialProduct);
   const [pendingProduct, setPendingProduct] = useState<DocsProduct | null>(null);
   const pendingNavigation = useRef<{
@@ -68,8 +80,8 @@ export function DocsProductProvider({
   const product = pendingProduct ?? inferredProduct ?? persistedProduct;
 
   useEffect(() => {
-    setTheme(DOCS_PRODUCTS[product].theme);
-  }, [product, setTheme]);
+    applyProductTheme(product);
+  }, [product]);
 
   const persistProduct = useCallback((nextProduct: DocsProduct) => {
     writeProductCookie(nextProduct);
@@ -108,7 +120,7 @@ export function DocsProductProvider({
         flushSync(() => {
           setPersistedProduct(nextProduct);
           setPendingProduct(nextProduct);
-          setTheme(DOCS_PRODUCTS[nextProduct].theme);
+          applyProductTheme(nextProduct);
         });
         if (href !== pathname) router.push(href);
       };
@@ -167,7 +179,7 @@ export function DocsProductProvider({
         commitNavigation();
       }
     },
-    [pathname, router, setTheme],
+    [pathname, router],
   );
 
   const value = useMemo(

--- a/docs/components/docs-product-context.tsx
+++ b/docs/components/docs-product-context.tsx
@@ -53,11 +53,14 @@ function writeProductCookie(product: DocsProduct): void {
  * tabs that are viewing the other product.
  */
 function applyProductTheme(product: DocsProduct): void {
-  const theme = DOCS_PRODUCTS[product].theme;
+  const { theme, themeColor } = DOCS_PRODUCTS[product];
   const root = document.documentElement;
   root.classList.remove('light', 'dark');
   root.classList.add(theme);
   root.style.colorScheme = theme;
+  document
+    .querySelector('meta[name="theme-color"]')
+    ?.setAttribute('content', themeColor);
 }
 
 export function DocsProductProvider({

--- a/docs/components/home-surfaces.tsx
+++ b/docs/components/home-surfaces.tsx
@@ -40,7 +40,6 @@ function IntentCard({ intent }: { intent: HomeIntent }) {
   return (
     <article className="grid overflow-hidden border border-fd-border bg-fd-card shadow-[0_1px_0_rgba(15,15,15,0.04)] md:grid-cols-[minmax(0,1fr)_calc(50%-0.75rem)]">
       <ProductSelectionLink
-        aria-label={`Explore ${intent.product} docs`}
         className="relative overflow-hidden border-b border-fd-border bg-fd-background p-5 pb-40 no-underline transition-colors hover:bg-fd-accent/20 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-fd-ring sm:p-6 sm:pb-44 md:min-h-72 md:border-b-0 md:border-r md:pb-6"
         href={DOCS_PRODUCTS[intent.productId].landingRoute}
         product={intent.productId}

--- a/docs/components/product-switcher.tsx
+++ b/docs/components/product-switcher.tsx
@@ -78,7 +78,9 @@ export function ProductSwitcher({ placement = 'sidebar' }: { placement?: 'nav' |
           {DOCS_PRODUCT_ORDER.map((productId, index) => {
             const option = DOCS_PRODUCTS[productId];
             const isCurrent = productId === product;
-            const destination = docsProductDestination(pathname, productId);
+            const destination = isCurrent
+              ? pathname
+              : docsProductDestination(pathname, productId);
             return (
               <div key={productId}>
                 {index > 0 && <div aria-hidden="true" className="mx-2 my-1 h-px bg-fd-border" />}

--- a/docs/lib/home-navigation.ts
+++ b/docs/lib/home-navigation.ts
@@ -30,6 +30,7 @@ interface DocsProductConfig {
   switcherDescription: string;
   landingRoute: string;
   theme: 'light' | 'dark';
+  themeColor: '#131211' | '#ffffff';
   routePrefixes: readonly string[];
   sidebar: readonly ProductSidebarGroup[];
   home: Omit<HomeIntent, 'productId' | 'product'>;
@@ -61,6 +62,7 @@ export const DOCS_PRODUCTS = {
     switcherDescription: 'Connect your apps to AI clients.',
     landingRoute: '/docs/agent-plugins',
     theme: 'light',
+    themeColor: '#ffffff',
     routePrefixes: [
       '/docs/agent-plugins',
       '/docs/claude-code-plugin',
@@ -107,6 +109,7 @@ export const DOCS_PRODUCTS = {
     switcherDescription: 'Build agents with the Composio SDK.',
     landingRoute: '/docs/quickstart',
     theme: 'dark',
+    themeColor: '#131211',
     routePrefixes: [
       '/docs/quickstart',
       '/docs/providers',

--- a/docs/tests/static/product-navigation.test.ts
+++ b/docs/tests/static/product-navigation.test.ts
@@ -162,9 +162,10 @@ describe('Docs product navigation', () => {
     expect(switcherSource).toContain('href="/"');
     expect(sharedLayoutSource).toContain('slots: { navTitle: ProductNavTitle }');
     expect(sharedLayoutSource).toContain('themeSwitch: { enabled: false }');
-    expect(contextSource).toContain('setTheme(DOCS_PRODUCTS[product].theme)');
+    expect(contextSource).toContain('applyProductTheme(product)');
     expect(contextSource).toContain('window.setTimeout(finish, 1500)');
-    expect(rootLayoutSource).toContain("localStorage.setItem('theme','${initialTheme}')");
+    expect(rootLayoutSource).toContain('forcedTheme: initialTheme');
+    expect(rootLayoutSource).not.toContain("localStorage.setItem('theme'");
     expect(rootLayoutSource).toContain('hotKey: false');
   });
 });

--- a/docs/tests/static/product-navigation.test.ts
+++ b/docs/tests/static/product-navigation.test.ts
@@ -21,12 +21,14 @@ describe('Docs product navigation', () => {
       switcherDescription: 'Connect your apps to AI clients.',
       landingRoute: '/docs/agent-plugins',
       theme: 'light',
+      themeColor: '#ffffff',
     });
     expect(DOCS_PRODUCTS.platform).toMatchObject({
       product: 'Platform',
       switcherDescription: 'Build agents with the Composio SDK.',
       landingRoute: '/docs/quickstart',
       theme: 'dark',
+      themeColor: '#131211',
     });
   });
 
@@ -163,8 +165,15 @@ describe('Docs product navigation', () => {
     expect(sharedLayoutSource).toContain('slots: { navTitle: ProductNavTitle }');
     expect(sharedLayoutSource).toContain('themeSwitch: { enabled: false }');
     expect(contextSource).toContain('applyProductTheme(product)');
+    expect(contextSource).toContain('.querySelector(\'meta[name="theme-color"]\')');
+    expect(contextSource).toContain("?.setAttribute('content', themeColor)");
     expect(contextSource).toContain('window.setTimeout(finish, 1500)');
     expect(rootLayoutSource).toContain('forcedTheme: initialTheme');
+    expect(rootLayoutSource).toContain("storageKey: 'composio-docs-theme'");
+    expect(rootLayoutSource).toContain(
+      'content={DOCS_PRODUCTS[initialProduct].themeColor}',
+    );
+    expect(contextSource).not.toContain("localStorage.setItem('theme'");
     expect(rootLayoutSource).not.toContain("localStorage.setItem('theme'");
     expect(rootLayoutSource).toContain('hotKey: false');
   });


### PR DESCRIPTION
## Summary

Applies the top findings from a multi-reviewer code review of #4335 (which merged before these could land on the PR branch). Four validated findings, all small and behavior-preserving outside the fixes themselves:

- **Cross-tab theme fight (P1):** #4335 routed the product-derived theme through next-themes' shared `theme` localStorage key -- written by the root layout's inline head script on every hard load and by `setTheme` on every client switch. next-themes listens for cross-tab storage events on that key, so two docs tabs on different products (Platform dark / For You light) silently repaint each other with no self-heal (the provider effect's deps are `[product, setTheme]`, so the flipped tab never corrects). The product theme is derived state, not a preference: this PR applies it directly to the document element (`applyProductTheme`) and passes `forcedTheme: initialTheme` from the server-resolved product so hydration cannot flip a stale stored value. No `theme` localStorage writes remain anywhere.
- **theme-color meta (P2):** the two `prefers-color-scheme`-keyed metas meant mobile browser chrome mismatched the forced page theme (white chrome over dark Platform pages for light-OS users). Now a single meta keyed to the product theme.
- **Switcher current-option href (P2):** the popover option marked `aria-current="page"` resolved to the product landing route, so middle-click, hover status bar, and copy-link all pointed at the wrong URL. It now hrefs the current pathname.
- **Explore-card aria-label (P3):** `aria-label` replaced the link's accessible name, so the product description inside the card was not announced. Dropped; heading + description now form the name.

## Changes

- `docs/app/layout.tsx` -- inline script no longer writes localStorage (pre-paint class priming unchanged); single product-keyed `theme-color` meta; `forcedTheme: initialTheme` on `RootProvider`.
- `docs/components/docs-product-context.tsx` -- `setTheme`/`useTheme` removed; new `applyProductTheme` used in the product effect and the flushSync commit.
- `docs/components/product-switcher.tsx` -- `destination = isCurrent ? pathname : docsProductDestination(...)`.
- `docs/components/home-surfaces.tsx` -- Explore-card `aria-label` removed.
- `docs/tests/static/product-navigation.test.ts` -- pins the new invariants (`applyProductTheme`, `forcedTheme: initialTheme`, and a negative assertion that `localStorage.setItem('theme'` stays out).

## Testing

- `bun test tests/static/` -- 541 pass / 0 fail
- `bun run types:check` -- clean
- `bun run lint` -- only pre-existing warnings (`home-surfaces.tsx:102` `no-img-element` is in `ForYouVisual`, untouched)
- Worth a manual check: two tabs on different products no longer repaint each other (static tests cannot prove cross-tab storage isolation)

## Notes

- Docs-only change; no changeset required.
- Review context: follow-up to #4335. Remaining review findings (navigation state-machine races, theme-scope design call, decision record) are tracked separately.
