### PR TITLE
fix(py): keep local results when remote multi-execute transport fails

### DIFF
--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -487,10 +487,17 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
             for idx, future in local_futures:
                 local_results.append((idx, future.result()))
 
-            # Gather remote result
+            # Gather remote result. A transport failure (exception from the
+            # backend call) must not discard completed local results, so it
+            # is captured here and surfaced as per-tool failures below
+            # (matches TS).
             remote_result: t.Optional[t.Dict[str, t.Any]] = None
+            remote_error_message: t.Optional[str] = None
             if remote_future:
-                remote_result = remote_future.result()
+                try:
+                    remote_result = remote_future.result()
+                except Exception as error:
+                    remote_error_message = str(error) or "Remote tool execution failed"
 
         # If only one local tool and no remote, return unwrapped
         if not remote_indices and len(local_results) == 1:
@@ -515,11 +522,26 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         # Restore original request order, then re-index sequentially.
         remote_data_raw = (remote_result or {}).get("data")
         remote_data = remote_data_raw if isinstance(remote_data_raw, dict) else {}
-        remote_results_list = (
-            remote_data.get("results", [])
-            if isinstance(remote_data.get("results"), list)
-            else []
-        )
+        remote_results_list: t.List[t.Dict[str, t.Any]]
+        if remote_error_message is not None:
+            remote_results_list = [
+                {
+                    "response": {
+                        "successful": False,
+                        "data": {},
+                        "error": remote_error_message,
+                    },
+                    "tool_slug": parsed[index]["tool_slug"],
+                    "error": remote_error_message,
+                }
+                for index in remote_indices
+            ]
+        else:
+            remote_results_list = (
+                remote_data.get("results", [])
+                if isinstance(remote_data.get("results"), list)
+                else []
+            )
         merged_results = [
             {
                 **entry,
@@ -534,19 +556,23 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         all_results = [{**entry, "index": i} for i, entry in enumerate(merged_results)]
         failed = sum(1 for r in all_results if r.get("error"))
         merged_data = {**remote_data, "results": all_results}
-        if local_entries and any(
-            key in remote_data
-            for key in ("total_count", "success_count", "error_count")
+        if local_entries and (
+            remote_error_message is not None
+            or any(
+                key in remote_data
+                for key in ("total_count", "success_count", "error_count")
+            )
         ):
             merged_data["total_count"] = len(all_results)
             merged_data["success_count"] = len(all_results) - failed
             merged_data["error_count"] = failed
 
-        remote_error = (
-            str(remote_result.get("error"))
-            if remote_result and remote_result.get("error") is not None
-            else None
-        )
+        remote_error = remote_error_message
+        if remote_error is None and remote_result:
+            raw_remote_error = remote_result.get("error")
+            remote_error = (
+                str(raw_remote_error) if raw_remote_error is not None else None
+            )
         has_any_error = any(r.get("error") for _, r in local_results) or bool(
             remote_error
         )

--- a/python/tests/test_custom_tools.py
+++ b/python/tests/test_custom_tools.py
@@ -1344,6 +1344,66 @@ class TestMultiExecuteRouting:
         assert result["successful"] is True
         assert result["data"]["results"][0]["tool_slug"] == "GREP"
 
+    def test_remote_transport_failure_keeps_local_results(self, grep_tool):
+        """A raised backend error becomes per-tool failures (matches TS)."""
+        s = self._make_session(grep_tool)
+        tm = MagicMock()
+
+        def failing_backend(slug, args):
+            raise RuntimeError("remote unavailable")
+
+        tm._wrap_execute_tool_for_tool_router.return_value = failing_backend
+        result = s._route_multi_execute(
+            {
+                "tools": [
+                    {"tool_slug": "GREP", "arguments": {"pattern": "x"}},
+                    {"tool_slug": "REMOTE", "arguments": {}},
+                    {"tool_slug": "OTHER_REMOTE", "arguments": {}},
+                ]
+            },
+            tm,
+        )
+        assert result["successful"] is False
+        assert result["error"] == "2 out of 3 tools failed"
+        results = result["data"]["results"]
+        assert [r["tool_slug"] for r in results] == ["GREP", "REMOTE", "OTHER_REMOTE"]
+        assert [r["index"] for r in results] == [0, 1, 2]
+        assert results[0]["response"] == {
+            "successful": True,
+            "data": {"matches": ["x"], "path": "."},
+        }
+        assert "error" not in results[0]
+        for entry in results[1:]:
+            assert entry["error"] == "remote unavailable"
+            assert entry["response"] == {
+                "successful": False,
+                "data": {},
+                "error": "remote unavailable",
+            }
+        assert result["data"]["total_count"] == 3
+        assert result["data"]["success_count"] == 1
+        assert result["data"]["error_count"] == 2
+
+    def test_remote_transport_failure_uses_fallback_message(self, grep_tool):
+        s = self._make_session(grep_tool)
+        tm = MagicMock()
+
+        def failing_backend(slug, args):
+            raise RuntimeError()
+
+        tm._wrap_execute_tool_for_tool_router.return_value = failing_backend
+        result = s._route_multi_execute(
+            {
+                "tools": [
+                    {"tool_slug": "GREP", "arguments": {"pattern": "x"}},
+                    {"tool_slug": "REMOTE", "arguments": {}},
+                ]
+            },
+            tm,
+        )
+        assert result["successful"] is False
+        assert result["data"]["results"][1]["error"] == "Remote tool execution failed"
+
     def test_remote_batch_error_without_item_errors_uses_batch_message(self, grep_tool):
         s = self._make_session(grep_tool)
         tm = MagicMock()


### PR DESCRIPTION
## Summary

Follow-up to #4310. The TypeScript SDK (since #3800) catches a thrown backend call for the remote half of a mixed `COMPOSIO_MULTI_EXECUTE_TOOL` batch and turns it into one failure entry per remote slug, so completed local results are not lost. The Python SDK still let the exception escape `_route_multi_execute`, discarding every local result that had already run.

This ports the TypeScript behavior so both SDKs return the same shape on a remote transport failure.

Fixes #

## Changes

- Catch the remote future's exception in `_route_multi_execute` and keep `str(error)`, falling back to `Remote tool execution failed` when the message is empty (same fallback as TS).
- Synthesize `{response: {successful: False, data: {}, error}, tool_slug, error}` for each remote index and merge them in original request order.
- Recompute `total_count` / `success_count` / `error_count` on transport failure, as TS does.
- Add two regression tests mirroring the TS cases in `customToolRouting.test.ts`: local results preserved with per-tool remote errors, and the empty-message fallback.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

- `uv run --locked --group dev pytest tests/test_custom_tools.py -q`: 87 passed.
- `uv run --locked --group dev nox -s chk`: ruff and mypy clean.
- Without the source change, the new `test_remote_transport_failure_keeps_local_results` raises `RuntimeError: remote unavailable` out of `_route_multi_execute`.

## Checklist

- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [ ] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [ ] I added a changeset if this change affects published packages (Python does not use Changesets)

## Additional context

TypeScript reference: `ts/packages/core/src/models/ToolRouterSession.ts`, the `remoteErrorMessage` branch, and the test "should preserve successful local results when remote transport fails".

https://claude.ai/code/session_01PAXMbiZd3qPoJ8Z9uPvEAb
EOF -R ComposioHQ/composio