### PR TITLE
fix(sdk): run typedoc without a shell in generate-docs (SEC-899)

### DIFF
--- a/ts/packages/core/scripts/generate-docs.ts
+++ b/ts/packages/core/scripts/generate-docs.ts
@@ -19,6 +19,11 @@ const PACKAGE_DIR = join(SCRIPT_DIR, '..');
 const MODELS_DIR = join(PACKAGE_DIR, 'src/models');
 const OUTPUT_DIR = join(PACKAGE_DIR, '../../../docs/content/reference/sdk-reference/typescript');
 const TEMP_JSON = join(PACKAGE_DIR, '.typedoc-output.json');
+const TYPEDOC_BIN = join(
+  dirname(fileURLToPath(import.meta.resolve('typedoc/package.json'))),
+  'bin',
+  'typedoc'
+);
 
 // Internal classes that should NOT be documented (accessed via other APIs)
 const INTERNAL_CLASSES = new Set([
@@ -75,14 +80,13 @@ export async function discoverModelFiles(modelsDir: string = MODELS_DIR): Promis
     .map(f => `src/models/${f}`);
 }
 
-// Argument vector for `npx typedoc`, one array element per argument so the
-// entry points are never joined into a shell command line.
-export function buildTypeDocArgs(
+// TypeDoc arguments, one array element per argument so the entry points are
+// never joined into a shell command line.
+function buildTypeDocArgs(
   entryPoints: readonly string[],
   outputJson: string = TEMP_JSON
 ): string[] {
   return [
-    'typedoc',
     '--json',
     outputJson,
     '--tsconfig',
@@ -93,6 +97,26 @@ export function buildTypeDocArgs(
     '--skipErrorChecking', // Skip TS errors, we just want the documentation
     ...entryPoints,
   ];
+}
+
+interface TypeDocCommandOptions {
+  outputJson?: string;
+  packageDir?: string;
+  typedocBin?: string;
+}
+
+export function runTypeDocCommand(
+  entryPoints: readonly string[],
+  {
+    outputJson = TEMP_JSON,
+    packageDir = PACKAGE_DIR,
+    typedocBin = TYPEDOC_BIN,
+  }: TypeDocCommandOptions = {}
+): void {
+  execFileSync(process.execPath, [typedocBin, ...buildTypeDocArgs(entryPoints, outputJson)], {
+    stdio: 'pipe',
+    cwd: packageDir,
+  });
 }
 
 // Discover classes to document from TypeDoc output
@@ -1165,7 +1189,7 @@ async function runTypeDoc(): Promise<TypeDocProject> {
   console.log(`  Found ${entryPoints.length} entry points`);
 
   try {
-    execFileSync('npx', buildTypeDocArgs(entryPoints), { stdio: 'pipe', cwd: PACKAGE_DIR });
+    runTypeDocCommand(entryPoints);
   } catch (error) {
     console.error('TypeDoc failed:', error);
     throw error;

--- a/ts/packages/core/scripts/generate-docs.ts
+++ b/ts/packages/core/scripts/generate-docs.ts
@@ -10,7 +10,7 @@
 import { readFileSync } from 'fs';
 import { mkdir, writeFile, rm, readdir, readFile } from 'fs/promises';
 import { join, dirname, resolve } from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 // Paths (relative to ts/packages/core)
@@ -55,12 +55,44 @@ function slugFor(className: string): string {
   return SLUG_OVERRIDES[className] ?? toKebabCase(className);
 }
 
+// Model file names become typedoc arguments. They are never interpolated into a
+// shell, but a name outside this charset is still not a model and is skipped
+// rather than passed through.
+const MODEL_FILE_NAME = /^[A-Za-z0-9_.-]+\.ts$/;
+
 // Discover model files automatically
-async function discoverModelFiles(): Promise<string[]> {
-  const files = await readdir(MODELS_DIR);
+export async function discoverModelFiles(modelsDir: string = MODELS_DIR): Promise<string[]> {
+  const files = await readdir(modelsDir);
   return files
     .filter(f => f.endsWith('.ts') && !f.includes('.test.') && !f.includes('.spec.'))
+    .filter(f => {
+      if (MODEL_FILE_NAME.test(f)) {
+        return true;
+      }
+      console.warn(`  Skipping model file with an unexpected name: ${JSON.stringify(f)}`);
+      return false;
+    })
     .map(f => `src/models/${f}`);
+}
+
+// Argument vector for `npx typedoc`, one array element per argument so the
+// entry points are never joined into a shell command line.
+export function buildTypeDocArgs(
+  entryPoints: readonly string[],
+  outputJson: string = TEMP_JSON
+): string[] {
+  return [
+    'typedoc',
+    '--json',
+    outputJson,
+    '--tsconfig',
+    'tsconfig.json',
+    '--excludePrivate',
+    '--excludeProtected',
+    '--excludeInternal',
+    '--skipErrorChecking', // Skip TS errors, we just want the documentation
+    ...entryPoints,
+  ];
 }
 
 // Discover classes to document from TypeDoc output
@@ -1132,21 +1164,8 @@ async function runTypeDoc(): Promise<TypeDocProject> {
 
   console.log(`  Found ${entryPoints.length} entry points`);
 
-  const cmd = [
-    'npx typedoc',
-    '--json',
-    TEMP_JSON,
-    '--tsconfig',
-    'tsconfig.json',
-    '--excludePrivate',
-    '--excludeProtected',
-    '--excludeInternal',
-    '--skipErrorChecking', // Skip TS errors, we just want the documentation
-    ...entryPoints,
-  ].join(' ');
-
   try {
-    execSync(cmd, { stdio: 'pipe', cwd: PACKAGE_DIR });
+    execFileSync('npx', buildTypeDocArgs(entryPoints), { stdio: 'pipe', cwd: PACKAGE_DIR });
   } catch (error) {
     console.error('TypeDoc failed:', error);
     throw error;

--- a/ts/packages/core/test/scripts/generate-docs.test.ts
+++ b/ts/packages/core/test/scripts/generate-docs.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  buildTypeDocArgs,
+  discoverModelFiles,
   escapeTextForMdx,
   escapeTypeForMdx,
   parseSourceSignatureTypesAtLine,
@@ -117,5 +122,46 @@ class Example {
     expect(signature?.parameters.get('fn')).toBe('(event: TriggerEvent) => void');
     expect(signature?.parameters.get('filters')).toBe('TriggerSubscribeParams');
     expect(signature?.returnType).toBe('void');
+  });
+});
+
+describe('generate-docs command construction', () => {
+  let modelsDir: string;
+
+  beforeEach(async () => {
+    modelsDir = await mkdtemp(join(tmpdir(), 'composio-generate-docs-'));
+  });
+
+  afterEach(async () => {
+    await rm(modelsDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('keeps only plainly named model files and drops shell metacharacter names', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    for (const name of [
+      'Files.ts',
+      'tool_router.ts',
+      'x;touch pwned.ts',
+      '$(id).ts',
+      'a b.ts',
+      'Files.test.ts',
+      'notes.md',
+    ]) {
+      await writeFile(join(modelsDir, name), '');
+    }
+
+    const discovered = await discoverModelFiles(modelsDir);
+
+    expect(discovered.sort()).toEqual(['src/models/Files.ts', 'src/models/tool_router.ts']);
+  });
+
+  it('passes every entry point as its own argument instead of a joined command line', () => {
+    const args = buildTypeDocArgs(['src/composio.ts', 'src/models/a b.ts'], '/tmp/out.json');
+
+    expect(args[0]).toBe('typedoc');
+    expect(args).toContain('src/models/a b.ts');
+    expect(args.some(arg => arg.includes(' typedoc') || arg.includes('npx'))).toBe(false);
+    expect(args.slice(-2)).toEqual(['src/composio.ts', 'src/models/a b.ts']);
   });
 });

--- a/ts/packages/core/test/scripts/generate-docs.test.ts
+++ b/ts/packages/core/test/scripts/generate-docs.test.ts
@@ -1,13 +1,13 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  buildTypeDocArgs,
   discoverModelFiles,
   escapeTextForMdx,
   escapeTypeForMdx,
   parseSourceSignatureTypesAtLine,
+  runTypeDocCommand,
   simplifyTypeForSignature,
   simplifyTypeForTable,
 } from '../../scripts/generate-docs';
@@ -156,12 +156,28 @@ describe('generate-docs command construction', () => {
     expect(discovered.sort()).toEqual(['src/models/Files.ts', 'src/models/tool_router.ts']);
   });
 
-  it('passes every entry point as its own argument instead of a joined command line', () => {
-    const args = buildTypeDocArgs(['src/composio.ts', 'src/models/a b.ts'], '/tmp/out.json');
+  it('runs TypeDoc with Node and passes every entry point as its own argument', async () => {
+    const typedocBin = join(modelsDir, 'typedoc');
+    const outputJson = join(modelsDir, 'typedoc-args.txt');
+    await writeFile(
+      typedocBin,
+      `const { writeFileSync } = require('node:fs');
+const args = process.argv.slice(2);
+const outputJson = args[args.indexOf('--json') + 1];
+writeFileSync(outputJson, args.join('\\n'));
+`
+    );
 
-    expect(args[0]).toBe('typedoc');
+    runTypeDocCommand(['src/composio.ts', 'src/models/a b.ts'], {
+      outputJson,
+      packageDir: modelsDir,
+      typedocBin,
+    });
+
+    const args = (await readFile(outputJson, 'utf8')).split('\n');
+    expect(args[0]).toBe('--json');
     expect(args).toContain('src/models/a b.ts');
-    expect(args.some(arg => arg.includes(' typedoc') || arg.includes('npx'))).toBe(false);
+    expect(args.some(arg => arg.includes('npx'))).toBe(false);
     expect(args.slice(-2)).toEqual(['src/composio.ts', 'src/models/a b.ts']);
   });
 });


### PR DESCRIPTION
## Summary
`ts/packages/core/scripts/generate-docs.ts` joined `npx typedoc` and every discovered `src/models/*.ts` file name into one string and ran it with `execSync`, so a model file whose name contains shell metacharacters would execute as a command. The script runs in CI on every push to `next` with a write-scoped app token (`generate-sdk-docs.yml`). Reported by AppSecure as SEC-899 (command injection via documentation generation).

Fixes SEC-899 (internal tracker).

## Changes
- Build the typedoc argument vector as an array (`buildTypeDocArgs`) and run it with `execFileSync`, so no shell is involved.
- Skip model files whose names fall outside `[A-Za-z0-9_.-]` (with a warning) in `discoverModelFiles`.
- Regression tests in `test/scripts/generate-docs.test.ts`: metacharacter names are dropped, entry points stay separate arguments.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
```
pnpm --filter @composio/core exec vitest run test/scripts/generate-docs.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)
pnpm exec prettier --check ts/packages/core/scripts/generate-docs.ts ts/packages/core/test/scripts/generate-docs.test.ts
All matched files use Prettier code style!
```
Node 24.17.0 and pnpm 11.8.0 via mise.

## Screenshots (if applicable)

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages (not needed: `scripts/` is a build-time script, not part of the published package)

## Additional context
The generated docs output is unchanged; only how typedoc is invoked changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
