### PR TITLE
docs: clarify LinkedIn toolkit version override

### DIFF
--- a/docs/content/kb/guide/toolkits-linkedin.mdx
+++ b/docs/content/kb/guide/toolkits-linkedin.mdx
@@ -14,6 +14,29 @@ aliases: ["/kb/toolkits/linkedin-troubleshooting","fetch-modern-linkedin-tools-w
 
 LinkedIn 426 `NONEXISTENT_VERSION` errors usually mean the request is using an older LinkedIn API version header. In Composio, this often happens when calls run on the base toolkit version `00000000_00` or another older pinned version. Specify the latest LinkedIn toolkit version on tool calls, or pin to the current fixed version if needed. If the error persists after switching to the latest version, contact Composio support with a failed call `logId` or request ID so the actual `LinkedIn-Version` header can be verified.
 
+## Execute LinkedIn tools with the latest toolkit version over REST
+
+Direct REST execution can select the current LinkedIn toolkit version by adding `"version": "latest"` to the request body. For example:
+
+```text
+POST https://backend.composio.dev/api/v3/tools/execute/LINKEDIN_CREATE_LINKED_IN_POST
+{
+  "user_id": "<user-id>",
+  "connected_account_id": "<connected-account-id>",
+  "version": "latest",
+  "arguments": {
+    "author": "urn:li:person:<person-id>",
+    "commentary": "Hello from Composio",
+    "lifecycleState": "PUBLISHED",
+    "visibility": "CONNECTIONS"
+  }
+}
+```
+
+Alternatively, use the `/api/v3.1/tools/execute/` endpoint, which defaults to the latest toolkit version.
+
+Do not pin `20241101` or another retired version. If the latest version still produces 426, collect the failed call `logId` or request ID so the resolved toolkit version and outgoing `LinkedIn-Version` header can be checked.
+
 ## Fetch modern LinkedIn tools with `toolkit_slug=linkedin` and `toolkit_versions=latest`
 
 The v3 tools-list endpoint defaults to the base toolkit version when no toolkit version is specified, which can return only legacy LinkedIn slugs. Use the singular filter `toolkit_slug=linkedin`; plural or alternate filters such as `toolkit_slugs`, `toolkits`, `app`, or `app_names` may be ignored. Add `toolkit_versions=latest`. Example: `GET /api/v3/tools?toolkit_slug=linkedin&toolkit_versions=latest&limit=100`.

--- a/docs/kb/articles/toolkits-linkedin.md
+++ b/docs/kb/articles/toolkits-linkedin.md
@@ -2,6 +2,29 @@
 
 LinkedIn 426 `NONEXISTENT_VERSION` errors usually mean the request is using an older LinkedIn API version header. In Composio, this often happens when calls run on the base toolkit version `00000000_00` or another older pinned version. Specify the latest LinkedIn toolkit version on tool calls, or pin to the current fixed version if needed. If the error persists after switching to the latest version, contact Composio support with a failed call `logId` or request ID so the actual `LinkedIn-Version` header can be verified.
 
+## Execute LinkedIn tools with the latest toolkit version over REST
+
+Direct REST execution can select the current LinkedIn toolkit version by adding `"version": "latest"` to the request body. For example:
+
+```text
+POST https://backend.composio.dev/api/v3/tools/execute/LINKEDIN_CREATE_LINKED_IN_POST
+{
+  "user_id": "<user-id>",
+  "connected_account_id": "<connected-account-id>",
+  "version": "latest",
+  "arguments": {
+    "author": "urn:li:person:<person-id>",
+    "commentary": "Hello from Composio",
+    "lifecycleState": "PUBLISHED",
+    "visibility": "CONNECTIONS"
+  }
+}
+```
+
+Alternatively, use the `/api/v3.1/tools/execute/` endpoint, which defaults to the latest toolkit version.
+
+Do not pin `20241101` or another retired version. If the latest version still produces 426, collect the failed call `logId` or request ID so the resolved toolkit version and outgoing `LinkedIn-Version` header can be checked.
+
 ## Fetch modern LinkedIn tools with `toolkit_slug=linkedin` and `toolkit_versions=latest`
 
 The v3 tools-list endpoint defaults to the base toolkit version when no toolkit version is specified, which can return only legacy LinkedIn slugs. Use the singular filter `toolkit_slug=linkedin`; plural or alternate filters such as `toolkit_slugs`, `toolkits`, `app`, or `app_names` may be ignored. Add `toolkit_versions=latest`. Example: `GET /api/v3/tools?toolkit_slug=linkedin&toolkit_versions=latest&limit=100`.

--- a/docs/tests/static/linkedin-version-guidance.test.ts
+++ b/docs/tests/static/linkedin-version-guidance.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const documents = [
+  readFileSync(join(process.cwd(), 'kb/articles/toolkits-linkedin.md'), 'utf8'),
+  readFileSync(join(process.cwd(), 'content/kb/guide/toolkits-linkedin.mdx'), 'utf8'),
+];
+
+describe('LinkedIn version troubleshooting', () => {
+  test('documents the REST execute override for retired LinkedIn API versions', () => {
+    for (const document of documents) {
+      expect(document).toContain('POST https://backend.composio.dev/api/v3/tools/execute/');
+      expect(document).toContain('"version": "latest"');
+      expect(document).toContain('/api/v3.1/tools/execute/');
+      expect(document).toContain('426 `NONEXISTENT_VERSION`');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

LinkedIn post execution can resolve the retired base toolkit version and return 426 `NONEXISTENT_VERSION`. Document the supported REST version-selection paths for this request.

Fixes #4320

## Changes
- Document the top-level `version: latest` override for v3 REST execution.
- Document the v3.1 execution endpoint and keep both LinkedIn knowledge-base copies aligned.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
Focused static tests passed for the new LinkedIn guidance and the existing execute-version assertions.

## Screenshots (if applicable)

## Checklist
- [ ] I have read the Code of Conduct and this PR adheres to it
- [ ] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [ ] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages

## Additional context

Suggested reviewers: Brendan O'Leary, Alberto Schiabel, Soham Basu.