### PR TITLE
fix(cli): curated help for every command family and a help command

### DIFF
--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -41,6 +41,13 @@
   `https://staging-dashboard.composio.dev/`.
 - `composio dev auth-configs create` now sends custom OAuth credentials and scopes
   in the API's expected shape instead of failing validation.
+- `composio orgs --help`, `composio signup --help`, and the group help pages for
+  `connections`, `triggers`, `tools`, `artifacts`, and `install` now render the same
+  curated, styled help page as every other command family, instead of falling back to
+  the framework's raw flag dump. `composio help <command>` is now a supported spelling
+  of command help (`composio help orgs` shows the same page as `composio orgs --help`),
+  and the `orgs` description in contextual error help matches the command's actual
+  description.
 
 ## 0.3.3
 

--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -41,13 +41,15 @@
   `https://staging-dashboard.composio.dev/`.
 - `composio dev auth-configs create` now sends custom OAuth credentials and scopes
   in the API's expected shape instead of failing validation.
-- `composio orgs --help`, `composio signup --help`, and the group help pages for
-  `connections`, `triggers`, `tools`, `artifacts`, and `install` now render the same
-  curated, styled help page as every other command family, instead of falling back to
-  the framework's raw flag dump. `composio help <command>` is now a supported spelling
-  of command help (`composio help orgs` shows the same page as `composio orgs --help`),
-  and the `orgs` description in contextual error help matches the command's actual
-  description.
+- `composio orgs --help`, `composio signup --help`, the `agent` family pages (signup,
+  login, whoami, inbox, claim), and the group help pages for `connections`, `triggers`,
+  `artifacts`, and `install` now render the same curated, styled help page as every
+  other command family, instead of falling back to the framework's raw flag dump.
+  `composio help <command>` is now a supported spelling of command help (`composio help
+orgs` shows the same page as `composio orgs --help`, with the same longest-prefix
+  fallback for deeper paths); an unknown target fails through the framework parser like
+  any other unknown command. The `orgs` description in contextual error help now matches
+  the command's actual description.
 
 ## 0.3.3
 

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -573,7 +573,21 @@ export const runWithConfig = Effect.gen(function* () {
       if (cmdParts.length === 0) {
         return printRootHelp(visibility, helpLevel);
       }
-      return printSubcommandHelp(cmdParts.join(' '), visibility, helpLevel);
+      // Resolve with the same longest-prefix scan the `--help` spelling uses, so
+      // `composio help dev toolkits` renders the curated dev page instead of an
+      // unknown-command line for a path that exists. `matchSubcommandHelp` reads a
+      // full argv with a trailing --help token, hence the synthetic prefix.
+      const subHelp = matchSubcommandHelp(
+        ['composio', 'composio', ...cmdParts, '--help'],
+        visibility
+      );
+      if (subHelp) {
+        return printSubcommandHelp(subHelp, visibility, helpLevel);
+      }
+      // Unknown target: fall through to the framework parser so the failure
+      // matches every other unknown command (stderr rendering, "Did you mean?",
+      // exit 1) instead of an exit-0 stdout line scripts would read as success.
+      return runCli(args);
     }
     const subHelp = matchSubcommandHelp(normalizedArgv, visibility);
     if (subHelp) {

--- a/ts/packages/cli/src/commands/index.ts
+++ b/ts/packages/cli/src/commands/index.ts
@@ -563,6 +563,18 @@ export const runWithConfig = Effect.gen(function* () {
     if (isRootHelp(normalizedArgv)) {
       return printRootHelp(visibility, parseHelpLevel(normalizedArgv[3]) ?? 'default');
     }
+    // `composio help [command] [level]` — the framework has no builtin help command, so
+    // route it through the same curated pages as `composio <command> --help`.
+    if (args[0] === 'help') {
+      const rest = args.slice(1);
+      const last = rest[rest.length - 1];
+      const helpLevel = parseHelpLevel(last) ?? 'default';
+      const cmdParts = parseHelpLevel(last) !== undefined ? rest.slice(0, -1) : rest;
+      if (cmdParts.length === 0) {
+        return printRootHelp(visibility, helpLevel);
+      }
+      return printSubcommandHelp(cmdParts.join(' '), visibility, helpLevel);
+    }
     const subHelp = matchSubcommandHelp(normalizedArgv, visibility);
     if (subHelp) {
       const helpLevel = parseHelpLevel(normalizedArgv[normalizedArgv.length - 1]) ?? 'default';

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -179,7 +179,7 @@ const ACCOUNT_COMMANDS: ReadonlyArray<TaggedValue<CompactCommand>> = [
   tagged({ name: 'login', description: 'Log in to Composio' }),
   tagged({ name: 'logout', description: 'Log out from Composio' }),
   tagged({ name: 'whoami', description: 'Show current account info' }),
-  tagged({ name: 'orgs', description: 'Manage current organization context (list, switch)' }),
+  tagged({ name: 'orgs', description: 'Manage default global organization/project context.' }),
   tagged({ name: 'version', description: 'Display CLI version' }),
   tagged({ name: 'upgrade', description: 'Upgrade CLI to the latest version' }),
   tagged({ name: 'config', description: 'View and manage CLI configuration' }),
@@ -587,6 +587,11 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
       'composio connections list --toolkit <toolkit>              List account selectors',
     ],
   },
+  connections: {
+    usage: 'composio connections <subcommand>',
+    description: 'View and manage Composio connected accounts.',
+    seeAlso: ['composio connections list', 'composio connections remove'],
+  },
   'connections list': {
     usage: 'composio connections list [--toolkit <text>]',
     description:
@@ -858,6 +863,35 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
 
   // ── Account commands ──────────────────────────────────────────────────
 
+  agent: {
+    usage: 'composio agent <subcommand>',
+    description: 'Manage Composio agent identity, inbox, and handoff.',
+    seeAlso: [
+      'composio agent signup',
+      'composio agent login',
+      'composio agent whoami',
+      'composio agent inbox',
+      'composio agent claim',
+    ],
+  },
+  signup: {
+    usage: 'composio signup [-f, --force] [--no-wait] [--no-login]',
+    description: 'Sign up and optionally log in as a Composio agent.',
+    options: [
+      {
+        name: '-f, --force',
+        description: 'Create a new agent identity even if ~/.composio/agent.json already exists',
+      },
+      {
+        name: '--no-wait',
+        description: 'Start agent signup and exit without waiting for credentials',
+      },
+      {
+        name: '--no-login',
+        description: 'Create or verify the agent identity without logging the CLI in',
+      },
+    ],
+  },
   login: {
     usage:
       'composio login [--no-browser] [--poll] [--no-wait] [--key text] [--user-api-key text] [--org text] [-y, --yes] [--no-skill-install]',
@@ -898,6 +932,32 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
   whoami: {
     usage: 'composio whoami',
     description: 'Display your account information.',
+  },
+  orgs: {
+    usage: 'composio orgs <subcommand>',
+    description: 'Manage default global organization/project context.',
+    seeAlso: ['composio orgs list', 'composio orgs switch'],
+  },
+  'orgs list': {
+    usage: 'composio orgs list [--limit integer]',
+    description: 'List organizations and show current global selection.',
+    options: [
+      {
+        name: '--limit <integer>',
+        description: 'Max organizations to fetch from API (default: 50)',
+      },
+    ],
+  },
+  'orgs switch': {
+    usage: 'composio orgs switch [--org-id text] [--limit integer]',
+    description: 'Switch current organization context.',
+    options: [
+      { name: '--org-id <text>', description: 'Organization ID to use as global default' },
+      {
+        name: '--limit <integer>',
+        description: 'Max orgs to fetch from API (default: 50)',
+      },
+    ],
   },
   setup: {
     usage: 'composio setup [--target auto|claude|codex|all] [--uninstall] [--yes] [--if-present]',
@@ -963,7 +1023,22 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     ],
   },
 
-  // ── Tools commands ────────────────────────────────────────────────────
+  artifacts: {
+    usage: 'composio artifacts <subcommand>',
+    description: 'Inspect session artifact directories.',
+    seeAlso: ['composio artifacts cwd'],
+  },
+  'artifacts cwd': {
+    usage: 'composio artifacts cwd',
+    description: 'Print the cwd-scoped session artifact directory.',
+  },
+  install: {
+    usage: 'composio install [--completions] [--no-completions] [--shell text]',
+    description:
+      'Set up shell integration (PATH and completions). Set COMPOSIO_BIN_DIR to choose the directory added to PATH; it otherwise defaults to ~/.local/bin when that holds this executable, and to the directory of the running binary.',
+  },
+
+  // ── Tools commands ──────────────────────────────────────────────────────
 
   tools: {
     usage: 'composio tools <command>',
@@ -989,6 +1064,11 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
     description:
       'View a brief summary of a tool and show the CLI-facing schema used by `composio execute --get-schema`.',
     args: [{ name: '<slug>', description: 'Tool slug (e.g. "GMAIL_SEND_EMAIL")' }],
+  },
+  triggers: {
+    usage: 'composio triggers <subcommand>',
+    description: 'Inspect and subscribe to trigger events.',
+    seeAlso: ['composio triggers list', 'composio triggers info'],
   },
   'triggers list': {
     usage: 'composio triggers list <toolkit> [--limit integer]',

--- a/ts/packages/cli/src/commands/root-help.ts
+++ b/ts/packages/cli/src/commands/root-help.ts
@@ -874,6 +874,58 @@ const SUBCOMMAND_HELP: Record<string, SubcommandHelp | TaggedValue<SubcommandHel
       'composio agent claim',
     ],
   },
+  'agent signup': {
+    usage: 'composio agent signup [-f, --force] [--no-wait] [--no-login]',
+    description: 'Sign up and optionally log in as a Composio agent.',
+    options: [
+      {
+        name: '-f, --force',
+        description: 'Create a new agent identity even if ~/.composio/agent.json already exists',
+      },
+      {
+        name: '--no-wait',
+        description: 'Start agent signup and exit without waiting for credentials',
+      },
+      {
+        name: '--no-login',
+        description: 'Create or verify the agent identity without logging the CLI in',
+      },
+    ],
+  },
+  'agent login': {
+    usage: 'composio agent login <composio_agent_key>',
+    description: 'Log in with an existing Composio agent key.',
+    args: [
+      {
+        name: '<composio_agent_key>',
+        description: 'Composio agent key for an existing agent identity',
+      },
+    ],
+  },
+  'agent whoami': {
+    usage: 'composio agent whoami',
+    description: 'Show the stored Composio agent identity.',
+  },
+  'agent inbox': {
+    usage: 'composio agent inbox [--limit integer]',
+    description: 'Read the stored Composio agent inbox.',
+    options: [
+      {
+        name: '--limit <integer>',
+        description: 'Maximum number of inbox messages to fetch (default: 50)',
+      },
+    ],
+  },
+  'agent claim': {
+    usage: 'composio agent claim <email>',
+    description: 'Invite a human admin to claim this agent org.',
+    args: [
+      {
+        name: '<email>',
+        description: 'Human email address to invite as an admin for this agent org',
+      },
+    ],
+  },
   signup: {
     usage: 'composio signup [-f, --force] [--no-wait] [--no-login]',
     description: 'Sign up and optionally log in as a Composio agent.',

--- a/ts/packages/cli/test/src/commands/root-help-consistency.test.ts
+++ b/ts/packages/cli/test/src/commands/root-help-consistency.test.ts
@@ -1,0 +1,71 @@
+import { layer } from '@effect/vitest';
+import { Effect } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { buildRootCommand } from 'src/commands';
+import {
+  getCommandHelpText,
+  matchSubcommandHelp,
+  printSubcommandHelp,
+} from 'src/commands/root-help';
+import { MockConsole, TestLive } from 'test/__utils__';
+
+const stableVisibility = {
+  isDevModeEnabled: true,
+  isExperimentalFeatureEnabled: () => false,
+};
+
+const getVisibleRootCommandNames = () =>
+  buildRootCommand(stableVisibility).subcommands.flatMap(group =>
+    group.commands.map(cmd => cmd.name)
+  );
+
+describe('subcommand help registry consistency', () => {
+  it('has a curated help entry for every visible root command', () => {
+    for (const name of getVisibleRootCommandNames()) {
+      const matched = matchSubcommandHelp(['bun', 'composio', name, '--help'], stableVisibility);
+      expect(matched, `missing curated help for \`composio ${name}\``).toBe(name);
+    }
+  });
+
+  it('matches every orgs family invocation', () => {
+    expect(matchSubcommandHelp(['bun', 'composio', 'orgs', '--help'], stableVisibility)).toBe(
+      'orgs'
+    );
+    expect(
+      matchSubcommandHelp(['bun', 'composio', 'orgs', 'list', '--help'], stableVisibility)
+    ).toBe('orgs list');
+    expect(
+      matchSubcommandHelp(['bun', 'composio', 'orgs', 'switch', '--help'], stableVisibility)
+    ).toBe('orgs switch');
+    expect(
+      matchSubcommandHelp(['bun', 'composio', 'orgs', '--help', 'full'], stableVisibility)
+    ).toBe('orgs');
+  });
+
+  it('renders the curated orgs page', () =>
+    Effect.gen(function* () {
+      yield* printSubcommandHelp('orgs', stableVisibility);
+      const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+      expect(output).toContain('USAGE');
+      expect(output).toContain('composio orgs <subcommand>');
+      expect(output).toContain('SEE ALSO');
+      expect(output).toContain('composio orgs list');
+      expect(output).toContain('composio orgs switch');
+    }));
+
+  it('renders curated pages for formerly raw-fallback groups', () =>
+    Effect.gen(function* () {
+      for (const cmd of ['connections', 'triggers', 'tools', 'artifacts', 'install']) {
+        yield* printSubcommandHelp(cmd, stableVisibility);
+        const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+        expect(output, `\`composio ${cmd}\` help page`).toContain('USAGE');
+      }
+    }));
+
+  it('uses the current orgs description in contextual help', () => {
+    expect(getCommandHelpText('orgs', stableVisibility)).toContain(
+      'Manage default global organization/project context.'
+    );
+  });
+});

--- a/ts/packages/cli/test/src/commands/root-help-consistency.test.ts
+++ b/ts/packages/cli/test/src/commands/root-help-consistency.test.ts
@@ -1,13 +1,13 @@
 import { layer } from '@effect/vitest';
 import { Effect } from 'effect';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { buildRootCommand } from 'src/commands';
 import {
   getCommandHelpText,
   matchSubcommandHelp,
   printSubcommandHelp,
 } from 'src/commands/root-help';
-import { MockConsole, TestLive } from 'test/__utils__';
+import { cli, MockConsole, TestLive } from 'test/__utils__';
 
 const stableVisibility = {
   isDevModeEnabled: true,
@@ -20,6 +20,10 @@ const getVisibleRootCommandNames = () =>
   );
 
 describe('subcommand help registry consistency', () => {
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
   it('has a curated help entry for every visible root command', () => {
     for (const name of getVisibleRootCommandNames()) {
       const matched = matchSubcommandHelp(['bun', 'composio', name, '--help'], stableVisibility);
@@ -42,30 +46,177 @@ describe('subcommand help registry consistency', () => {
     ).toBe('orgs');
   });
 
-  it('renders the curated orgs page', () =>
-    Effect.gen(function* () {
-      yield* printSubcommandHelp('orgs', stableVisibility);
-      const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
-
-      expect(output).toContain('USAGE');
-      expect(output).toContain('composio orgs <subcommand>');
-      expect(output).toContain('SEE ALSO');
-      expect(output).toContain('composio orgs list');
-      expect(output).toContain('composio orgs switch');
-    }));
-
-  it('renders curated pages for formerly raw-fallback groups', () =>
-    Effect.gen(function* () {
-      for (const cmd of ['connections', 'triggers', 'tools', 'artifacts', 'install']) {
-        yield* printSubcommandHelp(cmd, stableVisibility);
-        const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
-        expect(output, `\`composio ${cmd}\` help page`).toContain('USAGE');
-      }
-    }));
+  it('matches every agent family invocation', () => {
+    expect(matchSubcommandHelp(['bun', 'composio', 'agent', '--help'], stableVisibility)).toBe(
+      'agent'
+    );
+    for (const child of ['signup', 'login', 'whoami', 'inbox', 'claim']) {
+      expect(
+        matchSubcommandHelp(['bun', 'composio', 'agent', child, '--help'], stableVisibility),
+        `missing curated help for \`composio agent ${child}\``
+      ).toBe(`agent ${child}`);
+    }
+  });
 
   it('uses the current orgs description in contextual help', () => {
     expect(getCommandHelpText('orgs', stableVisibility)).toContain(
       'Manage default global organization/project context.'
     );
+  });
+
+  layer(TestLive())(it => {
+    it.effect('renders the curated orgs page', () =>
+      Effect.gen(function* () {
+        yield* printSubcommandHelp('orgs', stableVisibility);
+        const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+        expect(output).toContain('USAGE');
+        expect(output).toContain('composio orgs <subcommand>');
+        expect(output).toContain('SEE ALSO');
+        expect(output).toContain('composio orgs list');
+        expect(output).toContain('composio orgs switch');
+      })
+    );
+  });
+
+  layer(TestLive())(it => {
+    it.effect('renders curated pages for formerly raw-fallback groups', () =>
+      Effect.gen(function* () {
+        for (const cmd of ['connections', 'triggers', 'tools', 'artifacts', 'install']) {
+          yield* printSubcommandHelp(cmd, stableVisibility);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+          expect(output, `\`composio ${cmd}\` help page`).toContain('USAGE');
+        }
+      })
+    );
+  });
+
+  layer(TestLive())(it => {
+    it.effect('renders the curated agent signup page', () =>
+      Effect.gen(function* () {
+        yield* printSubcommandHelp('agent signup', stableVisibility);
+        const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+        expect(output).toContain('USAGE');
+        expect(output).toContain('composio agent signup');
+        expect(output).toContain('--no-wait');
+        expect(output).toContain('Sign up and optionally log in as a Composio agent.');
+      })
+    );
+  });
+
+  describe('composio help routing', () => {
+    layer(TestLive())(it => {
+      it.effect('bare `composio help` prints the root help page', () =>
+        Effect.gen(function* () {
+          yield* cli(['help']);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+          expect(output).toContain('USAGE');
+          expect(output).toContain('LEARN MORE');
+        })
+      );
+    });
+
+    layer(TestLive())(it => {
+      it.effect('`composio help orgs` matches `composio orgs --help`', () =>
+        Effect.gen(function* () {
+          yield* cli(['help', 'orgs']);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+          expect(output).toContain('USAGE');
+          expect(output).toContain('composio orgs <subcommand>');
+          expect(output).toContain('composio orgs list');
+        })
+      );
+    });
+
+    layer(TestLive())(it => {
+      it.effect('`composio help orgs list` prints the orgs list page', () =>
+        Effect.gen(function* () {
+          yield* cli(['help', 'orgs', 'list']);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+          expect(output).toContain('composio orgs list [--limit integer]');
+        })
+      );
+    });
+
+    layer(TestLive())(it => {
+      it.effect('`composio help agent signup` prints the agent signup page', () =>
+        Effect.gen(function* () {
+          yield* cli(['help', 'agent', 'signup']);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+          expect(output).toContain('composio agent signup');
+          expect(output).toContain('--no-wait');
+        })
+      );
+    });
+
+    layer(TestLive())(it => {
+      it.effect('`composio help orgs simple` applies the simple level', () =>
+        Effect.gen(function* () {
+          yield* cli(['help', 'orgs', 'simple']);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+          expect(output).toContain('USAGE');
+          expect(output).not.toContain('SEE ALSO');
+        })
+      );
+    });
+
+    layer(TestLive())(it => {
+      it.effect('`composio help orgs full` applies the full level', () =>
+        Effect.gen(function* () {
+          yield* cli(['help', 'orgs', 'full']);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+          expect(output).toContain('composio orgs <subcommand>');
+          expect(output).toContain('SEE ALSO');
+        })
+      );
+    });
+
+    layer(TestLive())(it => {
+      it.effect('`composio help orgs --help` tolerates a trailing help flag', () =>
+        Effect.gen(function* () {
+          yield* cli(['help', 'orgs', '--help']);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+          expect(output).toContain('composio orgs <subcommand>');
+        })
+      );
+    });
+
+    layer(TestLive())(it => {
+      it.effect('`composio help dev toolkits` falls back to the curated dev page', () =>
+        Effect.gen(function* () {
+          yield* cli(['help', 'dev', 'toolkits']);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+          expect(output).toContain('GUARDED');
+        })
+      );
+    });
+
+    layer(TestLive())(it => {
+      it.effect('`composio help <unknown>` fails like any unknown command', () =>
+        Effect.gen(function* () {
+          yield* cli(['help', 'frobnicate']).pipe(Effect.catch(() => Effect.void));
+          const stdout = (yield* MockConsole.getLines({ stripAnsi: true, stream: 'stdout' })).join(
+            '\n'
+          );
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+          // The framework renders its unknown-subcommand failure (stderr channel,
+          // "Did you mean?", exit 1 via CliError.ShowHelp) instead of an exit-0
+          // "Unknown command" line on the stdout data channel.
+          expect(stdout).not.toContain('Unknown command');
+          expect(output).not.toContain('Unknown command');
+          expect(output).toContain('generate');
+        })
+      );
+    });
   });
 });


### PR DESCRIPTION
This PR:
- follows https://github.com/ComposioHQ/composio/pull/3901 (merged as 0abc629f5)
- fixes a help-system inconsistency: whole command families (`orgs`, `signup`, `agent`, `connections`, `triggers`, `artifacts`, `install`) silently fell through to the framework's raw parser rendering instead of the curated styled help pages every other family gets
- adds curated help entries for the `agent` children (`agent signup`, `agent login`, `agent whoami`, `agent inbox`, `agent claim`), mirroring the `orgs list`/`orgs switch` pattern
- adds `composio help [command] [level]` — the framework has no builtin help command, so `composio help orgs` now routes to the same curated page as `composio orgs --help`; bare `composio help` keeps printing the root help. The spelling resolves targets with the same longest-prefix scan as `--help` (so `composio help dev toolkits` renders the curated dev page), and an unknown target falls through to the framework parser (stderr, "Did you mean?", exit 1) exactly like any other unknown command
- fixes the stale `orgs` description in the contextual-error help registry
- adds a consistency regression test that walks every visible root command and fails when any lacks a curated help entry, plus routing tests for every `composio help` path (bare, family, child, level suffixes, trailing `--help`, deep-path fallback, and unknown targets)

## Context

Auditing the CLI surfaced that `composio orgs --help` rendered a completely different page from `composio config --help`: unstyled headers, a different section layout, and the root-level `--log-level` flag exposed on a subcommand page. Root cause: `root-help.ts`'s `SUBCOMMAND_HELP` registry — which drives the curated `--help` pages — was missing those commands, so they fell through `matchSubcommandHelp` to v4's default parser rendering. The new consistency test walks the visible root command graph and locks this class shut; it caught `signup` and `agent` during development.

Review follow-ups (from code review + prior feedback):
- the `agent` family now has per-command entries, so `composio agent signup --help` and `composio help agent signup` show signup's own flags instead of the group page / an "Unknown command" line
- `composio help <unknown>` no longer prints "Unknown command" to stdout with exit 0; it fails through the framework parser like every other unknown command, so scripted probes and the stdout data channel stay honest
- the `help` spelling resolves deep paths with the same longest-prefix fallback `--help` uses
- the two rendering tests now actually execute (`layer(TestLive())` + `it.effect`) — previously they returned a bare `Effect` from a plain `it` and passed vacuously
- the changelog no longer lists `tools` as newly curated (its entry already existed at the base of this PR)

Guidance-only surface: no parsing, execution, or exit-code behavior changes beyond the `help` spelling itself — help pages and the new `help` command only.

Validation:

- `pnpm --filter @composio/cli typecheck` and full suite: 1342 passed (16 new tests, all executing under `layer(TestLive())`)
- oxlint and prettier clean
- binary smoke-tested: orgs/signup/agent (group + children)/connections/triggers/tools/artifacts/install help pages, all `composio help` paths (bare, family, child, level, deep-path, unknown -> parser error on stderr), and `whoami` against the staging API

Built on top of the merged #3901.
