### PR TITLE
docs: curate the agent routing map and separate the full index

### DIFF
--- a/docs/app/llms-index.txt/route.ts
+++ b/docs/app/llms-index.txt/route.ts
@@ -1,0 +1,232 @@
+import {
+  source,
+  examplesSource,
+  referenceSource,
+  toolkitsSource,
+  knowledgeBaseSource,
+} from '@/lib/source';
+import { detectReferenceApiVersion } from '@/lib/api-version';
+import { TOOLKIT_COUNT_LABEL } from '@/lib/toolkit-count';
+import {
+  formatKnowledgeDiscoveryLinks,
+  getLocalKnowledgeDiscoveryPaths,
+} from '@/lib/knowledge/discovery';
+import type { ReactNode } from 'react';
+
+export const revalidate = false;
+
+// Fumadocs page tree node types
+interface PageNode {
+  type: 'page';
+  name: ReactNode;
+  url: string;
+  external?: boolean;
+}
+
+interface SeparatorNode {
+  type: 'separator';
+  name?: ReactNode;
+}
+
+interface FolderNode {
+  type: 'folder';
+  name: ReactNode;
+  index?: PageNode;
+  children: TreeNode[];
+}
+
+type TreeNode = PageNode | SeparatorNode | FolderNode;
+
+/** Extract plain text from a ReactNode (handles strings, numbers, skips elements). */
+function nodeText(name: ReactNode): string | null {
+  if (typeof name === 'string') return name;
+  if (typeof name === 'number') return String(name);
+  return null;
+}
+
+/**
+ * A section is legacy/deprecated when its separator heading says so (e.g.
+ * "Direct Tool Execution Guides (Legacy)"). We omit those sections from the
+ * default LLM index so code generators reach for the current session-based
+ * APIs, not deprecated ones.
+ */
+function isLegacySeparator(name: ReactNode): boolean {
+  const text = nodeText(name);
+  return text != null && /legacy|deprecated/i.test(text);
+}
+
+/**
+ * Walk the fumadocs page tree and generate a markdown index.
+ * Separators become ## headings, pages become URL entries, folders recurse.
+ * Legacy/deprecated sections (and everything under them) are skipped.
+ *
+ * A folder emits a heading one level deeper, and markdown headings do not
+ * close — so a plain page emitted after a folder reads as belonging to that
+ * folder. `meta.json` order is the human sidebar's order and cannot absorb
+ * this, so each section's direct pages are buffered and flushed ahead of its
+ * folders. Within pages, and within folders, `meta.json` order is preserved.
+ */
+function walkPageTree(nodes: TreeNode[], depth = 2): string {
+  const lines: string[] = [];
+  let skippingSection = false;
+  let sectionPages: string[] = [];
+  let sectionFolders: string[] = [];
+
+  function flushSection() {
+    lines.push(...sectionPages, ...sectionFolders);
+    sectionPages = [];
+    sectionFolders = [];
+  }
+
+  for (const node of nodes) {
+    if (node.type === 'separator') {
+      // A separator starts a new section; skip it and its pages when legacy.
+      flushSection();
+      skippingSection = isLegacySeparator(node.name);
+      if (skippingSection) continue;
+      const text = nodeText(node.name);
+      if (text) {
+        lines.push('', `${'#'.repeat(depth)} ${text}`, '');
+      }
+      continue;
+    }
+
+    if (skippingSection) continue;
+
+    switch (node.type) {
+      case 'page':
+        if (!node.external) {
+          sectionPages.push(formatPage({ url: node.url, data: source.getPageByHref(node.url)?.page.data }));
+        }
+        break;
+
+      case 'folder': {
+        // Folders are sub-sections within separator sections, so one level deeper
+        const text = nodeText(node.name);
+        if (text) {
+          sectionFolders.push('', `${'#'.repeat(depth + 1)} ${text}`, '');
+        }
+        // If folder has an index page, include it
+        if (node.index && !node.index.external) {
+          sectionFolders.push(formatPage({ url: node.index.url, data: source.getPageByHref(node.index.url)?.page.data }));
+        }
+        // Recurse into children
+        if (node.children.length > 0) {
+          sectionFolders.push(walkPageTree(node.children, depth + 1));
+        }
+        break;
+      }
+    }
+  }
+
+  flushSection();
+
+  return lines
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function formatPage(page: { url: string; data?: { title?: string; description?: string } }) {
+  const title = (page.data?.title ?? page.url).replace(/[\[\]\r\n]/g, ' ');
+  const description = page.data?.description?.replace(/[\r\n]/g, ' ');
+  return `- [${title}](https://docs.composio.dev${page.url}.md)${description ? `: ${description}` : ''}`;
+}
+
+/**
+ * Splits reference pages by REST version.
+ *
+ * This list is built with a flat `.map(formatPage)` that bypasses the
+ * `isLegacySeparator` filter the guides tree gets, so the two trees used to
+ * arrive interleaved under one unlabelled heading — and `/reference/v3/` is
+ * the only version-shaped path in the corpus, so it is the highest-precision
+ * match for the query most readers intend as "current Composio".
+ *
+ * Partitioned with `detectApiVersion`, not a literal path test, so moving the
+ * legacy tree's URL stays a one-line change in `lib/api-version.ts`.
+ */
+function partitionByApiVersion<T extends { url: string }>(pages: T[]) {
+  const current: T[] = [];
+  const legacy: T[] = [];
+  const versionIndependent: T[] = [];
+  for (const page of pages) {
+    const version = detectReferenceApiVersion(page.url);
+    if (version === '3.0') legacy.push(page);
+    else if (version === '3.1') current.push(page);
+    else versionIndependent.push(page);
+  }
+  return { current, legacy, versionIndependent };
+}
+
+export async function GET() {
+  try {
+    const docsTree = walkPageTree(source.pageTree.children as TreeNode[]);
+
+    const examplesPages = examplesSource.getPages();
+    const toolkitsPages = toolkitsSource.getPages();
+    const {
+      current: currentReferencePages,
+      legacy: legacyReferencePages,
+      versionIndependent: versionIndependentReferencePages,
+    } = partitionByApiVersion(referenceSource.getPages());
+
+    const legacyReferenceSection =
+      legacyReferencePages.length > 0
+        ? `
+## API Reference (v3.0, legacy — supported, not for new code)
+
+${legacyReferencePages.map(formatPage).join('\n')}
+`
+        : '';
+    const knowledgeBasePages = knowledgeBaseSource.getPages();
+    const knowledgeDiscoveryLinks = formatKnowledgeDiscoveryLinks(
+      (await getLocalKnowledgeDiscoveryPaths()).filter(
+        (path) => !path.startsWith('/kb/guide/'),
+      ),
+    );
+
+    const index = `# Composio Documentation
+
+> Composio powers ${TOOLKIT_COUNT_LABEL} toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.
+
+For a shorter routing map, start at [llms.txt](https://docs.composio.dev/llms.txt).
+
+${docsTree}
+
+## Examples
+
+${examplesPages.map(formatPage).join('\n')}
+
+## Knowledge Base
+
+${knowledgeDiscoveryLinks}
+
+${knowledgeBasePages.map(formatPage).join('\n')}
+
+## API Reference (v3.1, current)
+
+${currentReferencePages.map(formatPage).join('\n')}
+${legacyReferenceSection}
+## SDK and product reference (version-independent)
+
+${versionIndependentReferencePages.map(formatPage).join('\n')}
+
+## Toolkits
+
+${toolkitsPages.map(formatPage).join('\n')}
+
+## Full Documentation
+
+- [Full documentation](https://docs.composio.dev/llms-full.txt): All current page bodies.
+`;
+
+    return new Response(index, {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+    });
+  } catch (error) {
+    console.error('Error generating llms.txt:', error);
+    return new Response('Error generating documentation index', { status: 500 });
+  }
+}

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -8,7 +8,15 @@ export function GET() {
 
 > Build and operate agents with authentication, tool discovery, execution, and ${TOOLKIT_COUNT_LABEL} toolkits.
 
-Use Platform to build Composio into your application. Use For You to connect your own apps to an existing agent. Start with the current session-based SDK. REST v3.1 is current; REST v3.0 is legacy and is not the starting point for new code.
+Default to Composio Platform for application codebases where users or tenants connect their accounts. Use Composio For You for a personal agent or automation using the developer's own accounts. Start with the current session-based SDK. REST v3.1 is current; REST v3.0 is legacy and is not the starting point for new code.
+
+## Before you implement
+
+Inspect the project's framework, agent architecture, authentication, and user or tenant identity model. Explain where Composio fits. If the intended workflow is unclear, ask what the user wants their application or agent to accomplish with connected apps before making changes.
+
+Load and follow the official [Composio Agent Skill](https://github.com/ComposioHQ/composio/blob/next/skills/composio/SKILL.md) for setup guidance and implementation patterns. If it is missing, install it for the project with \`npx skills add ComposioHQ/composio --skill composio\`, requesting approval if your host requires it. If skills are unsupported or installation fails, use the documentation linked below and report that fallback.
+
+If it is unclear whether the goal is to integrate Composio into the application or connect apps to the coding agent itself, clarify that first. Fetch the relevant Markdown pages below for the chosen path. Use the complete index when you need a guide or reference not listed here.
 
 ## Choose your path
 

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -1,230 +1,49 @@
-import {
-  source,
-  examplesSource,
-  referenceSource,
-  toolkitsSource,
-  knowledgeBaseSource,
-} from '@/lib/source';
-import { detectReferenceApiVersion } from '@/lib/api-version';
 import { TOOLKIT_COUNT_LABEL } from '@/lib/toolkit-count';
-import {
-  formatKnowledgeDiscoveryLinks,
-  getLocalKnowledgeDiscoveryPaths,
-} from '@/lib/knowledge/discovery';
-import type { ReactNode } from 'react';
 
 export const revalidate = false;
 
-// Fumadocs page tree node types
-interface PageNode {
-  type: 'page';
-  name: ReactNode;
-  url: string;
-  external?: boolean;
-}
+/** Curated routing map; the exhaustive catalog lives at /llms-index.txt. */
+export function GET() {
+  return new Response(`# Composio Documentation
 
-interface SeparatorNode {
-  type: 'separator';
-  name?: ReactNode;
-}
+> Build and operate agents with authentication, tool discovery, execution, and ${TOOLKIT_COUNT_LABEL} toolkits.
 
-interface FolderNode {
-  type: 'folder';
-  name: ReactNode;
-  index?: PageNode;
-  children: TreeNode[];
-}
+Use Platform to build Composio into your application. Use For You to connect your own apps to an existing agent. Start with the current session-based SDK. REST v3.1 is current; REST v3.0 is legacy and is not the starting point for new code.
 
-type TreeNode = PageNode | SeparatorNode | FolderNode;
+## Choose your path
 
-/** Extract plain text from a ReactNode (handles strings, numbers, skips elements). */
-function nodeText(name: ReactNode): string | null {
-  if (typeof name === 'string') return name;
-  if (typeof name === 'number') return String(name);
-  return null;
-}
+- [Platform or For You](https://docs.composio.dev/docs.md): Choose between building an application and using your own connected apps.
+- [Set up a coding agent](https://docs.composio.dev/docs/agent-setup.md): Install the Composio skill to add Composio to an existing project.
+- [SDK quickstart](https://docs.composio.dev/docs/quickstart.md): Install Python or TypeScript packages, create a session, and run an agent.
+- [Native agent plugins](https://docs.composio.dev/docs/agent-plugins.md): Use your own apps from Codex or Claude Code.
+- [Connect an MCP client](https://docs.composio.dev/docs/composio-connect.md): Connect an existing client to your apps over MCP.
 
-/**
- * A section is legacy/deprecated when its separator heading says so (e.g.
- * "Direct Tool Execution Guides (Legacy)"). We omit those sections from the
- * default LLM index so code generators reach for the current session-based
- * APIs, not deprecated ones.
- */
-function isLegacySeparator(name: ReactNode): boolean {
-  const text = nodeText(name);
-  return text != null && /legacy|deprecated/i.test(text);
-}
+## Build an application
 
-/**
- * Walk the fumadocs page tree and generate a markdown index.
- * Separators become ## headings, pages become URL entries, folders recurse.
- * Legacy/deprecated sections (and everything under them) are skipped.
- *
- * A folder emits a heading one level deeper, and markdown headings do not
- * close — so a plain page emitted after a folder reads as belonging to that
- * folder. `meta.json` order is the human sidebar's order and cannot absorb
- * this, so each section's direct pages are buffered and flushed ahead of its
- * folders. Within pages, and within folders, `meta.json` order is preserved.
- */
-function walkPageTree(nodes: TreeNode[], depth = 2): string {
-  const lines: string[] = [];
-  let skippingSection = false;
-  let sectionPages: string[] = [];
-  let sectionFolders: string[] = [];
-
-  function flushSection() {
-    lines.push(...sectionPages, ...sectionFolders);
-    sectionPages = [];
-    sectionFolders = [];
-  }
-
-  for (const node of nodes) {
-    if (node.type === 'separator') {
-      // A separator starts a new section; skip it and its pages when legacy.
-      flushSection();
-      skippingSection = isLegacySeparator(node.name);
-      if (skippingSection) continue;
-      const text = nodeText(node.name);
-      if (text) {
-        lines.push('', `${'#'.repeat(depth)} ${text}`, '');
-      }
-      continue;
-    }
-
-    if (skippingSection) continue;
-
-    switch (node.type) {
-      case 'page':
-        if (!node.external) {
-          sectionPages.push(`- https://docs.composio.dev${node.url}.md`);
-        }
-        break;
-
-      case 'folder': {
-        // Folders are sub-sections within separator sections, so one level deeper
-        const text = nodeText(node.name);
-        if (text) {
-          sectionFolders.push('', `${'#'.repeat(depth + 1)} ${text}`, '');
-        }
-        // If folder has an index page, include it
-        if (node.index) {
-          sectionFolders.push(`- https://docs.composio.dev${node.index.url}.md`);
-        }
-        // Recurse into children
-        if (node.children.length > 0) {
-          sectionFolders.push(walkPageTree(node.children, depth + 1));
-        }
-        break;
-      }
-    }
-  }
-
-  flushSection();
-
-  return lines
-    .join('\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
-
-function formatPage(page: { url: string }) {
-  return `- https://docs.composio.dev${page.url}.md`;
-}
-
-/**
- * Splits reference pages by REST version.
- *
- * This list is built with a flat `.map(formatPage)` that bypasses the
- * `isLegacySeparator` filter the guides tree gets, so the two trees used to
- * arrive interleaved under one unlabelled heading — and `/reference/v3/` is
- * the only version-shaped path in the corpus, so it is the highest-precision
- * match for the query most readers intend as "current Composio".
- *
- * Partitioned with `detectApiVersion`, not a literal path test, so moving the
- * legacy tree's URL stays a one-line change in `lib/api-version.ts`.
- */
-function partitionByApiVersion<T extends { url: string }>(pages: T[]) {
-  const current: T[] = [];
-  const legacy: T[] = [];
-  const versionIndependent: T[] = [];
-  for (const page of pages) {
-    const version = detectReferenceApiVersion(page.url);
-    if (version === '3.0') legacy.push(page);
-    else if (version === '3.1') current.push(page);
-    else versionIndependent.push(page);
-  }
-  return { current, legacy, versionIndependent };
-}
-
-export async function GET() {
-  try {
-    const docsTree = walkPageTree(source.pageTree.children as TreeNode[]);
-
-    const examplesPages = examplesSource.getPages();
-    const toolkitsPages = toolkitsSource.getPages();
-    const {
-      current: currentReferencePages,
-      legacy: legacyReferencePages,
-      versionIndependent: versionIndependentReferencePages,
-    } = partitionByApiVersion(referenceSource.getPages());
-
-    const legacyReferenceSection =
-      legacyReferencePages.length > 0
-        ? `
-## API Reference (v3.0, legacy — supported, not for new code)
-
-${legacyReferencePages.map(formatPage).join('\n')}
-`
-        : '';
-    const knowledgeBasePages = knowledgeBaseSource.getPages();
-    const knowledgeDiscoveryLinks = formatKnowledgeDiscoveryLinks(
-      (await getLocalKnowledgeDiscoveryPaths()).filter(
-        (path) => !path.startsWith('/kb/guide/'),
-      ),
-    );
-
-    const index = `# Composio Documentation
-
-> Composio powers ${TOOLKIT_COUNT_LABEL} toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.
-
-> **For AI agents:** Route by intent. To build an application, start with [Quickstart](https://docs.composio.dev/docs/quickstart.md) or [Providers](https://docs.composio.dev/docs/providers.md) and use \`composio.create(user_id)\` + \`session.tools()\`. To use Composio from Codex or Claude Code without explicit MCP intent, install the [native agent plugin](https://docs.composio.dev/docs/agent-plugins.md). To connect an existing client over MCP, use [Composio Connect](https://docs.composio.dev/docs/composio-connect.md). When an application creates a session and needs MCP transport, use [Sessions via MCP](https://docs.composio.dev/docs/sessions-via-mcp.md). See any page's .md endpoint for full usage instructions.
-
-${docsTree}
-
-## Examples
-
-${examplesPages.map(formatPage).join('\n')}
-
-## Knowledge Base
-
-${knowledgeDiscoveryLinks}
-
-${knowledgeBasePages.map(formatPage).join('\n')}
+- [Core concepts](https://docs.composio.dev/docs/how-composio-works.md): Understand users, sessions, toolkits, and tool execution.
+- [Authentication](https://docs.composio.dev/docs/authentication.md): Distinguish auth configs from connected accounts and connect your application's users.
+- [Configure sessions](https://docs.composio.dev/docs/configuring-sessions.md): Select toolkits, auth configs, and connected accounts for a user.
+- [SDKs and frameworks](https://docs.composio.dev/docs/providers.md): Choose the provider for your agent framework.
+- [Sessions via MCP](https://docs.composio.dev/docs/sessions-via-mcp.md): Give an application-created session to an MCP-compatible framework.
+- [Single-toolkit MCP](https://docs.composio.dev/docs/single-toolkit-mcp.md): Build an MCP server scoped to one toolkit.
+- [Troubleshooting](https://docs.composio.dev/kb.md): Diagnose authentication, connection, and execution failures.
+- [Production rate limits](https://docs.composio.dev/reference/rate-limits.md): Plan for request limits before deployment.
 
 ## API Reference (v3.1, current)
 
-${currentReferencePages.map(formatPage).join('\n')}
-${legacyReferenceSection}
-## SDK and product reference (version-independent)
+- [Current REST API](https://docs.composio.dev/reference.md): Use the current base URL and browse endpoint groups.
 
-${versionIndependentReferencePages.map(formatPage).join('\n')}
+## API Reference (v3.0, legacy)
 
-## Toolkits
+- [Legacy REST API](https://docs.composio.dev/reference/v3.md): Maintain existing v3.0 integrations. Use v3.1 for new code.
 
-${toolkitsPages.map(formatPage).join('\n')}
+## Optional
 
-## Full Documentation
+- [Changelog](https://docs.composio.dev/docs/changelog.md): Find dated release notes and read what changed.
 
-- https://docs.composio.dev/llms-full.txt
-`;
-
-    return new Response(index, {
-      headers: {
-        'Content-Type': 'text/plain; charset=utf-8',
-      },
-    });
-  } catch (error) {
-    console.error('Error generating llms.txt:', error);
-    return new Response('Error generating documentation index', { status: 500 });
-  }
+- [Complete documentation index](https://docs.composio.dev/llms-index.txt): All guides, SDK references, endpoint groups, and toolkit pages, with legacy routes labeled.
+- [Knowledge Base](https://docs.composio.dev/kb.md): Find support answers and toolkit-specific troubleshooting.
+- [Examples](https://docs.composio.dev/examples.md): Browse complete application examples.
+- [Full documentation](https://docs.composio.dev/llms-full.txt): Load all current page bodies when individual pages are insufficient.
+`, { headers: { 'Content-Type': 'text/plain; charset=utf-8' } });
 }

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -41,6 +41,7 @@ const config = {
     '/llms.mdx/**': [...OPENAPI_SPEC_FILES],
     '/llms-full.txt/**': [...OPENAPI_SPEC_FILES],
     '/llms.txt/**': [...OPENAPI_SPEC_FILES],
+    '/llms-index.txt/**': [...OPENAPI_SPEC_FILES, './kb/**'],
     '/kb/**': ['./kb/**'],
     '/api/knowledge-search/**': [...OPENAPI_SPEC_FILES, './content/**', './kb/**'],
   },

--- a/docs/tests/integration/llm-endpoints.test.ts
+++ b/docs/tests/integration/llm-endpoints.test.ts
@@ -41,8 +41,8 @@ describe("LLM endpoints - API reference version labelling", () => {
     expect(text.split("\n")).not.toContain("## API Reference");
   });
 
-  test("/llms.txt groups every legacy URL under the legacy heading, not interleaved", async () => {
-    const lines = (await (await fetchPage("/llms.txt")).text()).split("\n");
+  test("/llms-index.txt groups every legacy URL under the legacy heading, not interleaved", async () => {
+    const lines = (await (await fetchPage("/llms-index.txt")).text()).split("\n");
 
     const legacyStart = lines.findIndex(line => line.startsWith(LEGACY_HEADING_PREFIX));
     expect(legacyStart, "no legacy reference group").toBeGreaterThan(-1);

--- a/docs/tests/static/kb-discovery.test.ts
+++ b/docs/tests/static/kb-discovery.test.ts
@@ -56,8 +56,8 @@ describe('public KB discovery', () => {
     expect(source('app/sitemap.ts')).toContain('getLocalKnowledgeDiscoveryPaths');
     expect(source('scripts/validate-links.ts')).toContain('knowledgeBaseSource');
     expect(source('scripts/validate-links.ts')).toContain('getLocalKnowledgeDiscoveryPaths');
-    expect(source('app/llms.txt/route.ts')).toContain('knowledgeBaseSource');
-    expect(source('app/llms.txt/route.ts')).toContain('getLocalKnowledgeDiscoveryPaths');
+    expect(source('app/llms-index.txt/route.ts')).toContain('knowledgeBaseSource');
+    expect(source('app/llms-index.txt/route.ts')).toContain('getLocalKnowledgeDiscoveryPaths');
     expect(source('app/llms-full.txt/route.ts')).toContain('knowledgeBaseSource');
     expect(source('app/llms-full.txt/route.ts')).toContain('getLocalKnowledgeDiscoveryPaths');
     expect(source('app/llms.mdx/[[...slug]]/route.ts')).toContain("prefix: 'kb'");

--- a/docs/tests/static/knowledge-corpus.test.ts
+++ b/docs/tests/static/knowledge-corpus.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import sitemap from '@/app/sitemap';
-import { GET as getLlmsIndex } from '@/app/llms.txt/route';
+import { GET as getLlmsIndex } from '@/app/llms-index.txt/route';
 import { getAlgoliaSearchDocuments, getDocsSearchIndexes } from '@/lib/search-index';
 import * as searchIndexModule from '@/lib/search-index';
 import { getLocalKnowledgeDiscoveryPaths } from '@/lib/knowledge/discovery';

--- a/docs/tests/static/llms-routing.test.ts
+++ b/docs/tests/static/llms-routing.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'bun:test';
+import { GET } from '../../app/llms.txt/route';
+import { source, referenceSource, examplesSource, knowledgeBaseSource } from '../../lib/source';
+
+test('routing map is bounded and covers the current developer decisions', async () => {
+  const text = await GET().text();
+  expect(text.length).toBeLessThan(6000);
+  const primary = text.split('## Optional')[0];
+  for (const path of ['docs', 'docs/agent-setup', 'docs/quickstart', 'docs/agent-plugins',
+    'docs/authentication', 'docs/configuring-sessions', 'kb']) {
+    expect(primary).toContain(`https://docs.composio.dev/${path}.md`);
+  }
+  expect(text).toContain('[Complete documentation index](https://docs.composio.dev/llms-index.txt)');
+  expect(text).not.toMatch(/^- https?:/m);
+  expect(text).toContain('REST v3.0 is legacy');
+  const pages = new Set([source, referenceSource, examplesSource, knowledgeBaseSource]
+    .flatMap(collection => collection.getPages().map(page => page.url)));
+  pages.add('/docs/changelog');
+  for (const match of text.matchAll(/\]\(https:\/\/docs\.composio\.dev([^)]*)\.md\)/g)) {
+    expect(pages.has(match[1]), `unresolved route: ${match[1]}`).toBe(true);
+  }
+});

--- a/docs/tests/static/start-routing.test.ts
+++ b/docs/tests/static/start-routing.test.ts
@@ -83,7 +83,7 @@ describe('getting-started routing policy', () => {
    * files — has to fail something.
    */
   test('emits every authentication guide into llms.txt exactly once', async () => {
-    const { GET } = await import('../../app/llms.txt/route');
+    const { GET } = await import('../../app/llms-index.txt/route');
     const llms = await (await GET()).text();
 
     for (const url of ['/docs/authentication', ...GUIDE_URLS]) {
@@ -93,7 +93,7 @@ describe('getting-started routing policy', () => {
   });
 
   test('does not turn external sidebar links into documentation URLs', async () => {
-    const { GET } = await import('../../app/llms.txt/route');
+    const { GET } = await import('../../app/llms-index.txt/route');
     const llms = await (await GET()).text();
 
     expect(llms).not.toContain('- https://docs.composio.dev/llms.txt.md');
@@ -106,11 +106,11 @@ describe('getting-started routing policy', () => {
    * the sidebar shows it as a sibling.
    */
   test('files each page under the section it belongs to', async () => {
-    const { GET } = await import('../../app/llms.txt/route');
+    const { GET } = await import('../../app/llms-index.txt/route');
     const lines = (await (await GET()).text()).split('\n');
 
     const sectionOf = (url: string) => {
-      const index = lines.findIndex(line => line.endsWith(`${url}.md`));
+      const index = lines.findIndex(line => line.includes(`${url}.md)`));
       expect(index, `${url} missing from llms.txt`).toBeGreaterThan(-1);
       const preceding = lines.slice(0, index);
       return {


### PR DESCRIPTION
Replace the exhaustive `/llms.txt` dump with a short routing map for product selection, installation, authentication, sessions, execution, and troubleshooting. Keep the full catalog at `/llms-index.txt`, using named links and descriptions, and put that catalog and other long-tail resources under Optional. Current REST v3.1 and legacy v3.0 remain explicitly separated.

Fixes [DEVREL-34](https://linear.app/composio/issue/DEVREL-34). The format follows the descriptive-link and Optional conventions in the [llms.txt proposal](https://llmstxt.org/).

Validation: 551 static tests passed, including bounded routing-map coverage and route resolution. Typecheck, lint, and link validation passed. Existing exhaustive-catalog coverage now tests `/llms-index.txt`; the HTTP version-grouping test follows the new catalog route. Existing lint warnings remain.
