### PR TITLE
docs(agents): codify Effect.gen vs Effect.fn convention

### DIFF
--- a/.agents/skills/effect-v4/SKILL.md
+++ b/.agents/skills/effect-v4/SKILL.md
@@ -19,8 +19,8 @@ See [versions.json](versions.json) for the full matrix (also `typescript`, `vite
 ## Read next
 
 - [references/core-patterns.md](references/core-patterns.md) — services, layers, typed
-  errors, Schema, and the v3→v4 rename table (labeled historical, for recognizing stale
-  patterns).
+  errors, Schema, choosing between `Effect.gen` and `Effect.fn`, and the v3→v4 rename table
+  (labeled historical, for recognizing stale patterns).
 - [references/cli-surface.md](references/cli-surface.md) — `effect/unstable/cli`:
   `Command`, `Flag`, `Argument`, `GlobalFlag`, `CliConfig`, the custom
   `CliOutput.Formatter`, and the runner's double-print rule.
@@ -34,8 +34,12 @@ trust the file and fix the reference.
 
 ## Non-negotiables
 
-- `Effect.gen` with `yield*` for generator workflows; `Effect.fn('name')(function* () {...})`
-  for named Effect-returning functions.
+- `Effect.gen(function* () {...})` for effect values — the dominant form, including named
+  module consts — and `(params) => Effect.gen(...)` for parameterized helpers.
+  `Effect.fn(...)` is the function form whose effects carry stack-frame annotations (its
+  optional name string adds a per-call tracing span), worth it for service members and
+  combinator callbacks that should be attributable in error reports. All forms re-run
+  their body per execution. See "`Effect.gen` vs `Effect.fn`" in core-patterns.
 - Define services with `Context.Service` and an explicit `static readonly Default`/`layer`
   layer built with `Layer.succeed`/`Layer.effect`/`Layer.provide`. V4 does not generate a
   layer for you.

--- a/.agents/skills/effect-v4/references/core-patterns.md
+++ b/.agents/skills/effect-v4/references/core-patterns.md
@@ -121,6 +121,75 @@ are ESLint-banned in `ts/packages/cli/src`. From `@composio/cli-keyring`'s
 `effect.ts`, both `Effect.tryPromise` and `Effect.promise` kept their v3 signatures
 unchanged in v4.
 
+## `Effect.gen` vs `Effect.fn`: which form where
+
+All of these wrap a generator, and all are lazy in the same way: the body is
+`suspend`-wrapped, so it **re-runs on every execution** of the resulting effect — which is
+why `Effect.retry`/`Effect.repeat` redo the work instead of replaying a cached result
+(`gen` in `ts/vendor/effect/packages/effect/src/internal/effect.ts`).
+`Effect.fnUntracedEager` is the one eager variant. The axis that actually differs is **what
+the expression is** — an Effect value or a function — and **what the tracer records**:
+
+- `Effect.gen(function* () {...})` produces an Effect **value**. The default for one-shot
+  workflows and named module consts, from `ts/packages/cli/src/analytics/dispatch.ts`:
+
+  ```ts no-check
+  const getUserApiKey = Effect.gen(function* () {
+    const envApiKey = configuredString(
+      yield* optionalString('COMPOSIO_USER_API_KEY').parse(getEnvironmentProvider())
+    );
+    if (envApiKey) {
+      return envApiKey;
+    }
+    // ...
+  });
+  ```
+
+- `(params) => Effect.gen(function* () {...})` is a plain function returning an effect —
+  the default for parameterized helpers, from
+  `ts/packages/cli/scripts/generate-toolkit-slugs.ts`:
+
+  ```ts no-check
+  const fetchPage = (params: {
+    baseUrl: string;
+    headers: Record<string, string>;
+    cursor?: string;
+  }): Effect.Effect<ToolkitsPageDecoded, ToolkitFetchError> =>
+    Effect.gen(function* () {
+      // ...
+    });
+  ```
+
+- `Effect.fn(function* (...) {...})` also returns a **function**, but every effect it
+  produces carries stack-frame annotations for both the call site and the definition site
+  (`makeFn` updates `CurrentStackFrame`) — this is what feeds the CLI's span-chain recovery
+  from `Cause.StackTrace` in error reports. The named form `Effect.fn('span.name')(...)`
+  additionally opens a **tracing span** per call; `Effect.fnUntraced` drops the frames.
+  Use it for service-shape members and combinator callbacks whose failures should be
+  attributable, from `ts/packages/cli/src/services/composio-clients.ts`:
+
+  ```ts no-check
+  return {
+    get: Effect.fn(function* () {
+      // ...
+    }) satisfies () => Effect.Effect<_RawComposioClient, NoSuchElementError, never>,
+    getFor: Effect.fn(function* (params: {
+      userApiKey?: string;
+      orgId?: string;
+      projectId?: string;
+    }) {
+      // ...
+    }),
+  };
+  ```
+
+  The named form's per-call span is additive to those frames; add the name when the span
+  should appear in error reports, otherwise leave it off.
+
+When in doubt: value → `Effect.gen`; function → a plain arrow returning `Effect.gen`,
+upgrading to `Effect.fn` when failure attribution in error reports is worth the annotation.
+Do not migrate one form to the other wholesale.
+
 ## v3 → v4 rename table (historical — recognize stale patterns, don't copy them)
 
 Verified against `ts/vendor/effect/migration/v3-to-v4.md` and this migration's own


### PR DESCRIPTION
This PR:
- builds on top of https://github.com/ComposioHQ/composio/pull/3901
- rewrites the `effect-v4` skill's `Effect.gen`/`Effect.fn` rule, which implied every named effect should be `Effect.fn('name')` — no site in the ~490-use codebase does that
- states the axis that actually differs: Effect value vs function, and what the tracer records (`CurrentStackFrame` stack frames; per-call span with the named form)
- corrects the laziness claim: all forms are `suspend`-wrapped and re-run their body per execution (verified in `ts/vendor/effect`), which is what makes `Effect.retry`/`Effect.repeat` redo work
- adds a "which form where" section to `core-patterns.md` with excerpts cited from real files (`dispatch.ts`, `generate-toolkit-slugs.ts`, `composio-clients.ts`)
- guidance-only: zero code changes; the codebase already follows the codified convention

## Context

Reviewing the Effect v4 port surfaced that the skill's one-line rule did not match the landed code (6 `Effect.fn` uses vs ~488 `Effect.gen`), and that the accurate rule is subtler than either "always fn" or "always gen": every generator form is equally lazy, and the choice is about value-vs-function shape plus whether failure attribution in error reports (span-chain recovery from `Cause.StackTrace`) is worth the annotation. Codifying this stops agents from "migrating" one form into the other.

Validation:

- `node .agents/skills/effect-v4/scripts/check-examples.mjs` — all checked TypeScript blocks compile
- `pnpm validate:agent-skills` and `pnpm validate:skill-routing` — 19 skills pass
- prettier clean on both touched files

Merge after #3901.
