### PR TITLE
ci(dependabot): run the pip updater at the uv workspace root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,11 +47,22 @@ updates:
         applies-to: security-updates
         patterns: ["*"]
 
-  # Python SDK and provider packages
+  # Python SDK and provider packages.
+  #
+  # The uv workspace root is "/": that is where pyproject.toml declares
+  # [tool.uv.workspace] and where uv.lock lives, so Dependabot must run there
+  # to update the lockfile. Pointing it at "/python" only rewrote
+  # python/pyproject.toml and left uv.lock behind (see the langchain-openai
+  # security bump in ec24c54ff), and alerts against the lockfile never
+  # auto-resolved. The explicit provider directories are the projects that are
+  # not workspace members and resolve on their own.
   - package-ecosystem: "pip"
     directories:
-      - "/python"
-      - "/python/providers/*"
+      - "/"
+      - "/python/providers/autogen"
+      - "/python/providers/claude_agent_sdk"
+      - "/python/providers/langgraph"
+      - "/python/providers/llamaindex"
     schedule:
       interval: "weekly"
       day: "friday"


### PR DESCRIPTION
This PR:

- points Dependabot's `pip` ecosystem at `/`, where `pyproject.toml` declares the uv workspace and `uv.lock` lives, instead of `/python` and `/python/providers/*`
- fixes security bumps that never touched the lockfile: Dependabot's langchain-openai bump in ec24c54ff edited only `python/pyproject.toml`, and Dependabot alert 439 for that package is still open against a pin that has been at 1.6.0 since 2026-08-24
- keeps explicit directories for the four providers that are not workspace members (`autogen`, `claude_agent_sdk`, `langgraph`, `llamaindex`) so they keep getting updates on their own manifests
- leaves the `tomli` and `ag2` ignores and the grouping untouched

Follow-up worth a look, out of scope here: `python/providers/openai` is a workspace member but also carries its own `uv.lock`, which uv ignores when it resolves the workspace from the root.

