### PR TITLE
docs: expose release notes from agent-readable pages

### DIFF
--- a/docs/app/llms-full.txt/route.ts
+++ b/docs/app/llms-full.txt/route.ts
@@ -166,7 +166,7 @@ export async function GET() {
     ]);
 
     const results = [
-      `# Composio Documentation\n\n> Composio powers ${TOOLKIT_COUNT_LABEL} toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.${SESSION_GUARDRAILS}\n# Documentation\n`,
+      `# Composio Documentation\n\n> Composio powers ${TOOLKIT_COUNT_LABEL} toolkits, tool search, context management, authentication, and a sandboxed workbench to help you build AI agents that turn intent into action.${SESSION_GUARDRAILS}\n\n[Changelog](https://docs.composio.dev/docs/changelog.md): Browse dated release notes and follow each date for its full Markdown.\n# Documentation\n`,
       ...docsResults,
       '\n# Knowledge Hub navigation\n',
       knowledgeDiscoveryLinks,

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -588,7 +588,7 @@ ${page.data.description || ''}`;
   }
 
   const footer = includeFooter
-    ? `\n\n---\n\n📚 **More documentation:** [View all docs](https://docs.composio.dev/llms.txt) | [Glossary](https://docs.composio.dev/llms.mdx/reference/glossary) | [Examples](https://docs.composio.dev/llms.mdx/examples) | [API Reference](https://docs.composio.dev/llms.mdx/reference)`
+    ? `\n\n---\n\n📚 **More documentation:** [View all docs](https://docs.composio.dev/llms.txt) | [Changelog](https://docs.composio.dev/docs/changelog.md) | [Glossary](https://docs.composio.dev/llms.mdx/reference/glossary) | [Examples](https://docs.composio.dev/llms.mdx/examples) | [API Reference](https://docs.composio.dev/llms.mdx/reference)`
     : '';
 
   // Legacy pages (frontmatter `legacy: true`) document point-in-time migrations

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -224,6 +224,17 @@ const config = {
         destination: '/docs/sandbox/remote',
         permanent: true,
       },
+      // Preserve machine-readable release notes before the legacy HTML redirects.
+      {
+        source: '/docs/changelog/:path*.md',
+        destination: '/llms.mdx/docs/changelog/:path*',
+        permanent: true,
+      },
+      {
+        source: '/docs/changelog/:path*.mdx',
+        destination: '/llms.mdx/docs/changelog/:path*',
+        permanent: true,
+      },
       {
         source: '/docs/changelog',
         destination: '/reference/changelog',

--- a/docs/tests/integration/changelog-discovery.test.ts
+++ b/docs/tests/integration/changelog-discovery.test.ts
@@ -15,4 +15,7 @@ test('an agent can discover the changelog and read a dated release', async () =>
   expect(release.status).toBe(200);
   expect(release.headers.get('content-type')).toContain('text/markdown');
   expect((await release.text()).length).toBeGreaterThan(200);
+  const mdx = await fetchPage(dated![1].replace(/\.md$/, '.mdx'));
+  expect(mdx.status).toBe(200);
+  expect(mdx.headers.get('content-type')).toContain('text/markdown');
 });

--- a/docs/tests/integration/changelog-discovery.test.ts
+++ b/docs/tests/integration/changelog-discovery.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test';
+import { fetchPage } from './helpers';
+
+test('an agent can discover the changelog and read a dated release', async () => {
+  const quickstart = await fetchPage('/docs/quickstart.md');
+  expect(quickstart.status).toBe(200);
+  expect(await quickstart.text()).toContain('https://docs.composio.dev/docs/changelog.md');
+  const index = await fetchPage('/docs/changelog.md');
+  expect(index.status).toBe(200);
+  expect(index.headers.get('content-type')).toContain('text/markdown');
+  const text = await index.text();
+  const dated = text.match(/https:\/\/docs\.composio\.dev(\/docs\/changelog\/\d{4}\/\d{2}\/\d{2}\.md)/);
+  expect(dated).not.toBeNull();
+  const release = await fetchPage(dated![1]);
+  expect(release.status).toBe(200);
+  expect(release.headers.get('content-type')).toContain('text/markdown');
+  expect((await release.text()).length).toBeGreaterThan(200);
+});

--- a/docs/tests/static/changelog-discovery.test.ts
+++ b/docs/tests/static/changelog-discovery.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'bun:test';
+import { getLLMText } from '../../lib/source';
+import { readFileSync } from 'node:fs';
+
+test('page Markdown and the full corpus route agents to dated release notes', async () => {
+  const markdown = await getLLMText({
+    url: '/docs/quickstart',
+    data: { title: 'Quickstart', getText: async () => 'Install the SDK.' },
+  });
+  expect(markdown).toContain('[Changelog](https://docs.composio.dev/docs/changelog.md)');
+  expect(readFileSync('app/llms-full.txt/route.ts', 'utf8'))
+    .toContain('[Changelog](https://docs.composio.dev/docs/changelog.md)');
+});


### PR DESCRIPTION
Agents reading individual pages or `/llms-full.txt` could miss the Markdown changelog. Its dated `.md` links also matched a broad legacy redirect and landed on HTML instead of release-note Markdown.

Link page Markdown and the full corpus to `/docs/changelog.md`, and route dated `.md` and `.mdx` requests to the existing Markdown renderer before the legacy HTML redirects. Add an HTTP regression that follows quickstart → changelog → dated release and checks both extensions.

Fixes [DEVREL-31](https://linear.app/composio/issue/DEVREL-31).

Validation: typecheck, link validation, and all 551 static tests passed for discovery. The new HTTP test reproduced the redirect defect locally and in CI. The corrected combined production build passed. Its full HTTP suite passed 92 tests with one existing API-key-dependent skip, including dated .md and .mdx release-note checks. No new feed format or dependency is added.
