### PR TITLE
fix(core): stop dropping auth field metadata from toolkit auth details

### DIFF
--- a/.changeset/toolkit-auth-field-is-secret.md
+++ b/.changeset/toolkit-auth-field-is-secret.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Stop dropping `is_secret`, `legacy_template_name` and `auth_hint_url` from toolkit auth config details. `transformToolkitRetrieveResponse` passed the auth field groups through unchanged, so the snake_case keys never matched `ToolkitAuthFieldSchema` and zod stripped them during validation; `auth_hint_url` was never mapped at all. Fields returned by `toolkits.getConnectedAccountInitiationFields()` and `toolkits.getAuthConfigCreationFields()` now carry `isSecret`, which the API documents as the signal for whether a client should mask the input, plus `legacyTemplateName`; auth config details returned by `toolkits.get()` now carry `authHintUrl`. Each of these keys is present only when the API sends it, so spreading a field no longer overwrites a caller's own fallback with `undefined`.

--- a/ts/packages/core/src/types/toolkit.types.ts
+++ b/ts/packages/core/src/types/toolkit.types.ts
@@ -66,10 +66,27 @@ export const ToolkitAuthFieldSchema = z.object({
   name: z.string(),
   type: z.string(),
   default: z.string().nullable().optional(),
+  /**
+   * Whether this field holds a secret/credential value. Clients use it to
+   * decide whether to mask the input when collecting the value in their own
+   * UI. The property is absent when the API omits the flag for the field.
+   */
+  isSecret: z.boolean().optional(),
+  /**
+   * The legacy template name the API reports for this field, mapped from
+   * `legacy_template_name`. The API declares it as an optional string without
+   * further documenting its semantics.
+   */
+  legacyTemplateName: z.string().optional(),
 });
 export const ToolkitAuthConfigDetailsSchema = z.object({
   name: z.string(),
   mode: z.string(),
+  /**
+   * URL to a page where users can obtain or configure credentials for this
+   * authentication method, e.g. `https://github.com/settings/tokens`.
+   */
+  authHintUrl: z.string().nullable().optional(),
   fields: z.object({
     authConfigCreation: z.object({
       optional: z.array(ToolkitAuthFieldSchema),

--- a/ts/packages/core/src/utils/transformers/toolkits.ts
+++ b/ts/packages/core/src/utils/transformers/toolkits.ts
@@ -6,12 +6,65 @@ import {
 import {
   ToolKitListResponse,
   ToolKitListResponseSchema,
+  ToolkitAuthField,
   ToolkitRetrieveResponse,
   ToolkitRetrieveResponseSchema,
   ToolkitRetrieveCategoriesResponse,
   ToolkitRetrieveCategoriesResponseSchema,
 } from '../../types/toolkit.types';
 import { transform } from '../transform';
+
+type RawToolkitAuthConfigDetailFields = NonNullable<
+  RawToolkitRetrieveResponse['auth_config_details']
+>[number]['fields'];
+
+/**
+ * A single auth form field as the API ships it, across all four groups. The
+ * generated client declares each group as its own interface; they are identical
+ * today, so the union costs nothing and keeps the mapping honest if they ever
+ * drift apart.
+ *
+ * Most keys are already camelCase on the wire (`displayName`), but `is_secret`
+ * and `legacy_template_name` are not, so the field needs an explicit mapping
+ * instead of a pass-through: a pass-through leaves them under keys the schema
+ * does not know and zod strips them while validating.
+ *
+ * `type-tests/toolkit-auth-field-mapping.test-d.ts` fails the build when the
+ * generated client grows a key in any of the four groups that is not listed
+ * there.
+ */
+type RawToolkitAuthField =
+  | RawToolkitAuthConfigDetailFields['auth_config_creation']['required'][number]
+  | RawToolkitAuthConfigDetailFields['auth_config_creation']['optional'][number]
+  | RawToolkitAuthConfigDetailFields['connected_account_initiation']['required'][number]
+  | RawToolkitAuthConfigDetailFields['connected_account_initiation']['optional'][number];
+
+const transformToolkitAuthField = (field: RawToolkitAuthField): ToolkitAuthField => ({
+  name: field.name,
+  displayName: field.displayName,
+  description: field.description,
+  type: field.type,
+  required: field.required,
+  // Optional keys are spread conditionally rather than assigned. Assigning an
+  // absent wire key creates an own property holding `undefined`, which silently
+  // beats a caller's fallback in `{ default: 'fallback', ...field }`. JSON never
+  // carries an explicit `undefined`, so checking for it is the same test as
+  // asking whether the server sent the key at all — and `null` and `false`
+  // survive.
+  ...(field.default !== undefined && { default: field.default }),
+  ...(field.is_secret !== undefined && { isSecret: field.is_secret }),
+  ...(field.legacy_template_name !== undefined && {
+    legacyTemplateName: field.legacy_template_name,
+  }),
+});
+
+const transformToolkitAuthFieldGroup = (group: {
+  required: Array<RawToolkitAuthField>;
+  optional: Array<RawToolkitAuthField>;
+}) => ({
+  required: group.required.map(transformToolkitAuthField),
+  optional: group.optional.map(transformToolkitAuthField),
+});
 
 export const transformToolkitListResponse = (
   response: RawToolkitListResponse
@@ -70,9 +123,16 @@ export const transformToolkitRetrieveResponse = (
       authConfigDetails: response.auth_config_details?.map(authConfig => ({
         name: authConfig.name,
         mode: authConfig.mode,
+        ...(authConfig.auth_hint_url !== undefined && {
+          authHintUrl: authConfig.auth_hint_url,
+        }),
         fields: {
-          authConfigCreation: authConfig.fields.auth_config_creation,
-          connectedAccountInitiation: authConfig.fields.connected_account_initiation,
+          authConfigCreation: transformToolkitAuthFieldGroup(
+            authConfig.fields.auth_config_creation
+          ),
+          connectedAccountInitiation: transformToolkitAuthFieldGroup(
+            authConfig.fields.connected_account_initiation
+          ),
         },
         proxy: {
           baseUrl: authConfig.proxy?.base_url,

--- a/ts/packages/core/test/utils/transformers/toolkits.test.ts
+++ b/ts/packages/core/test/utils/transformers/toolkits.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import { transformToolkitRetrieveResponse } from '../../../src/utils/transformers/toolkits';
+
+type RawRetrieveResponse = Parameters<typeof transformToolkitRetrieveResponse>[0];
+
+/**
+ * The API describes every auth form field with an `is_secret` flag ("Clients use
+ * it to decide whether to mask the input"), a `legacy_template_name`, and every
+ * auth method with an `auth_hint_url`. All three are snake_case on the wire, so a
+ * pass-through leaves them under keys the zod schema does not know and validation
+ * strips them.
+ *
+ * Every one of the four field groups is populated here, because the transformer
+ * maps each of them separately.
+ */
+const rawToolkit = {
+  name: 'Shopify',
+  slug: 'shopify',
+  meta: {
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-02T00:00:00Z',
+    tools_count: 12,
+    triggers_count: 3,
+  },
+  is_local_toolkit: false,
+  composio_managed_auth_schemes: ['OAUTH2'],
+  auth_config_details: [
+    {
+      name: 'API Key',
+      mode: 'API_KEY',
+      auth_hint_url: 'https://shopify.dev/api-keys',
+      fields: {
+        auth_config_creation: {
+          required: [
+            {
+              name: 'client_secret',
+              displayName: 'Client Secret',
+              description: 'The app client secret',
+              type: 'string',
+              required: true,
+              is_secret: true,
+              legacy_template_name: 'clientSecret',
+            },
+          ],
+          optional: [
+            {
+              name: 'scopes',
+              displayName: 'Scopes',
+              description: 'Comma separated scopes',
+              type: 'string',
+              required: false,
+              is_secret: false,
+              default: null,
+              legacy_template_name: 'oauthScopes',
+            },
+          ],
+        },
+        connected_account_initiation: {
+          required: [
+            {
+              name: 'api_key',
+              displayName: 'API Key',
+              description: 'Your Shopify API key',
+              type: 'string',
+              required: true,
+              is_secret: true,
+              legacy_template_name: 'apiKey',
+            },
+          ],
+          optional: [
+            {
+              name: 'shop_domain',
+              displayName: 'Shop Domain',
+              description: 'your-store.myshopify.com',
+              type: 'string',
+              required: false,
+              is_secret: false,
+              default: 'example.myshopify.com',
+            },
+          ],
+        },
+      },
+    },
+  ],
+} as unknown as RawRetrieveResponse;
+
+/** Same shape, but the API omits every optional key. */
+const rawToolkitWithoutOptionalKeys = {
+  ...rawToolkit,
+  auth_config_details: [
+    {
+      name: 'Bearer',
+      mode: 'BEARER_TOKEN',
+      fields: {
+        auth_config_creation: { required: [], optional: [] },
+        connected_account_initiation: {
+          required: [
+            {
+              name: 'token',
+              displayName: 'Token',
+              description: 'A bearer token',
+              type: 'string',
+              required: true,
+            },
+          ],
+          optional: [],
+        },
+      },
+    },
+  ],
+} as unknown as RawRetrieveResponse;
+
+const initiationRequired = (raw: RawRetrieveResponse) =>
+  transformToolkitRetrieveResponse(raw).authConfigDetails?.[0].fields.connectedAccountInitiation
+    .required[0];
+
+describe('transformToolkitRetrieveResponse', () => {
+  it('preserves is_secret as isSecret in all four auth field groups', () => {
+    const fields = transformToolkitRetrieveResponse(rawToolkit).authConfigDetails?.[0].fields;
+
+    expect(fields?.authConfigCreation.required[0].isSecret).toBe(true);
+    expect(fields?.authConfigCreation.optional[0].isSecret).toBe(false);
+    expect(fields?.connectedAccountInitiation.required[0].isSecret).toBe(true);
+    expect(fields?.connectedAccountInitiation.optional[0].isSecret).toBe(false);
+  });
+
+  it('preserves legacy_template_name as legacyTemplateName', () => {
+    const fields = transformToolkitRetrieveResponse(rawToolkit).authConfigDetails?.[0].fields;
+
+    expect(fields?.authConfigCreation.required[0].legacyTemplateName).toBe('clientSecret');
+    expect(fields?.authConfigCreation.optional[0].legacyTemplateName).toBe('oauthScopes');
+    expect(fields?.connectedAccountInitiation.required[0].legacyTemplateName).toBe('apiKey');
+  });
+
+  it('maps a whole field without losing or inventing keys', () => {
+    expect(initiationRequired(rawToolkit)).toEqual({
+      name: 'api_key',
+      displayName: 'API Key',
+      description: 'Your Shopify API key',
+      type: 'string',
+      required: true,
+      isSecret: true,
+      legacyTemplateName: 'apiKey',
+    });
+  });
+
+  it('keeps a null default and a false flag rather than dropping them', () => {
+    const field =
+      transformToolkitRetrieveResponse(rawToolkit).authConfigDetails?.[0].fields.authConfigCreation
+        .optional[0];
+
+    expect(field?.default).toBeNull();
+    expect(field?.isSecret).toBe(false);
+  });
+
+  it('maps auth_hint_url to authHintUrl', () => {
+    const details = transformToolkitRetrieveResponse(rawToolkit).authConfigDetails?.[0];
+
+    expect(details?.authHintUrl).toBe('https://shopify.dev/api-keys');
+  });
+
+  /**
+   * `toEqual` treats a missing property and one holding `undefined` as equal, so
+   * these assertions use `toHaveProperty`. Creating the key unconditionally would
+   * override a caller's fallback in `{ default: 'fallback', ...field }`.
+   */
+  it('omits optional keys entirely when the API does not send them', () => {
+    const field = initiationRequired(rawToolkitWithoutOptionalKeys);
+
+    expect(field).not.toHaveProperty('default');
+    expect(field).not.toHaveProperty('isSecret');
+    expect(field).not.toHaveProperty('legacyTemplateName');
+    expect(
+      transformToolkitRetrieveResponse(rawToolkitWithoutOptionalKeys).authConfigDetails?.[0]
+    ).not.toHaveProperty('authHintUrl');
+  });
+
+  it('lets a caller fallback survive spreading a field with no default', () => {
+    const field = initiationRequired(rawToolkitWithoutOptionalKeys);
+
+    expect({ default: 'caller fallback', ...field }.default).toBe('caller fallback');
+  });
+});

--- a/ts/packages/core/type-tests/toolkit-auth-field-mapping.test-d.ts
+++ b/ts/packages/core/type-tests/toolkit-auth-field-mapping.test-d.ts
@@ -1,0 +1,95 @@
+/**
+ * Type-level guard for the toolkit auth field mapping.
+ *
+ * `transformToolkitRetrieveResponse` projects each auth form field key by key.
+ * A key the generated client declares but the projection forgets is dropped
+ * silently: zod removes it while validating, and no runtime test notices unless
+ * someone thought to assert that exact key. That is how `is_secret`,
+ * `legacy_template_name` and `auth_hint_url` were lost.
+ *
+ * What this file does: it fails the build (tsconfig.type-tests.json) when
+ * `@composio/client` declares a key in any of the four field groups, or on the
+ * auth config detail, that is not listed below.
+ *
+ * What it does NOT do: it does not verify that the transformer still assigns
+ * those keys. The lists here are hand-written, so removing an assignment from
+ * the mapper while leaving its key listed stays green at compile time. The
+ * runtime test pins the projection for the keys known today
+ * (`test/utils/transformers/toolkits.test.ts`, "maps a whole field without
+ * losing or inventing keys"); this file covers the keys nobody has seen yet.
+ */
+import type { ToolkitRetrieveResponse as RawToolkitRetrieveResponse } from '@composio/client/resources/toolkits';
+import type { ToolkitAuthField, ToolkitAuthConfigDetails } from '../src';
+
+type RawAuthConfigDetail = NonNullable<RawToolkitRetrieveResponse['auth_config_details']>[number];
+type RawFields = RawAuthConfigDetail['fields'];
+
+/**
+ * The generated client declares each of the four field groups as its own
+ * interface. They are identical today, but a plain `keyof` over their union
+ * would yield only the keys they share, so a key added to one group alone would
+ * slip through. Distributing `keyof` over the union keeps every group covered.
+ */
+type RawAuthField =
+  | RawFields['auth_config_creation']['required'][number]
+  | RawFields['auth_config_creation']['optional'][number]
+  | RawFields['connected_account_initiation']['required'][number]
+  | RawFields['connected_account_initiation']['optional'][number];
+
+type KeysOfUnion<T> = T extends unknown ? keyof T : never;
+
+/** Compile error carrying the offending keys when `Actual` is not empty. */
+type NoneLeftOver<Actual extends PropertyKey> = [Actual] extends [never] ? true : Actual;
+
+/**
+ * Wire keys the transformer deliberately maps onto `ToolkitAuthField`.
+ * Add a key here only together with the mapping and the schema field.
+ */
+type MappedFieldKeys =
+  | 'name'
+  | 'displayName'
+  | 'description'
+  | 'type'
+  | 'required'
+  | 'default'
+  | 'is_secret'
+  | 'legacy_template_name';
+
+const everyFieldKeyIsMapped: NoneLeftOver<Exclude<KeysOfUnion<RawAuthField>, MappedFieldKeys>> =
+  true;
+void everyFieldKeyIsMapped;
+
+/**
+ * Wire keys on the auth config detail. `deprecated_auth_provider_details` is
+ * listed as knowingly skipped: the client marks it `@deprecated` and warns
+ * against further use, so it is excluded on purpose rather than by oversight.
+ */
+type MappedDetailKeys =
+  'name' | 'mode' | 'fields' | 'proxy' | 'auth_hint_url' | 'deprecated_auth_provider_details';
+
+const everyDetailKeyIsMapped: NoneLeftOver<
+  Exclude<KeysOfUnion<RawAuthConfigDetail>, MappedDetailKeys>
+> = true;
+void everyDetailKeyIsMapped;
+
+/** The camelCase counterparts must exist on the public types. */
+type MissingOnField = Exclude<
+  | 'name'
+  | 'displayName'
+  | 'description'
+  | 'type'
+  | 'required'
+  | 'default'
+  | 'isSecret'
+  | 'legacyTemplateName',
+  keyof ToolkitAuthField
+>;
+const fieldTargetsExist: NoneLeftOver<MissingOnField> = true;
+void fieldTargetsExist;
+
+type MissingOnDetail = Exclude<
+  'name' | 'mode' | 'fields' | 'proxy' | 'authHintUrl',
+  keyof ToolkitAuthConfigDetails
+>;
+const detailTargetsExist: NoneLeftOver<MissingOnDetail> = true;
+void detailTargetsExist;


### PR DESCRIPTION
## Summary

`transformToolkitRetrieveResponse` projects `auth_config_details[]` key by key and silently dropped
three keys the pinned client declares. `is_secret` and `legacy_template_name` are snake_case, so zod
stripped them; `auth_hint_url` was never listed.

The API documents `is_secret` as "Clients use it to decide whether to mask the input". Without it a
consumer rendering its own credential form cannot tell an API key from a shop subdomain, so a field holding a secret is not reported as one.

## Changes

- Map auth fields explicitly; add `isSecret`, `legacyTemplateName` and `authHintUrl` to the schemas
- Spread optional keys conditionally, so a key the API omits stays absent rather than `undefined`,
  which would beat a caller's fallback
- Add a runtime test over all four field groups, plus a type-level test that fails the build on an
  unlisted client key in any group. It catches new wire keys, not an assignment removed from the
  mapper; the runtime test pins that for the keys known today
- Add a patch changeset for `@composio/core`

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?

- `pnpm --filter @composio/core test`: 55 files, 1288 passed, 2 expected fail; typecheck and
  `validate:changesets` exit 0
- `pnpm lint:packages`: exit 0 with 54 pre-existing warnings, one in a file this PR touches; no new
  warning on added lines
- The runtime test fails 5 of its 7 cases on `origin/next`; the two green on both are the regression
  guards. The type-level test was checked against all four client interfaces
- Node 24.18.0; `mise.toml` pins 24.17.0, unavailable here, so it was not run under it. Not
  run: the root workspace suite (its `test:toolchain` needs Bun), Docker E2E, the Python suite

## Screenshots (if applicable)

N/A

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed, with the exceptions listed above
- [x] I updated documentation as needed (none needed: the new keys carry TSDoc; the SDK reference is
      generated from unchanged signatures)
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages

## Additional context

Left out on purpose: `user_visible` and `required_scopes`, in the spec but not the pinned client;
`deprecated_auth_provider_details`, which the client marks deprecated; and the keys this transformer
drops outside `auth_config_details`, all pre-existing and adjacent.

An auth config detail that omits a field group, which the client declares as required, now yields
empty lists for that group instead of failing validation, matching how this repo's docs pipeline
defaults them (`docs/lib/toolkit-api.ts`). The other group stays usable, which is typically the one
the caller asked for.
