### PR TITLE
docs: clarify Auth Config and session tool restrictions

### DIFF
--- a/docs/content/kb/guide/platform-session-tool-policies.mdx
+++ b/docs/content/kb/guide/platform-session-tool-policies.mdx
@@ -74,6 +74,12 @@ const session = await composio.create("user_123", {
 
 - [Enable and disable specific tools](https://docs.composio.dev/docs/configuring-sessions#enabling-or-disabling-specific-tools)
 
+An Auth Config's tool access allowlist applies when tools are listed through
+that Auth Config's tools API and on the older MCP path. It does not restrict
+tool discovery or execution in a Tool Router session. To restrict a session,
+configure its session-level tools or toolkit settings when creating the
+session; those restrictions apply to both discovery and execution.
+
 ## Combine provider scopes with session tool restrictions
 
 OAuth scopes control what the provider grants to a connected account. Session

--- a/docs/kb/source/platform/session-tool-policies/public.md
+++ b/docs/kb/source/platform/session-tool-policies/public.md
@@ -79,6 +79,12 @@ const session = await composio.create("user_123", {
 
 - [Enable and disable specific tools](https://docs.composio.dev/docs/configuring-sessions#enabling-or-disabling-specific-tools)
 
+An Auth Config's tool access allowlist applies when tools are listed through
+that Auth Config's tools API and on the older MCP path. It does not restrict
+tool discovery or execution in a Tool Router session. To restrict a session,
+configure its session-level tools or toolkit settings when creating the
+session; those restrictions apply to both discovery and execution.
+
 ## Combine provider scopes with session tool restrictions
 
 OAuth scopes control what the provider grants to a connected account. Session


### PR DESCRIPTION
## Summary

This clarifies that Auth Config tool access allowlists apply to the tools API and older MCP path, while Tool Router discovery and execution use session-level tools or toolkit settings.

Fixes #3542

## Changes
- Clarify the scope of Auth Config tool access allowlists.
- Document the session-level restriction used for Tool Router discovery and execution.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
- `bun test tests/static/session-execution.test.ts`
- `git diff --check`

## Screenshots (if applicable)

## Checklist
- [ ] I have read the Code of Conduct and this PR adheres to it
- [ ] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [ ] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages

## Reviewers
- Alberto Schiabel (@jkomyno)
- Adesh Deshmukh (@AdeshDeshmukh)

## Additional context
Documentation-only change; no changeset is required.