### PR TITLE
fix(json-schema-to-zod): guard schema `pattern` compilation

### DIFF
--- a/.changeset/json-schema-to-zod-pattern-guard.md
+++ b/.changeset/json-schema-to-zod-pattern-guard.md
@@ -3,4 +3,4 @@
 '@composio/core': patch
 ---
 
-Guard schema `pattern` and `patternProperties` compilation. A pattern that does not compile, nests unbounded quantifiers (such as `^(a+)+$`), or exceeds 1024 characters now fails conversion with an `InvalidPatternError` that names the offending property path instead of a raw `SyntaxError` or a validator that can block the event loop. `@composio/core` surfaces that path in the `JsonSchemaToZodError` message.
+Guard schema `pattern` and `patternProperties` compilation. A pattern that does not compile or exceeds 1024 characters now fails conversion with an `InvalidPatternError` that names the offending property path instead of a raw `SyntaxError`. `@composio/core` surfaces that path in the `JsonSchemaToZodError` message. No backtracking heuristic is applied: a hostile `pattern` that backtracks catastrophically remains a known limitation.

--- a/.changeset/json-schema-to-zod-pattern-guard.md
+++ b/.changeset/json-schema-to-zod-pattern-guard.md
@@ -1,0 +1,6 @@
+---
+'@composio/json-schema-to-zod': patch
+'@composio/core': patch
+---
+
+Guard schema `pattern` and `patternProperties` compilation. A pattern that does not compile, nests unbounded quantifiers (such as `^(a+)+$`), or exceeds 1024 characters now fails conversion with an `InvalidPatternError` that names the offending property path instead of a raw `SyntaxError` or a validator that can block the event loop. `@composio/core` surfaces that path in the `JsonSchemaToZodError` message.

