### PR TITLE
fix(cli): cap remote file downloads in tool uploads (SEC-908)

### DIFF
--- a/.changeset/read-response-body-export.md
+++ b/.changeset/read-response-body-export.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Export `readResponseBodyWithLimit` and `MAX_URL_UPLOAD_SIZE_BYTES` so downstream packages can apply the SDK's 100 MiB cap when they download a file from a user-supplied URL. The CLI's tool-input file uploads now use it instead of buffering the whole response.

--- a/ts/packages/cli/src/services/tool-file-uploads.ts
+++ b/ts/packages/cli/src/services/tool-file-uploads.ts
@@ -6,7 +6,7 @@
 import type * as FileSystem from '@effect/platform/FileSystem';
 import type * as Path from '@effect/platform/Path';
 import type { Composio as RawComposioClient } from '@composio/client';
-import { assertSafeFileUploadPath } from '@composio/core';
+import { assertSafeFileUploadPath, readResponseBodyWithLimit } from '@composio/core';
 import { ssrfSafeFetch } from '@composio/core/utils/ssrf-guard';
 import { Cause, Data, Effect, Exit, Predicate } from 'effect';
 import { guessToolkitFromToolSlug } from 'src/utils/toolkit-from-tool-slug';
@@ -155,7 +155,10 @@ const readFileFromUrl = async (path: Path.Path, url: string) => {
     });
   }
 
-  const bytes = new Uint8Array(await response.arrayBuffer());
+  // Same cap as the core SDK's URL uploads: a remote server must not be able
+  // to exhaust memory with an oversized or never-ending body. Copied into a
+  // fresh ArrayBuffer-backed view for the same reason as readFileFromDisk.
+  const bytes = new Uint8Array(await readResponseBodyWithLimit(response));
   const parsedUrl = new URL(url);
   const fileName = path.basename(parsedUrl.pathname) || `file-${Date.now()}`;
 

--- a/ts/packages/cli/test/src/services/tool-file-uploads.test.ts
+++ b/ts/packages/cli/test/src/services/tool-file-uploads.test.ts
@@ -11,6 +11,7 @@ import { Composio as RawComposioClient } from '@composio/client';
 import {
   ComposioBlockedInternalUrlError,
   ComposioSensitiveFilePathBlockedError,
+  MAX_URL_UPLOAD_SIZE_BYTES,
 } from '@composio/core';
 import { schemaHasFileUploadable, uploadToolInputFiles } from 'src/services/tool-file-uploads';
 
@@ -234,5 +235,48 @@ describe('uploadToolInputFiles — URL SSRF boundary', () => {
       Effect.provide(Layer.mergeAll(BunFileSystem.layer, BunPath.layer)),
       Effect.ensuring(Effect.sync(() => rmSync(root, { recursive: true, force: true })))
     );
+  });
+});
+
+describe('uploadToolInputFiles — URL download size cap', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it.effect('rejects a remote file that declares a body above the cap before buffering it', () => {
+    const createPresignedURL = vi.fn();
+    const client = makeClient(createPresignedURL);
+    const oversized = String(MAX_URL_UPLOAD_SIZE_BYTES + 1);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response('not the real body', {
+            status: 200,
+            headers: { 'content-length': oversized, 'content-type': 'application/octet-stream' },
+          })
+      )
+    );
+
+    return Effect.gen(function* () {
+      const fsApi = yield* FileSystem.FileSystem;
+      const pathApi = yield* Path.Path;
+
+      yield* Effect.promise(() =>
+        expect(
+          uploadToolInputFiles({
+            fs: fsApi,
+            path: pathApi,
+            toolSlug: 'GMAIL_SEND_EMAIL',
+            arguments_: { attachment: 'https://1.1.1.1/large.bin' },
+            inputSchema,
+            client,
+          })
+        ).rejects.toThrow(/exceeds maximum allowed size/)
+      );
+
+      expect(createPresignedURL).not.toHaveBeenCalled();
+    }).pipe(Effect.provide(Layer.mergeAll(BunFileSystem.layer, BunPath.layer)));
   });
 });

--- a/ts/packages/core/src/index.ts
+++ b/ts/packages/core/src/index.ts
@@ -33,6 +33,10 @@ export {
   isBlockedSensitiveFileUploadPath,
   BUILTIN_FILE_UPLOAD_PATH_DENY_SEGMENTS,
 } from './utils/sensitiveFileUploadPaths';
+// Bounded response reader for files fetched from user-supplied URLs. Exported
+// for the same reason as the denylist guard above: downstream packages read
+// remote files too, and every such read must enforce the same size cap.
+export { readResponseBodyWithLimit, MAX_URL_UPLOAD_SIZE_BYTES } from './utils/readResponseBody';
 export {
   sanitizeSchemaPropertyKeys,
   restoreOriginalKeys,


### PR DESCRIPTION
## Summary
AppSecure SEC-908 reported that remote files fetched from user-supplied URLs were read into memory with no size cap. The core SDK (`fileUtils.node.ts`, `RemoteFile.ts`, `ToolRouterSessionFileMount.ts`) and the Python SDK already stream through a 100 MiB limit. The CLI's tool-input upload path (`ts/packages/cli/src/services/tool-file-uploads.ts`) was the last remaining sink: `readFileFromUrl` still did `response.arrayBuffer()`, so a large or never-ending response could exhaust memory before the presigned upload was even requested.

Fixes SEC-908 (internal tracker).

## Changes
- `@composio/core` exports `readResponseBodyWithLimit` and `MAX_URL_UPLOAD_SIZE_BYTES`, next to the existing `assertSafeFileUploadPath` export, so downstream packages reuse the one bounded reader.
- CLI `readFileFromUrl` uses it in place of `response.arrayBuffer()`; behaviour is unchanged below the cap.
- Regression test: a response declaring a body above the cap is rejected before `createPresignedURL` is called.
- Changeset for `@composio/core` (patch). `@composio/cli` is in the changeset ignore list.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation
- [ ] Breaking change

## How Has This Been Tested?
```
pnpm --filter @composio/core build
pnpm --filter @composio/core exec vitest run test/utils/readResponseBody.test.ts
 Tests  4 passed (4)
pnpm --filter @composio/cli exec vitest run test/src/services/tool-file-uploads.test.ts
 Tests  8 passed (8)
pnpm exec prettier --check <touched files>
pnpm exec oxlint <touched files>
```
`tsc --noEmit` on the CLI package reports the same pre-existing errors on `next` and none in the touched files. Node 24.17.0, pnpm 11.8.0 via mise.

## Screenshots (if applicable)

## Checklist
- [x] I have read the Code of Conduct and this PR adheres to it
- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable
- [x] I added a changeset if this change affects published packages

## Additional context
The other files AppSecure listed for this finding were already capped on `next` (core: ecd0861, 8a56383; python: 54d07dc); this PR closes the residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
