### PR TITLE
ci(py): add pip-audit gate for the uv lockfiles

### DIFF
--- a/.github/workflows/py.audit.yml
+++ b/.github/workflows/py.audit.yml
@@ -1,0 +1,123 @@
+name: Audit Python SDK
+
+# Python counterpart of ts.audit.yml. Every tracked uv lockfile is exported to
+# a pinned requirements list and scanned with pip-audit against the PyPI
+# advisory database and OSV. Runtime dependencies only, matching the
+# `pnpm audit --prod` gate: the exports pass `--no-dev`, and workspace members
+# themselves are skipped since they are not published on PyPI.
+#
+# Advisories with no patched release belong in IGNORED_VULNS below, with a
+# comment. Do not silence the gate by dropping `--strict`.
+
+on:
+  push:
+    branches: [master, next]
+    paths:
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'python/pyproject.toml'
+      - 'python/providers/*/pyproject.toml'
+      - 'python/providers/*/uv.lock'
+      - '.github/actions/setup-python-uv/action.yml'
+      - '.github/workflows/py.audit.yml'
+      - 'mise.toml'
+      - 'mise.lock'
+  pull_request:
+    branches: [master, next]
+    paths:
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'python/pyproject.toml'
+      - 'python/providers/*/pyproject.toml'
+      - 'python/providers/*/uv.lock'
+      - '.github/actions/setup-python-uv/action.yml'
+      - '.github/workflows/py.audit.yml'
+      - 'mise.toml'
+      - 'mise.lock'
+  schedule:
+    # Advisories land without a commit; re-check the default branch weekly.
+    - cron: '30 6 * * 5'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  PIP_AUDIT_VERSION: 2.10.1
+  # chromadb <=1.5.9 (via crewai, which pins chromadb~=1.1.0). Upstream has
+  # published no patched release for any of the four advisories, so no bump
+  # reaches them. All four affect the Chroma *server* (auth, RBAC, and code
+  # injection in server endpoints); composio-crewai only imports the client
+  # library through crewai and never starts a server. Drop each entry once
+  # crewai moves to a chromadb release that closes it.
+  #   PYSEC-2026-311 = CVE-2026-45829 = GHSA-f4j7-r4q5-qw2c (pre-auth code injection)
+  #   CVE-2026-45833 = GHSA-36p7-vc44-83pf (code injection)
+  #   CVE-2026-45830 = GHSA-2wm9-hf6c-p5cr (cross-tenant data access)
+  #   CVE-2026-45831 = GHSA-xph7-9rjv-w5fr (RBAC scope not checked)
+  IGNORED_VULNS: >-
+    PYSEC-2026-311
+    CVE-2026-45833
+    CVE-2026-45830
+    CVE-2026-45831
+
+jobs:
+  audit:
+    name: Audit ${{ matrix.lock.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lock:
+          # The uv workspace at the repository root: the composio package and
+          # every provider listed in [tool.uv.workspace].
+          - name: workspace
+            directory: '.'
+            export-flags: '--all-packages'
+          # Standalone provider projects with their own lockfiles.
+          - name: composio-openai
+            directory: 'python/providers/openai'
+            export-flags: ''
+          - name: composio-claude-agent-sdk
+            directory: 'python/providers/claude_agent_sdk'
+            export-flags: ''
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Python with UV
+        uses: ./.github/actions/setup-python-uv
+        with:
+          enable-caching: 'false'
+
+      - name: Export locked runtime requirements
+        env:
+          LOCK_DIRECTORY: ${{ matrix.lock.directory }}
+          EXPORT_FLAGS: ${{ matrix.lock.export-flags }}
+        run: |
+          # shellcheck disable=SC2086 # EXPORT_FLAGS is intentionally word-split.
+          uv export \
+            --frozen \
+            --no-dev \
+            --no-hashes \
+            --no-emit-workspace \
+            --directory "$LOCK_DIRECTORY" \
+            --output-file "$RUNNER_TEMP/requirements.txt" \
+            $EXPORT_FLAGS
+          echo "Exported $(grep -c '==' "$RUNNER_TEMP/requirements.txt") pinned packages"
+
+      - name: Run pip-audit
+        run: |
+          ignore_flags=()
+          for id in $IGNORED_VULNS; do
+            ignore_flags+=(--ignore-vuln "$id")
+          done
+          uvx --from "pip-audit==$PIP_AUDIT_VERSION" pip-audit \
+            --requirement "$RUNNER_TEMP/requirements.txt" \
+            --no-deps \
+            --strict \
+            --progress-spinner off \
+            "${ignore_flags[@]}"

--- a/.github/workflows/py.audit.yml
+++ b/.github/workflows/py.audit.yml
@@ -76,13 +76,23 @@ jobs:
           - name: workspace
             directory: '.'
             export-flags: '--all-packages'
-          # Standalone provider projects with their own lockfiles.
+            standalone: false
+          # Provider projects with their own lockfiles, which pin the published
+          # `composio` from PyPI rather than the workspace checkout. uv resolves
+          # them on their own even though python/providers/openai is listed as
+          # a workspace member: discovery walks up from the provider, hits
+          # python/pyproject.toml first, and stops there because that project
+          # declares no workspace. The "Check lockfile origin" step below
+          # asserts this so a change to that layout cannot silently turn these
+          # jobs into a re-scan of the workspace export.
           - name: composio-openai
             directory: 'python/providers/openai'
             export-flags: ''
+            standalone: true
           - name: composio-claude-agent-sdk
             directory: 'python/providers/claude_agent_sdk'
             export-flags: ''
+            standalone: true
 
     steps:
       - name: Checkout Code
@@ -108,6 +118,29 @@ jobs:
             --output-file "$RUNNER_TEMP/requirements.txt" \
             $EXPORT_FLAGS
           echo "Exported $(grep -c '==' "$RUNNER_TEMP/requirements.txt") pinned packages"
+
+      - name: Check lockfile origin
+        env:
+          LOCK_DIRECTORY: ${{ matrix.lock.directory }}
+          STANDALONE: ${{ matrix.lock.standalone }}
+        run: |
+          # A standalone provider lock pins composio from PyPI, so its export
+          # carries a `composio==` line. A workspace export never does, because
+          # `--no-emit-workspace` drops workspace members.
+          if grep -q '^composio==' "$RUNNER_TEMP/requirements.txt"; then
+            origin=standalone
+          else
+            origin=workspace
+          fi
+          if [[ "$STANDALONE" == "true" && "$origin" != "standalone" ]]; then
+            echo "::error::expected $LOCK_DIRECTORY/uv.lock to resolve on its own, but uv exported the workspace lock"
+            exit 1
+          fi
+          if [[ "$STANDALONE" != "true" && "$origin" != "workspace" ]]; then
+            echo "::error::expected the workspace lock, but uv exported a standalone project lock"
+            exit 1
+          fi
+          echo "Audited the $origin lockfile"
 
       - name: Run pip-audit
         run: |


### PR DESCRIPTION
This PR:

- adds `py.audit.yml`, the Python counterpart of `ts.audit.yml`; there was no dependency audit for the Python SDK until now
- exports each tracked `uv.lock` (the root workspace plus the standalone `openai` and `claude_agent_sdk` provider projects) to pinned runtime requirements with `uv export --frozen --no-dev`, then scans them with a pinned `pip-audit --strict`
- runs on lockfile and manifest changes and on a weekly schedule, so advisories that land without a commit still surface
- ignores the four chromadb advisories with a comment: chromadb has no patched release, crewai pins `chromadb~=1.1.0`, and all four affect the Chroma server that `composio-crewai` never starts
- with those ignores the gate is green on `next` today, which I verified locally by running the exact workflow commands

