### PR TITLE
fix(py): raise `requests` and `urllib3` floors past open advisories

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,11 +15,16 @@ dependencies = [
     # The pinning adapter mounts through `get_connection_with_tls_context`,
     # which `HTTPAdapter.send` only calls on requests >= 2.32.2; older
     # versions silently skip it and the pinning never engages.
-    "requests>=2.32.2",
+    # 2.32.4 fixes GHSA-9hjg-9r4m-mvj7 (.netrc credentials leaked to a
+    # malicious URL); `url_safety` fetches user- and server-supplied URLs.
+    "requests>=2.32.4",
     # `url_safety` imports urllib3 directly: `NameResolutionError` only exists
     # from 2.0, and the pinning adapter reaches into 2.x connection internals.
     # requests alone allows 1.x, which would fail at import time.
-    "urllib3>=2",
+    # 2.7.0 fixes GHSA-mf9v-mfxr-j63j (decompression-bomb guard bypass in
+    # the streaming API our download size limit relies on) and
+    # GHSA-qccp-gfcp-xxvc (sensitive headers forwarded across origins).
+    "urllib3>=2.7.0",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/python/setup.py
+++ b/python/setup.py
@@ -32,10 +32,12 @@ setup(
         "jsonschema>=4.23.0",
         # `get_connection_with_tls_context` (the pinning adapter's mount
         # point) is only called by `HTTPAdapter.send` on requests >= 2.32.2.
-        "requests>=2.32.2",
+        # 2.32.4 fixes GHSA-9hjg-9r4m-mvj7 (.netrc credentials leak).
+        "requests>=2.32.4",
         # `url_safety` imports urllib3 directly and needs 2.x: 1.x has no
         # `NameResolutionError` and different connection internals.
-        "urllib3>=2",
+        # 2.7.0 fixes GHSA-mf9v-mfxr-j63j and GHSA-qccp-gfcp-xxvc.
+        "urllib3>=2.7.0",
     ],
     include_package_data=True,
 )

--- a/uv.lock
+++ b/uv.lock
@@ -826,9 +826,9 @@ requires-dist = [
     { name = "openai", specifier = ">=2.48.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "pysher", specifier = ">=1.0.8" },
-    { name = "requests", specifier = ">=2.32.2" },
+    { name = "requests", specifier = ">=2.32.4" },
     { name = "typing-extensions", specifier = ">=4.16.0" },
-    { name = "urllib3", specifier = ">=2" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
This PR:

- raises the `composio` package floors to `requests>=2.32.4` and `urllib3>=2.7.0` in `python/pyproject.toml`, `python/setup.py`, and `uv.lock`
- closes GHSA-9hjg-9r4m-mvj7 (`requests` `.netrc` credential leak via malicious URLs) for downstream installs; `url_safety` fetches user- and server-supplied URLs through a `trust_env` session
- closes GHSA-mf9v-mfxr-j63j (decompression-bomb guard bypass in the `urllib3` streaming API that `_fetch_file_from_url` relies on for its size limit) and GHSA-qccp-gfcp-xxvc (sensitive headers forwarded across origins)
- the workspace lock already resolves 2.34.2 / 2.7.0, so only the `requires-dist` specifiers change; `uv lock --check` passes and `import composio` still works
- documents the advisory IDs next to each floor so the next bump has context