--- a/ts/packages/core/src/utils/jsonSchema.ts
+++ b/ts/packages/core/src/utils/jsonSchema.ts
@@ -495,7 +495,10 @@ export function jsonSchemaToZodSchema<T extends z.ZodTypeAny>(
     const zodSchema = jsonSchemaToZod(schema) as T;
     return zodSchema;
   } catch (error) {
-    throw new JsonSchemaToZodError('Failed to convert JSON Schema to Zod Schema', {
+    // The cause names the offending property path; surface it in the message
+    // so a single malformed property is identifiable without unwrapping.
+    const detail = error instanceof Error ? `: ${error.message}` : '';
+    throw new JsonSchemaToZodError(`Failed to convert JSON Schema to Zod Schema${detail}`, {
       cause: error,
     });
   }

--- a/ts/packages/core/test/utils/jsonSchema.test.ts
+++ b/ts/packages/core/test/utils/jsonSchema.test.ts
@@ -3,8 +3,12 @@ import {
   deduplicateJsonSchemaRequiredArrays,
   dereferenceJsonSchema,
   ensureObjectTypeOnProperties,
+  jsonSchemaToZodSchema,
 } from '../../src/utils/jsonSchema';
-import { JsonSchemaRefResolutionError } from '../../src/errors/ValidationErrors';
+import {
+  JsonSchemaRefResolutionError,
+  JsonSchemaToZodError,
+} from '../../src/errors/ValidationErrors';
 import logger from '../../src/utils/logger';
 import { ToolSchema } from '../../src/types/tool.types';
 import {
@@ -630,6 +634,24 @@ describe('ToolSchema parameter-root preservation', () => {
     });
 
     expect(tool.inputParameters).not.toHaveProperty('additionalProperties');
+  });
+});
+
+describe('jsonSchemaToZodSchema', () => {
+  it('names the property whose pattern cannot be compiled', () => {
+    let caught: unknown;
+    try {
+      jsonSchemaToZodSchema({
+        type: 'object',
+        properties: { name: { type: 'string', pattern: '(' } },
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(JsonSchemaToZodError);
+    expect((caught as JsonSchemaToZodError).message).toContain('at properties.name');
+    expect((caught as JsonSchemaToZodError).cause).toBeInstanceOf(Error);
   });
 });
 

--- a/ts/packages/json-schema-to-zod/src/index.ts
+++ b/ts/packages/json-schema-to-zod/src/index.ts
@@ -1,2 +1,3 @@
 export type * from './types';
 export { jsonSchemaToZod, jsonSchemaToZodShape } from './json-schema-to-zod';
+export { InvalidPatternError, type InvalidPatternReason } from './utils/compile-pattern';

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-object.ts
@@ -5,6 +5,7 @@ import { parseAnyOf } from './parse-any-of';
 import { parseOneOf } from './parse-one-of';
 import { parseSchema } from './parse-schema';
 import type { JsonSchemaObject, Refs, JsonSchema } from '../types';
+import { compilePattern } from '../utils/compile-pattern';
 import { its } from '../utils/its';
 
 /**
@@ -104,7 +105,7 @@ function parseDynamicKeyObject(
 ): z.ZodTypeAny {
   const patterns = Object.entries(normalizedSchema.patternProperties ?? {}).map(
     ([pattern, schema]) => ({
-      regex: new RegExp(pattern),
+      regex: compilePattern('patternProperties', pattern, refs),
       parser: parseSchema(schema, {
         ...refs,
         path: [...refs.path, 'patternProperties', pattern],

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-schema.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-schema.ts
@@ -122,11 +122,11 @@ const selectParser: ParserSelector = (schema, refs) => {
   } else if (its.a.not(schema)) {
     return parseNot(schema, refs);
   } else if (hasTypelessScalarConstraints(schema)) {
-    return parseTypelessConstraints(schema);
+    return parseTypelessConstraints(schema, refs);
   } else if (its.a.multipleType(schema)) {
     return parseMultipleType(schema, refs);
   } else if (its.a.primitive(schema, 'string')) {
-    return parseString(schema);
+    return parseString(schema, refs);
   } else if (its.a.primitive(schema, 'number') || its.a.primitive(schema, 'integer')) {
     return parseNumber(schema);
   } else if (its.a.primitive(schema, 'boolean')) {

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-string.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-string.ts
@@ -1,9 +1,13 @@
 import { z } from 'zod/v3';
 
-import type { JsonSchemaObject } from '../types';
+import type { JsonSchemaObject, Refs } from '../types';
+import { compilePattern } from '../utils/compile-pattern';
 import { extendSchemaWithMessage } from '../utils/extend-schema';
 
-export const parseString = (jsonSchema: JsonSchemaObject & { type: 'string' }) => {
+export const parseString = (
+  jsonSchema: JsonSchemaObject & { type: 'string' },
+  refs: Pick<Refs, 'path'>
+) => {
   let zodSchema = z.string();
 
   zodSchema = extendSchemaWithMessage(zodSchema, jsonSchema, 'format', (zs, format, errorMsg) => {
@@ -39,7 +43,7 @@ export const parseString = (jsonSchema: JsonSchemaObject & { type: 'string' }) =
     zs.base64(errorMsg)
   );
   zodSchema = extendSchemaWithMessage(zodSchema, jsonSchema, 'pattern', (zs, pattern, errorMsg) =>
-    zs.regex(new RegExp(pattern), errorMsg)
+    zs.regex(compilePattern('pattern', pattern, refs), errorMsg)
   );
   // JSON Schema length constraints count Unicode code points, while Zod's
   // built-in `.min()`/`.max()` count UTF-16 code units and overcount astral

--- a/ts/packages/json-schema-to-zod/src/parsers/parse-typeless-constraints.ts
+++ b/ts/packages/json-schema-to-zod/src/parsers/parse-typeless-constraints.ts
@@ -2,7 +2,7 @@ import { z } from 'zod/v3';
 
 import { parseNumber } from './parse-number';
 import { parseString } from './parse-string';
-import type { JsonSchemaObject } from '../types';
+import type { JsonSchemaObject, Refs } from '../types';
 
 const SCALAR_CONSTRAINT_KEYS = [
   'minLength',
@@ -23,8 +23,11 @@ export const hasTypelessScalarConstraints = (schema: JsonSchemaObject): boolean 
  * schema declares no `type`: `{ "minLength": 2 }` restricts strings while
  * leaving every non-string value untouched.
  */
-export const parseTypelessConstraints = (schema: JsonSchemaObject): z.ZodTypeAny => {
-  const stringSchema = parseString({ ...schema, type: 'string' });
+export const parseTypelessConstraints = (
+  schema: JsonSchemaObject,
+  refs: Pick<Refs, 'path'>
+): z.ZodTypeAny => {
+  const stringSchema = parseString({ ...schema, type: 'string' }, refs);
   const numberSchema = parseNumber({ ...schema, type: 'number' });
 
   return z.any().superRefine((value, ctx) => {

--- a/ts/packages/json-schema-to-zod/src/utils/compile-pattern.ts
+++ b/ts/packages/json-schema-to-zod/src/utils/compile-pattern.ts
@@ -1,0 +1,155 @@
+import type { Refs } from '../types';
+
+/**
+ * Longest `pattern` / `patternProperties` key this package compiles. Tool
+ * schemas come from third-party toolkit definitions; anything past this is
+ * far outside what a format constraint needs and is rejected before it can
+ * cost anything at validation time.
+ */
+export const MAX_PATTERN_LENGTH = 1024;
+
+export type InvalidPatternReason = 'syntax' | 'nested-quantifier' | 'too-long';
+
+/**
+ * Raised at conversion time when a schema `pattern` cannot be turned into a
+ * safe `RegExp`. Conversion fails eagerly, in line with how this package and
+ * `@composio/json-schema-to-effect-schema` treat other schema defects: a broken
+ * schema is the tool author's bug, so it surfaces once at construction rather
+ * than on every validation as if the caller's input were wrong.
+ */
+export class InvalidPatternError extends Error {
+  override readonly name = 'InvalidPatternError';
+
+  constructor(
+    readonly keyword: 'pattern' | 'patternProperties',
+    readonly pattern: string,
+    readonly path: ReadonlyArray<string | number>,
+    readonly reason: InvalidPatternReason,
+    detail: string,
+    options?: ErrorOptions
+  ) {
+    const location = path.length > 0 ? path.join('.') : '<root>';
+    super(
+      `Invalid ${keyword} regular expression ${JSON.stringify(pattern)} at ${location}: ${detail}`,
+      options
+    );
+  }
+}
+
+/**
+ * Whether the pattern nests an unbounded quantifier (`*`, `+`, `{n,}`) inside
+ * a group that is itself unboundedly quantified, such as `(a+)+` or
+ * `(\d*x)*`. This is the star-height check `safe-regex` popularised: it is
+ * purely syntactic, so it misses alternation-driven blowups like `(a|aa)+`
+ * and flags some patterns that backtrack linearly in practice, but it catches
+ * the canonical catastrophic shapes without a regex engine or a dependency.
+ */
+export const hasNestedUnboundedQuantifier = (pattern: string): boolean => {
+  // One entry per open group: whether an unbounded quantifier appeared inside it.
+  const openGroups: boolean[] = [];
+  let closedGroupHadUnbounded = false;
+  let afterGroupClose = false;
+  let inClass = false;
+
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i];
+
+    if (char === '\\') {
+      i += 1;
+      afterGroupClose = false;
+      continue;
+    }
+
+    if (inClass) {
+      if (char === ']') inClass = false;
+      continue;
+    }
+
+    let unbounded = false;
+    switch (char) {
+      case '[':
+        inClass = true;
+        break;
+      case '(':
+        openGroups.push(false);
+        break;
+      case ')':
+        closedGroupHadUnbounded = openGroups.pop() ?? false;
+        afterGroupClose = true;
+        continue;
+      case '*':
+      case '+':
+        unbounded = true;
+        break;
+      case '{': {
+        const close = pattern.indexOf('}', i);
+        const body = close === -1 ? '' : pattern.slice(i + 1, close);
+        if (/^\d+,$/.test(body)) {
+          unbounded = true;
+        }
+        if (close !== -1 && /^\d+(,\d*)?$/.test(body)) {
+          i = close;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    if (unbounded) {
+      if (afterGroupClose && closedGroupHadUnbounded) {
+        return true;
+      }
+      for (let depth = 0; depth < openGroups.length; depth++) {
+        openGroups[depth] = true;
+      }
+    }
+
+    afterGroupClose = false;
+  }
+
+  return false;
+};
+
+/**
+ * Compile a schema pattern, rejecting anything that could not be compiled or
+ * that the {@link hasNestedUnboundedQuantifier} heuristic marks as unsafe.
+ *
+ * No `u` flag is passed: existing tool schemas rely on identity escapes that
+ * Unicode mode refuses, and the goal here is to fail on defects, not to
+ * tighten which patterns are accepted.
+ */
+export const compilePattern = (
+  keyword: 'pattern' | 'patternProperties',
+  pattern: string,
+  refs: Pick<Refs, 'path'>
+): RegExp => {
+  const path = keyword === 'pattern' ? refs.path : [...refs.path, 'patternProperties', pattern];
+
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    throw new InvalidPatternError(
+      keyword,
+      pattern,
+      path,
+      'too-long',
+      `pattern exceeds ${MAX_PATTERN_LENGTH} characters`
+    );
+  }
+
+  if (hasNestedUnboundedQuantifier(pattern)) {
+    throw new InvalidPatternError(
+      keyword,
+      pattern,
+      path,
+      'nested-quantifier',
+      'nested unbounded quantifiers can backtrack catastrophically'
+    );
+  }
+
+  try {
+    return new RegExp(pattern);
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    throw new InvalidPatternError(keyword, pattern, path, 'syntax', detail, { cause });
+  }
+};

--- a/ts/packages/json-schema-to-zod/src/utils/compile-pattern.ts
+++ b/ts/packages/json-schema-to-zod/src/utils/compile-pattern.ts
@@ -8,11 +8,11 @@ import type { Refs } from '../types';
  */
 export const MAX_PATTERN_LENGTH = 1024;
 
-export type InvalidPatternReason = 'syntax' | 'nested-quantifier' | 'too-long';
+export type InvalidPatternReason = 'syntax' | 'too-long';
 
 /**
  * Raised at conversion time when a schema `pattern` cannot be turned into a
- * safe `RegExp`. Conversion fails eagerly, in line with how this package and
+ * `RegExp`. Conversion fails eagerly, in line with how this package and
  * `@composio/json-schema-to-effect-schema` treat other schema defects: a broken
  * schema is the tool author's bug, so it surfaces once at construction rather
  * than on every validation as if the caller's input were wrong.
@@ -37,83 +37,14 @@ export class InvalidPatternError extends Error {
 }
 
 /**
- * Whether the pattern nests an unbounded quantifier (`*`, `+`, `{n,}`) inside
- * a group that is itself unboundedly quantified, such as `(a+)+` or
- * `(\d*x)*`. This is the star-height check `safe-regex` popularised: it is
- * purely syntactic, so it misses alternation-driven blowups like `(a|aa)+`
- * and flags some patterns that backtrack linearly in practice, but it catches
- * the canonical catastrophic shapes without a regex engine or a dependency.
- */
-export const hasNestedUnboundedQuantifier = (pattern: string): boolean => {
-  // One entry per open group: whether an unbounded quantifier appeared inside it.
-  const openGroups: boolean[] = [];
-  let closedGroupHadUnbounded = false;
-  let afterGroupClose = false;
-  let inClass = false;
-
-  for (let i = 0; i < pattern.length; i++) {
-    const char = pattern[i];
-
-    if (char === '\\') {
-      i += 1;
-      afterGroupClose = false;
-      continue;
-    }
-
-    if (inClass) {
-      if (char === ']') inClass = false;
-      continue;
-    }
-
-    let unbounded = false;
-    switch (char) {
-      case '[':
-        inClass = true;
-        break;
-      case '(':
-        openGroups.push(false);
-        break;
-      case ')':
-        closedGroupHadUnbounded = openGroups.pop() ?? false;
-        afterGroupClose = true;
-        continue;
-      case '*':
-      case '+':
-        unbounded = true;
-        break;
-      case '{': {
-        const close = pattern.indexOf('}', i);
-        const body = close === -1 ? '' : pattern.slice(i + 1, close);
-        if (/^\d+,$/.test(body)) {
-          unbounded = true;
-        }
-        if (close !== -1 && /^\d+(,\d*)?$/.test(body)) {
-          i = close;
-        }
-        break;
-      }
-      default:
-        break;
-    }
-
-    if (unbounded) {
-      if (afterGroupClose && closedGroupHadUnbounded) {
-        return true;
-      }
-      for (let depth = 0; depth < openGroups.length; depth++) {
-        openGroups[depth] = true;
-      }
-    }
-
-    afterGroupClose = false;
-  }
-
-  return false;
-};
-
-/**
- * Compile a schema pattern, rejecting anything that could not be compiled or
- * that the {@link hasNestedUnboundedQuantifier} heuristic marks as unsafe.
+ * Compile a schema pattern, rejecting anything that does not compile or that
+ * exceeds {@link MAX_PATTERN_LENGTH}.
+ *
+ * Both guards have no false positives: a pattern that fails here would never
+ * have worked. No backtracking (ReDoS) heuristic is applied on purpose — the
+ * syntactic checks that exist flag linear patterns such as `^(\d+\.)*\d+$`,
+ * and a wrong rejection fails the whole tool the schema belongs to. A hostile
+ * `pattern` that backtracks catastrophically remains a known limitation.
  *
  * No `u` flag is passed: existing tool schemas rely on identity escapes that
  * Unicode mode refuses, and the goal here is to fail on defects, not to
@@ -133,16 +64,6 @@ export const compilePattern = (
       path,
       'too-long',
       `pattern exceeds ${MAX_PATTERN_LENGTH} characters`
-    );
-  }
-
-  if (hasNestedUnboundedQuantifier(pattern)) {
-    throw new InvalidPatternError(
-      keyword,
-      pattern,
-      path,
-      'nested-quantifier',
-      'nested unbounded quantifiers can backtrack catastrophically'
     );
   }
 

--- a/ts/packages/json-schema-to-zod/test/compile-pattern.test.ts
+++ b/ts/packages/json-schema-to-zod/test/compile-pattern.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import { InvalidPatternError, jsonSchemaToZod } from '../src/index';
+import {
+  MAX_PATTERN_LENGTH,
+  compilePattern,
+  hasNestedUnboundedQuantifier,
+} from '../src/utils/compile-pattern';
+
+const invalidPatternAt = (build: () => unknown): InvalidPatternError => {
+  try {
+    build();
+  } catch (error) {
+    expect(error).toBeInstanceOf(InvalidPatternError);
+    return error as InvalidPatternError;
+  }
+  throw new Error('expected conversion to fail');
+};
+
+describe('hasNestedUnboundedQuantifier', () => {
+  it.each([
+    '^(a+)+$',
+    '(a*)*',
+    '^(a+)*$',
+    '(a{2,})+',
+    '(a+){3,}',
+    '((ab)+c)*',
+    '(?:x+)+',
+    '(\\d*x)*',
+    '(a+)+?',
+  ])('flags %s', pattern => {
+    expect(hasNestedUnboundedQuantifier(pattern)).toBe(true);
+  });
+
+  it.each([
+    '^[a-z]+$',
+    '^\\d{4}-\\d{2}-\\d{2}$',
+    '(a+)',
+    '(a)+',
+    '(a+){2}',
+    '(a{2,5})+',
+    '(a+){2,5}',
+    '[(+)]+',
+    '\\(a+\\)+',
+    '(a+)b+',
+    '^(?:[a-z]+\\.){0,3}[a-z]+$',
+    '^(\\d+\\.){2}\\d+$',
+  ])('accepts %s', pattern => {
+    expect(hasNestedUnboundedQuantifier(pattern)).toBe(false);
+  });
+});
+
+describe('compilePattern', () => {
+  it('compiles a valid pattern into an equivalent RegExp', () => {
+    const regex = compilePattern('pattern', '^[a-z]+$', { path: [] });
+    expect(regex.test('abc')).toBe(true);
+    expect(regex.test('ABC')).toBe(false);
+  });
+
+  it('turns a RegExp SyntaxError into an InvalidPatternError that keeps the cause', () => {
+    const error = invalidPatternAt(() =>
+      compilePattern('pattern', '(', { path: ['properties', 'name'] })
+    );
+    expect(error.reason).toBe('syntax');
+    expect(error.path).toEqual(['properties', 'name']);
+    expect(error.cause).toBeInstanceOf(SyntaxError);
+    expect(error.message).toContain('at properties.name');
+  });
+
+  it('rejects patterns above the length cap', () => {
+    const error = invalidPatternAt(() =>
+      compilePattern('pattern', 'a'.repeat(MAX_PATTERN_LENGTH + 1), { path: [] })
+    );
+    expect(error.reason).toBe('too-long');
+    expect(error.message).toContain('<root>');
+  });
+
+  it('appends the patternProperties key to the reported path', () => {
+    const error = invalidPatternAt(() =>
+      compilePattern('patternProperties', '^(a+)+$', { path: ['properties', 'tags'] })
+    );
+    expect(error.reason).toBe('nested-quantifier');
+    expect(error.path).toEqual(['properties', 'tags', 'patternProperties', '^(a+)+$']);
+  });
+});
+
+describe('jsonSchemaToZod pattern guard', () => {
+  it('reports a malformed property pattern with its path instead of a raw SyntaxError', () => {
+    const error = invalidPatternAt(() =>
+      jsonSchemaToZod({
+        type: 'object',
+        properties: { name: { type: 'string', pattern: '(' } },
+      })
+    );
+    expect(error).not.toBeInstanceOf(SyntaxError);
+    expect(error.keyword).toBe('pattern');
+    expect(error.pattern).toBe('(');
+    expect(error.message).toContain('at properties.name');
+  });
+
+  it('rejects a catastrophic pattern before it can be evaluated', () => {
+    const started = performance.now();
+    const error = invalidPatternAt(() =>
+      jsonSchemaToZod({
+        type: 'object',
+        properties: { code: { type: 'string', pattern: '^(a+)+$' } },
+      })
+    );
+    expect(error.reason).toBe('nested-quantifier');
+    expect(error.message).toContain('at properties.code');
+    expect(performance.now() - started).toBeLessThan(1000);
+  });
+
+  it('reports a typeless pattern with the path of the node carrying it', () => {
+    const error = invalidPatternAt(() =>
+      jsonSchemaToZod({
+        type: 'object',
+        properties: { slug: { pattern: '[' } },
+      })
+    );
+    expect(error.path).toEqual(['properties', 'slug']);
+  });
+
+  it('reports a malformed patternProperties key with its path', () => {
+    const error = invalidPatternAt(() =>
+      jsonSchemaToZod({
+        type: 'object',
+        properties: {
+          labels: {
+            type: 'object',
+            patternProperties: { '^(x*)*$': { type: 'string' } },
+          },
+        },
+      })
+    );
+    expect(error.keyword).toBe('patternProperties');
+    expect(error.path).toEqual(['properties', 'labels', 'patternProperties', '^(x*)*$']);
+    expect(error.message).toContain('at properties.labels.patternProperties.^(x*)*$');
+  });
+
+  it('still enforces valid patterns', () => {
+    const schema = jsonSchemaToZod({
+      type: 'object',
+      properties: {
+        id: { type: 'string', pattern: '^[a-z]{3}-\\d+$' },
+        meta: { type: 'object', patternProperties: { '^x-': { type: 'number' } } },
+      },
+      required: ['id'],
+    });
+
+    expect(schema.safeParse({ id: 'abc-42', meta: { 'x-rate': 1 } }).success).toBe(true);
+    expect(schema.safeParse({ id: 'ABC-42' }).success).toBe(false);
+    expect(schema.safeParse({ id: 'abc-42', meta: { 'x-rate': 'one' } }).success).toBe(false);
+  });
+});

--- a/ts/packages/json-schema-to-zod/test/compile-pattern.test.ts
+++ b/ts/packages/json-schema-to-zod/test/compile-pattern.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { InvalidPatternError, jsonSchemaToZod } from '../src/index';
-import {
-  MAX_PATTERN_LENGTH,
-  compilePattern,
-  hasNestedUnboundedQuantifier,
-} from '../src/utils/compile-pattern';
+import { MAX_PATTERN_LENGTH, compilePattern } from '../src/utils/compile-pattern';
 
 const invalidPatternAt = (build: () => unknown): InvalidPatternError => {
   try {
@@ -16,39 +12,6 @@ const invalidPatternAt = (build: () => unknown): InvalidPatternError => {
   }
   throw new Error('expected conversion to fail');
 };
-
-describe('hasNestedUnboundedQuantifier', () => {
-  it.each([
-    '^(a+)+$',
-    '(a*)*',
-    '^(a+)*$',
-    '(a{2,})+',
-    '(a+){3,}',
-    '((ab)+c)*',
-    '(?:x+)+',
-    '(\\d*x)*',
-    '(a+)+?',
-  ])('flags %s', pattern => {
-    expect(hasNestedUnboundedQuantifier(pattern)).toBe(true);
-  });
-
-  it.each([
-    '^[a-z]+$',
-    '^\\d{4}-\\d{2}-\\d{2}$',
-    '(a+)',
-    '(a)+',
-    '(a+){2}',
-    '(a{2,5})+',
-    '(a+){2,5}',
-    '[(+)]+',
-    '\\(a+\\)+',
-    '(a+)b+',
-    '^(?:[a-z]+\\.){0,3}[a-z]+$',
-    '^(\\d+\\.){2}\\d+$',
-  ])('accepts %s', pattern => {
-    expect(hasNestedUnboundedQuantifier(pattern)).toBe(false);
-  });
-});
 
 describe('compilePattern', () => {
   it('compiles a valid pattern into an equivalent RegExp', () => {
@@ -77,10 +40,10 @@ describe('compilePattern', () => {
 
   it('appends the patternProperties key to the reported path', () => {
     const error = invalidPatternAt(() =>
-      compilePattern('patternProperties', '^(a+)+$', { path: ['properties', 'tags'] })
+      compilePattern('patternProperties', '[', { path: ['properties', 'tags'] })
     );
-    expect(error.reason).toBe('nested-quantifier');
-    expect(error.path).toEqual(['properties', 'tags', 'patternProperties', '^(a+)+$']);
+    expect(error.reason).toBe('syntax');
+    expect(error.path).toEqual(['properties', 'tags', 'patternProperties', '[']);
   });
 });
 
@@ -96,19 +59,6 @@ describe('jsonSchemaToZod pattern guard', () => {
     expect(error.keyword).toBe('pattern');
     expect(error.pattern).toBe('(');
     expect(error.message).toContain('at properties.name');
-  });
-
-  it('rejects a catastrophic pattern before it can be evaluated', () => {
-    const started = performance.now();
-    const error = invalidPatternAt(() =>
-      jsonSchemaToZod({
-        type: 'object',
-        properties: { code: { type: 'string', pattern: '^(a+)+$' } },
-      })
-    );
-    expect(error.reason).toBe('nested-quantifier');
-    expect(error.message).toContain('at properties.code');
-    expect(performance.now() - started).toBeLessThan(1000);
   });
 
   it('reports a typeless pattern with the path of the node carrying it', () => {
@@ -128,14 +78,27 @@ describe('jsonSchemaToZod pattern guard', () => {
         properties: {
           labels: {
             type: 'object',
-            patternProperties: { '^(x*)*$': { type: 'string' } },
+            patternProperties: { '^x-(': { type: 'string' } },
           },
         },
       })
     );
     expect(error.keyword).toBe('patternProperties');
-    expect(error.path).toEqual(['properties', 'labels', 'patternProperties', '^(x*)*$']);
-    expect(error.message).toContain('at properties.labels.patternProperties.^(x*)*$');
+    expect(error.path).toEqual(['properties', 'labels', 'patternProperties', '^x-(']);
+    expect(error.message).toContain('at properties.labels.patternProperties.^x-(');
+  });
+
+  it('keeps compiling quantified groups that backtrack linearly', () => {
+    const schema = jsonSchemaToZod({
+      type: 'object',
+      properties: { version: { type: 'string', pattern: '^(\\d+\\.)*\\d+$' } },
+      required: ['version'],
+    });
+
+    expect(schema.safeParse({ version: '1.2.3' }).success).toBe(true);
+    expect(schema.safeParse({ version: '42' }).success).toBe(true);
+    expect(schema.safeParse({ version: '1.2.' }).success).toBe(false);
+    expect(schema.safeParse({ version: 'v1' }).success).toBe(false);
   });
 
   it('still enforces valid patterns', () => {


### PR DESCRIPTION
This PR:

- Adds `src/utils/compile-pattern.ts` in `@composio/json-schema-to-zod`, a shared helper that compiles `pattern` and `patternProperties` keys through `new RegExp` inside a try/catch and rethrows a typed `InvalidPatternError` (exported) that names the keyword, the pattern, and the property path (e.g. `at properties.name`), mirroring the eager `assertRegexCompiles` guard in `@composio/json-schema-to-effect-schema`.
- Adds a 1024-character cap on pattern length, reported through the same error with `reason: 'too-long'`.
- Chooses fail-at-conversion over degrade-with-warning: the package has no warning hook or lenient `refs` mode, its sibling packages and `oneOf` handling already throw on schema defects, and a silently dropped `pattern` would widen what a tool accepts without anyone noticing.
- Threads `refs.path` into `parseString` and `parseTypelessConstraints` so the error carries the property path, and appends `patternProperties.<key>` for dynamic-key objects.
- Makes `@composio/core`'s `jsonSchemaToZodSchema` include the cause message in `JsonSchemaToZodError`, so the wrapped error names the malformed property without unwrapping `cause`.
- Leaves out a nested-quantifier (star-height) ReDoS heuristic on purpose: it flags linear patterns such as `^(\d+\.)*\d+$`, a wrong rejection makes `tools.get` fail for the whole tool, and it cannot be validated against the live toolkit catalog without false-positive risk. Catastrophic backtracking from a hostile `pattern` remains a known limitation; only zero-false-positive guards ship here.
- Adds `test/compile-pattern.test.ts` (`(` -> `InvalidPatternError` with `SyntaxError` cause, length cap, typeless and `patternProperties` paths, `^(\d+\.)*\d+$` still compiles and enforces, valid patterns still enforced) and a core test for the wrapped message; adds a patch changeset for both packages.
- Verification: `pnpm test` + `pnpm typecheck` in `ts/packages/json-schema-to-zod` (4 files, 255 tests), `pnpm test` in `ts/packages/core` (54 files, 1281 passed, 2 expected fail), root `pnpm typecheck` (14/14), `lint:packages` and Prettier clean.

https://claude.ai/code/session_016ZuBv7JhVdSYTLYcTy2VJr