### PR TITLE
fix(docs): hide deprecated fields only in API playground

### DIFF
--- a/docs/components/api-page.tsx
+++ b/docs/components/api-page.tsx
@@ -1,13 +1,22 @@
 'use client';
 
-import { createElement, type FC, type ReactNode } from 'react';
-import { createOpenAPIPage } from 'fumadocs-openapi/ui';
+import {
+  createContext, createElement, use, useEffect, useEffectEvent, useMemo,
+  type FC, type ReactNode,
+} from 'react';
+import {
+  createOpenAPIPage, useOperationContext, useServerContext, type APIPlaygroundProps,
+} from 'fumadocs-openapi/ui';
+import { hideDeprecatedFields } from '@/lib/openapi-deprecated';
 import { generateSchemaData } from './schema-generator';
 import { CustomSchemaUI } from './custom-schema-ui';
 
 export const APIPage = createOpenAPIPage({
   generateTypeScriptDefinitions: false,
-  playground: { enabled: true },
+  playground: {
+    enabled: true,
+    render: (props) => <DeprecatedFieldsPlayground {...props} />,
+  },
   schemaUI: {
     render: (options, ctx) => {
       const client = (
@@ -53,6 +62,61 @@ export const APIPage = createOpenAPIPage({
     },
   },
 });
+
+// A separate page context keeps filtered schemas and initial request examples
+// inside the playground. The surrounding reference uses the complete contract.
+const PlaygroundSyncContext = createContext<{
+  operation: ReturnType<typeof useOperationContext>;
+  server: ReturnType<typeof useServerContext>;
+} | null>(null);
+
+function PlaygroundSync({ children }: { children: ReactNode }) {
+  const parent = use(PlaygroundSyncContext)!;
+  const { example, setExample, addListener, removeListener } = useOperationContext();
+  const { server } = useServerContext();
+  useEffect(() => {
+    if (parent.operation.example && parent.operation.example !== example)
+      setExample(parent.operation.example);
+  }, [parent.operation.example, example, setExample]);
+  useEffect(() => {
+    const listener = parent.operation.setExampleData;
+    addListener(listener);
+    return () => removeListener(listener);
+  }, [addListener, removeListener, parent.operation.setExampleData]);
+  const syncServer = useEffectEvent(() => {
+    if (!server) return;
+    parent.server.setServer(server.url);
+    parent.server.setServerVariables(server.variables);
+  });
+  useEffect(() => {
+    syncServer();
+  }, [server]);
+  return children;
+}
+
+const PlaygroundPage = createOpenAPIPage({
+  generateTypeScriptDefinitions: false,
+  content: {
+    renderOperationLayout: ({ apiPlayground }) => <PlaygroundSync>{apiPlayground}</PlaygroundSync>,
+  },
+});
+
+function DeprecatedFieldsPlayground({ path, method, ctx }: APIPlaygroundProps) {
+  const operation = useOperationContext();
+  const server = useServerContext();
+  const bundled = useMemo(
+    () => hideDeprecatedFields(ctx.schema.bundled),
+    [ctx.schema.bundled]
+  );
+  return (
+    <PlaygroundSyncContext value={{ operation, server }}>
+      <PlaygroundPage
+        payload={{ bundled, proxyUrl: ctx.proxyUrl }}
+        operations={[{ path, method }]}
+      />
+    </PlaygroundSyncContext>
+  );
+}
 
 function getRawRef(value: object): string | undefined {
   if (!('$ref' in value)) return undefined;

--- a/docs/lib/openapi-deprecated.ts
+++ b/docs/lib/openapi-deprecated.ts
@@ -33,7 +33,7 @@ const SCHEMA_CHILDREN = new Set([
   'unevaluatedProperties',
 ]);
 
-/** Filter only the copy used by the docs; keep the published API contract intact. */
+/** Filter only the playground copy; keep the reference and published contract intact. */
 export function hideDeprecatedFields<T extends object>(input: T): T {
   const document = structuredClone(input);
   function object(value: unknown) {

--- a/docs/lib/openapi-deprecated.ts
+++ b/docs/lib/openapi-deprecated.ts
@@ -1,0 +1,186 @@
+import { z } from 'zod';
+
+const ObjectSchema = z.record(z.string(), z.unknown());
+const Schema = z
+  .object({
+    $ref: z.string().optional(),
+    deprecated: z.boolean().optional(),
+    properties: z.record(z.string(), z.unknown()).optional(),
+    required: z.array(z.string()).optional(),
+  })
+  .loose();
+
+// These are payloads, not schemas. In particular, a payload may legitimately
+// contain properties named "deprecated" or "properties".
+const PAYLOAD_KEYS = new Set(['default', 'example', 'examples', 'enum', 'const']);
+const SCHEMA_MAPS = new Set([
+  'properties',
+  'patternProperties',
+  '$defs',
+  'definitions',
+  'dependentSchemas',
+]);
+const SCHEMA_LISTS = new Set(['allOf', 'anyOf', 'oneOf', 'prefixItems']);
+const SCHEMA_CHILDREN = new Set([
+  'items',
+  'additionalProperties',
+  'contains',
+  'not',
+  'if',
+  'then',
+  'else',
+  'propertyNames',
+  'unevaluatedProperties',
+]);
+
+/** Filter only the copy used by the docs; keep the published API contract intact. */
+export function hideDeprecatedFields<T extends object>(input: T): T {
+  const document = structuredClone(input);
+  function object(value: unknown) {
+    const parsed = ObjectSchema.safeParse(value);
+    if (!parsed.success) return undefined;
+    return parsed.data;
+  }
+
+  function resolvePointer(ref: string): unknown {
+    if (!ref.startsWith('#/')) return undefined;
+    let value: unknown = input;
+    for (const part of ref.slice(2).split('/')) {
+      value = object(value)?.[decodeURIComponent(part).replace(/~1/g, '/').replace(/~0/g, '~')];
+    }
+    return value;
+  }
+
+  function resolve(value: unknown, seen = new Set<string>()): z.infer<typeof Schema> | undefined {
+    const parsed = Schema.safeParse(value);
+    if (!parsed.success) return undefined;
+    const schema = parsed.data;
+    if (!schema.$ref || seen.has(schema.$ref)) return schema;
+    seen.add(schema.$ref);
+    return { ...resolve(resolvePointer(schema.$ref), seen), ...schema };
+  }
+
+  function schemaVariants(value: unknown, seen = new Set<unknown>()): z.infer<typeof Schema>[] {
+    if (seen.has(value)) return [];
+    seen.add(value);
+    const schema = resolve(value);
+    if (!schema) return [];
+    return [
+      schema,
+      ...['allOf', 'anyOf', 'oneOf'].flatMap(key => {
+        const variants = schema[key];
+        return Array.isArray(variants) ? variants.flatMap(item => schemaVariants(item, seen)) : [];
+      }),
+    ];
+  }
+
+  function properties(value: unknown) {
+    const result = new Map<string, unknown[]>();
+    for (const schema of schemaVariants(value)) {
+      for (const [name, child] of Object.entries(schema.properties ?? {})) {
+        result.set(name, [...(result.get(name) ?? []), child]);
+      }
+    }
+    return result;
+  }
+
+  const allDeprecated = (schemas: unknown[]) =>
+    schemas.every(schema => resolve(schema)?.deprecated === true);
+
+  // Inspect the original schemas, which still contain the deprecation flags.
+  // If a union also defines a current field with this name, preserve its value.
+  function cleanValue(value: unknown, rawSchema: unknown): unknown {
+    if (Array.isArray(value)) {
+      const items = schemaVariants(rawSchema)
+        .map(schema => schema.items)
+        .filter(item => item !== undefined);
+      return value.map(item => cleanValue(item, { allOf: items }));
+    }
+    const record = object(value);
+    if (!record) return value;
+    for (const [name, children] of properties(rawSchema)) {
+      if (allDeprecated(children)) delete record[name];
+      else if (Object.hasOwn(record, name))
+        record[name] = cleanValue(record[name], { allOf: children });
+    }
+    return record;
+  }
+
+  function filterSchema(value: unknown): unknown {
+    const parsed = Schema.safeParse(value);
+    if (!parsed.success) return value; // Boolean schemas are valid in OpenAPI 3.1.
+    const schema = parsed.data;
+    if (schema.properties) {
+      const hidden = new Set(
+        Object.entries(schema.properties)
+          .filter(([, child]) => resolve(child)?.deprecated === true)
+          .map(([name]) => name)
+      );
+      schema.properties = Object.fromEntries(
+        Object.entries(schema.properties)
+          .filter(([name]) => !hidden.has(name))
+          .map(([name, child]) => [name, filterSchema(child)])
+      );
+    }
+    if (schema.required) {
+      const fields = properties(value);
+      schema.required = schema.required.filter(name => {
+        const definitions = fields.get(name);
+        return !definitions || !allDeprecated(definitions);
+      });
+    }
+    for (const [key, child] of Object.entries(schema)) {
+      if (key === 'default' || key === 'example') schema[key] = cleanValue(child, value);
+      else if (key === 'examples' && Array.isArray(child))
+        schema[key] = child.map(item => cleanValue(item, value));
+      else if (key !== 'properties' && SCHEMA_MAPS.has(key)) {
+        const map = object(child);
+        if (map)
+          schema[key] = Object.fromEntries(
+            Object.entries(map).map(([name, item]) => [name, filterSchema(item)])
+          );
+      } else if (SCHEMA_LISTS.has(key) && Array.isArray(child))
+        schema[key] = child.map(filterSchema);
+      else if (SCHEMA_CHILDREN.has(key)) schema[key] = filterSchema(child);
+    }
+    return schema;
+  }
+
+  function walk(value: unknown, key = ''): unknown {
+    if (Array.isArray(value)) return value.map(item => walk(item));
+    const record = object(value);
+    if (!record) return value;
+    for (const [name, child] of Object.entries(record)) {
+      if (name === 'schema') record[name] = filterSchema(child);
+      else if (key === 'components' && name === 'schemas') {
+        const schemas = object(child);
+        if (schemas)
+          record[name] = Object.fromEntries(
+            Object.entries(schemas).map(([id, schema]) => [id, filterSchema(schema)])
+          );
+      } else if (!PAYLOAD_KEYS.has(name) && !name.startsWith('x-'))
+        record[name] = walk(child, name);
+    }
+    if (record.schema) {
+      if (Object.hasOwn(record, 'example'))
+        record.example = cleanValue(record.example, object(value)?.schema);
+      const examples = object(record.examples);
+      if (examples) {
+        record.examples = Object.fromEntries(
+          Object.entries(examples).map(([name, entry]) => {
+            const example = resolve(entry);
+            if (example && Object.hasOwn(example, 'value')) {
+              example.value = cleanValue(example.value, object(value)?.schema);
+              delete example.$ref; // Inline this usage so shared examples remain unchanged.
+            }
+            return [name, example ?? entry];
+          })
+        );
+      }
+    }
+    return record;
+  }
+
+  Object.assign(document, walk(document));
+  return document;
+}

--- a/docs/lib/openapi.ts
+++ b/docs/lib/openapi.ts
@@ -1,6 +1,5 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'path';
-import { hideDeprecatedFields } from './openapi-deprecated';
 import { createOpenAPI } from 'fumadocs-openapi/server';
 import { declareOperationTags, type OpenAPIDocument } from './openapi-tags';
 
@@ -35,7 +34,7 @@ export const openapiV3 = createOpenAPI({
 
 async function loadOpenAPISchema(path: string) {
   const document = JSON.parse(await readFile(path, 'utf8')) as OpenAPIDocument;
-  return declareOperationTags(normalizeNoAuthSecurity(hideDeprecatedFields(document)));
+  return declareOperationTags(normalizeNoAuthSecurity(document));
 }
 
 export function normalizeNoAuthSecurity<T extends OpenAPIDocument>(document: T): T {

--- a/docs/lib/openapi.ts
+++ b/docs/lib/openapi.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'path';
+import { hideDeprecatedFields } from './openapi-deprecated';
 import { createOpenAPI } from 'fumadocs-openapi/server';
 import { declareOperationTags, type OpenAPIDocument } from './openapi-tags';
 
@@ -34,7 +35,7 @@ export const openapiV3 = createOpenAPI({
 
 async function loadOpenAPISchema(path: string) {
   const document = JSON.parse(await readFile(path, 'utf8')) as OpenAPIDocument;
-  return declareOperationTags(normalizeNoAuthSecurity(document));
+  return declareOperationTags(normalizeNoAuthSecurity(hideDeprecatedFields(document)));
 }
 
 export function normalizeNoAuthSecurity<T extends OpenAPIDocument>(document: T): T {

--- a/docs/tests/static/openapi-deprecated.test.ts
+++ b/docs/tests/static/openapi-deprecated.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { hideDeprecatedFields } from '../../lib/openapi-deprecated';
 import { openapi, openapiV3 } from '../../lib/openapi';
 
-describe('docs OpenAPI deprecation filter', () => {
+describe('playground OpenAPI deprecation filter', () => {
   test('removes fields and their values while preserving the source and legacy operations', () => {
     const schema = {
       type: 'object',
@@ -144,19 +144,24 @@ describe('docs OpenAPI deprecation filter', () => {
     expect(hideDeprecatedFields(source)).toEqual(source);
   });
 
-  test('filters the actual documents consumed by both schema UI and playground', async () => {
+  test('keeps deprecated reference fields and filters only the playground copy', async () => {
     for (const server of [openapi, openapiV3]) {
       const schemas = await server.getSchemas();
       for (const [path, { bundled }] of Object.entries(schemas)) {
         if (path.endsWith('openapi-webhooks.json')) continue;
-        const managed = bundled.components?.schemas?.ComposioManagedAuthConfigCreate;
+        const original = structuredClone(bundled);
+        const reference = bundled.components?.schemas?.ComposioManagedAuthConfigCreate;
+        expect(reference).toHaveProperty('properties.tool_access_config');
+        expect(reference).toHaveProperty('properties.restrict_to_following_tools');
+        const playground = hideDeprecatedFields(bundled);
+        const managed = playground.components?.schemas?.ComposioManagedAuthConfigCreate;
         expect(managed).toHaveProperty('properties.credentials');
         expect(managed).not.toHaveProperty('properties.tool_access_config');
         expect(managed).not.toHaveProperty('properties.restrict_to_following_tools');
-        expect(bundled.components?.schemas?.CustomAuthConfigCreate).not.toHaveProperty(
+        expect(playground.components?.schemas?.CustomAuthConfigCreate).not.toHaveProperty(
           'properties.tool_access_config'
         );
-        const operation = Object.values(bundled.paths ?? {})
+        const operation = Object.values(playground.paths ?? {})
           .flatMap(item => item?.post ?? [])
           .find(
             item =>
@@ -164,6 +169,7 @@ describe('docs OpenAPI deprecation filter', () => {
           );
         expect(operation).toBeDefined();
         expect(JSON.stringify(operation?.requestBody)).not.toContain('restrict_to_following_tools');
+        expect(bundled).toEqual(original);
       }
     }
     // The downloadable contract remains complete on disk.

--- a/docs/tests/static/openapi-deprecated.test.ts
+++ b/docs/tests/static/openapi-deprecated.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { hideDeprecatedFields } from '../../lib/openapi-deprecated';
+import { openapi, openapiV3 } from '../../lib/openapi';
+
+describe('docs OpenAPI deprecation filter', () => {
+  test('removes fields and their values while preserving the source and legacy operations', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        current: { type: 'string' },
+        old: { deprecated: true },
+        nested: { type: 'array', items: { properties: { old: { deprecated: true }, keep: {} } } },
+        metadata: { type: 'object', additionalProperties: true },
+      },
+      required: ['current', 'old'],
+      default: {
+        current: 'yes',
+        old: 'no',
+        nested: [{ old: 1, keep: 2 }],
+        metadata: { deprecated: true },
+      },
+    };
+    const source = {
+      paths: {
+        '/test': {
+          post: {
+            deprecated: true,
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema,
+                  example: schema.default,
+                  examples: { named: { value: schema.default } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const original = structuredClone(source);
+    const result = hideDeprecatedFields(source);
+    const media = result.paths['/test'].post.requestBody.content['application/json'];
+    const expected = { current: 'yes', nested: [{ keep: 2 }], metadata: { deprecated: true } };
+    expect(media.schema.properties).not.toHaveProperty('old');
+    expect(media.schema.required).toEqual(['current']);
+    expect(media.schema.default).toEqual(expected);
+    expect(media.example).toEqual(expected);
+    expect(media.examples.named.value).toEqual(expected);
+    expect(result.paths['/test'].post.deprecated).toBe(true);
+    expect(source).toEqual(original);
+    expect(hideDeprecatedFields(result)).toEqual(result);
+  });
+
+  test('handles references, aliases, compositions, recursion and boolean schemas', () => {
+    const source = {
+      components: {
+        schemas: {
+          'Old/Field': { deprecated: true },
+          Alias: { $ref: '#/components/schemas/Old~1Field' },
+          Recursive: {
+            properties: {
+              old: { deprecated: true },
+              next: { $ref: '#/components/schemas/Recursive' },
+            },
+          },
+          Composed: {
+            allOf: [{ properties: { old: { deprecated: true }, keep: true }, required: ['old'] }],
+          },
+          Root: {
+            properties: {
+              alias: { $ref: '#/components/schemas/Alias' },
+              retained: { $ref: '#/components/schemas/Alias', deprecated: false },
+              recursive: { $ref: '#/components/schemas/Recursive' },
+              external: { $ref: 'https://example.com/schema.json' },
+              boolean: true,
+            },
+            default: { alias: 1, retained: 2, recursive: { old: 1, next: { old: 2 } } },
+          },
+        },
+      },
+    };
+    const result = hideDeprecatedFields(source).components.schemas;
+    expect(result.Root.properties).not.toHaveProperty('alias');
+    expect(result.Root.properties.retained).toEqual(
+      source.components.schemas.Root.properties.retained
+    );
+    expect(result.Root.properties.external).toEqual(
+      source.components.schemas.Root.properties.external
+    );
+    expect(result.Root.properties.boolean).toBe(true);
+    expect(result.Root.default).toEqual({ retained: 2, recursive: { next: {} } });
+    expect(result.Recursive.properties).not.toHaveProperty('old');
+    expect(result.Composed.allOf[0].properties).toEqual({ keep: true });
+    expect(result.Composed.allOf[0].required).toEqual([]);
+  });
+
+  test('cleans composed requirements and referenced examples without deleting current union fields', () => {
+    const source = {
+      components: { examples: { shared: { value: { old: 1, keep: 2 } } } },
+      paths: {
+        '/test': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    allOf: [{ properties: { old: { deprecated: true }, keep: {} } }],
+                    required: ['old', 'keep'],
+                  },
+                  examples: { sample: { $ref: '#/components/examples/shared' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const result = hideDeprecatedFields(source);
+    const media = result.paths['/test'].post.requestBody.content['application/json'];
+    expect(media.schema.required).toEqual(['keep']);
+    expect(media.examples.sample).toEqual({ value: { keep: 2 } });
+    expect(result.components.examples.shared.value).toEqual({ old: 1, keep: 2 });
+    const union = {
+      components: {
+        schemas: {
+          Union: {
+            oneOf: [{ properties: { field: { deprecated: true } } }, { properties: { field: {} } }],
+            default: { field: 'still supported' },
+          },
+        },
+      },
+    };
+    expect(hideDeprecatedFields(union).components.schemas.Union.default).toEqual({
+      field: 'still supported',
+    });
+  });
+
+  test('does not treat examples or extension values as schema definitions', () => {
+    const payload = { schema: { properties: { old: { deprecated: true } } } };
+    const source = { example: payload, 'x-custom': payload };
+    expect(hideDeprecatedFields(source)).toEqual(source);
+  });
+
+  test('filters the actual documents consumed by both schema UI and playground', async () => {
+    for (const server of [openapi, openapiV3]) {
+      const schemas = await server.getSchemas();
+      for (const [path, { bundled }] of Object.entries(schemas)) {
+        if (path.endsWith('openapi-webhooks.json')) continue;
+        const managed = bundled.components?.schemas?.ComposioManagedAuthConfigCreate;
+        expect(managed).toHaveProperty('properties.credentials');
+        expect(managed).not.toHaveProperty('properties.tool_access_config');
+        expect(managed).not.toHaveProperty('properties.restrict_to_following_tools');
+        expect(bundled.components?.schemas?.CustomAuthConfigCreate).not.toHaveProperty(
+          'properties.tool_access_config'
+        );
+        const operation = Object.values(bundled.paths ?? {})
+          .flatMap(item => item?.post ?? [])
+          .find(
+            item =>
+              item.operationId === 'postAuthConfigs' || item.operationId === 'postApiV3AuthConfigs'
+          );
+        expect(operation).toBeDefined();
+        expect(JSON.stringify(operation?.requestBody)).not.toContain('restrict_to_following_tools');
+      }
+    }
+    // The downloadable contract remains complete on disk.
+    expect(readFileSync(join(process.cwd(), 'public/openapi.json'), 'utf8')).toContain(
+      '"restrict_to_following_tools"'
+    );
+  });
+});


### PR DESCRIPTION
Deprecated API fields clutter the interactive playground at the top of reference pages. Hide those inputs while retaining their descriptions, deprecation badges, defaults, and response examples in the reference below.

Filter a cloned schema only inside the playground renderer. Keep the shared OpenAPI loader unchanged and preserve synchronization between playground edits, example selection, server selection, and generated request code. Published OpenAPI files remain unchanged.

Validation: all 547 docs static tests pass, `bun run types:check` passes, and `bun run lint` passes with existing warnings. Browser checks on Create auth config confirm both auth variants omit deprecated inputs, the JSON editor omits deprecated values, reference descriptions and badges remain, and edits update the cURL example.

Fixes DEVREL-51.
