### PR TITLE
fix(docs): serve social preview images from the docs host

### DIFF
--- a/docs/app/api/og/route.tsx
+++ b/docs/app/api/og/route.tsx
@@ -1,0 +1,28 @@
+import { ImageResponse } from 'next/og';
+
+export function GET(request: Request) {
+  const input = new URL(request.url).searchParams.get('title')?.trim();
+  const title = Array.from(input || 'Composio Docs').slice(0, 120).join('');
+
+  return new ImageResponse(
+    <div style={{
+      display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
+      width: '100%', height: '100%', padding: 72, background: '#131211', color: '#faf9f6',
+      fontFamily: 'sans-serif',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 18, fontSize: 32 }}>
+        <div style={{ width: 28, height: 28, background: '#f76b15', borderRadius: 6 }} />
+        Composio Docs
+      </div>
+      <div style={{ display: 'flex', fontSize: title.length > 60 ? 48 : 68, lineHeight: 1.12,
+        letterSpacing: -2, maxWidth: 1056, overflowWrap: 'break-word' }}>
+        {title}
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 24, color: '#bbb7b0' }}>
+        <span>Build and operate agents</span>
+        <span>docs.composio.dev</span>
+      </div>
+    </div>,
+    { width: 1200, height: 630, headers: { 'Cache-Control': 'public, max-age=86400' } },
+  );
+}

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -48,13 +48,13 @@ export const metadata: Metadata = {
     description: SITE_DESCRIPTION,
     siteName: 'Composio Docs',
     type: 'website',
-    images: ['https://og.composio.dev/api/og?title=Composio%20Docs'],
+    images: ['https://docs.composio.dev/api/og?title=Composio%20Docs'],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Composio Docs',
     description: SITE_DESCRIPTION,
-    images: ['https://og.composio.dev/api/og?title=Composio%20Docs'],
+    images: ['https://docs.composio.dev/api/og?title=Composio%20Docs'],
   },
 };
 

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -163,7 +163,7 @@ export function getOgImageUrl(
   _description?: string
 ): string {
   const encodedTitle = encodeURIComponent(title ?? 'Composio Docs');
-  return `https://og.composio.dev/api/og?title=${encodedTitle}`;
+  return `https://docs.composio.dev/api/og?title=${encodedTitle}`;
 }
 
 /**

--- a/docs/tests/static/og-image.test.ts
+++ b/docs/tests/static/og-image.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'bun:test';
+import { GET } from '../../app/api/og/route';
+import { getOgImageUrl } from '../../lib/source';
+
+test('docs host renders a PNG for the advertised title URL', async () => {
+  for (const title of ['Welcome', 'Authentication & OAuth / setup', 'Very long title '.repeat(20), '']) {
+    const url = getOgImageUrl('docs', [], title);
+    expect(new URL(url).origin).toBe('https://docs.composio.dev');
+    const response = GET(new Request(url));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('image/png');
+    const bytes = Buffer.from(await response.arrayBuffer());
+    expect(bytes.subarray(1, 4).toString()).toBe('PNG');
+    expect(bytes.readUInt32BE(16)).toBe(1200);
+    expect(bytes.readUInt32BE(20)).toBe(630);
+  }
+});


### PR DESCRIPTION
The live docs advertise `https://og.composio.dev/api/og?title=Welcome`, which returns HTTP 404 and breaks link previews. Serve 1200×630 PNG previews from `/api/og` on the docs host and point the shared page metadata and root metadata at that route. Titles are bounded to keep the image readable and rendering work limited.

Fixes [DEVREL-41](https://linear.app/composio/issue/DEVREL-41).

Validation: reproduced the live 404, rendered and visually inspected the replacement image, tested PNG signatures and dimensions for default, normal, special-character, and long titles, and passed typecheck, lint, and all 551 static tests. Existing lint warnings remain. No remote image service or new dependency is required.
