### PR TITLE
fix(docs): improve homepage social preview

### DIFF
--- a/docs/app/(home)/docs/[[...slug]]/page.tsx
+++ b/docs/app/(home)/docs/[[...slug]]/page.tsx
@@ -72,10 +72,23 @@ export async function generateMetadata(props: PageProps<'/docs/[[...slug]]'>): P
   const ogImage = getOgImageUrl('docs', page.slugs, page.data.title, page.data.description);
 
   return {
-    title: page.data.title,
+    title: page.slugs.length === 0
+      ? { absolute: `${page.data.title} | Composio Documentation` }
+      : page.data.title,
     description: page.data.description,
     alternates: { canonical: page.url },
-    openGraph: { images: [ogImage] },
-    twitter: { card: 'summary_large_image', images: [ogImage] },
+    openGraph: {
+      title: page.data.title,
+      description: page.data.description,
+      siteName: 'Composio Docs',
+      type: 'website',
+      images: [ogImage],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: page.data.title,
+      description: page.data.description,
+      images: [ogImage],
+    },
   };
 }

--- a/docs/app/api/og/route.tsx
+++ b/docs/app/api/og/route.tsx
@@ -1,10 +1,54 @@
 import { ImageResponse } from 'next/og';
 
 export function GET(request: Request) {
-  const input = new URL(request.url).searchParams.get('title')?.trim();
+  const params = new URL(request.url).searchParams;
+  const input = params.get('title')?.trim();
   const title = Array.from(input || 'Composio Docs').slice(0, 120).join('');
 
   return new ImageResponse(
+    params.get('variant') === 'home' ? (
+      <div style={{
+        display: 'flex', width: '100%', height: '100%',
+        background: '#131211', color: '#faf9f6', fontFamily: 'sans-serif',
+      }}>
+        <div style={{
+          display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
+          width: 810, padding: '60px 64px',
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 16, fontSize: 28 }}>
+            <div style={{ width: 24, height: 24, background: '#f76b15', borderRadius: 5 }} />
+            Composio Docs
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+            <div style={{ display: 'flex', flexDirection: 'column', fontSize: 76, lineHeight: 1.04, letterSpacing: -3 }}>
+              <span>Build and operate</span>
+              <span style={{ color: '#ff8a42' }}>AI agents.</span>
+            </div>
+            <div style={{ display: 'flex', fontSize: 27, lineHeight: 1.4, color: '#bbb7b0', maxWidth: 620 }}>
+              Tools, managed authentication, and secure execution for your agents.
+            </div>
+          </div>
+          <div style={{ display: 'flex', fontSize: 23, color: '#bbb7b0' }}>docs.composio.dev</div>
+        </div>
+        <div style={{
+          display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
+          width: 390, padding: '64px 40px', background: '#f76b15', color: '#131211',
+        }}>
+          <div style={{ display: 'flex', fontSize: 20, letterSpacing: 3 }}>FROM THE DOCS</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+            {['SDK', 'CLI', 'MCP'].map((label) => (
+              <div key={label} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: '1px solid #b84c0b', paddingBottom: 20 }}>
+                <span style={{ fontSize: 48 }}>{label}</span>
+                <span style={{ fontSize: 32 }}>↗</span>
+              </div>
+            ))}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 22px', borderRadius: 8, background: '#131211', color: '#faf9f6', fontSize: 26 }}>
+            <span>Start building</span><span>→</span>
+          </div>
+        </div>
+      </div>
+    ) : (
     <div style={{
       display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
       width: '100%', height: '100%', padding: 72, background: '#131211', color: '#faf9f6',
@@ -22,7 +66,8 @@ export function GET(request: Request) {
         <span>Build and operate agents</span>
         <span>docs.composio.dev</span>
       </div>
-    </div>,
+    </div>
+    ),
     { width: 1200, height: 630, headers: { 'Cache-Control': 'public, max-age=86400' } },
   );
 }

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -48,13 +48,13 @@ export const metadata: Metadata = {
     description: SITE_DESCRIPTION,
     siteName: 'Composio Docs',
     type: 'website',
-    images: ['https://docs.composio.dev/api/og?title=Composio%20Docs'],
+    images: ['https://docs.composio.dev/api/og?variant=home'],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Composio Docs',
     description: SITE_DESCRIPTION,
-    images: ['https://docs.composio.dev/api/og?title=Composio%20Docs'],
+    images: ['https://docs.composio.dev/api/og?variant=home'],
   },
 };
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Welcome
-description: Choose whether to build Composio into an application or use it from an existing agent, then start with the SDK, a native plugin, the CLI, or MCP.
+title: Build and operate AI agents
+description: Give your agents tools, managed authentication, and secure execution. Get started with the SDK, CLI, or MCP.
 keywords: [getting started, introduction]
 ---
 

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -157,11 +157,14 @@ export type ChangelogEntry = DocCollectionEntry<
 export const changelogEntries = changelog as ChangelogEntry[];
 
 export function getOgImageUrl(
-  _section: string,
-  _slugs: string[],
+  section: string,
+  slugs: string[],
   title?: string,
   _description?: string
 ): string {
+  if (section === 'docs' && slugs.length === 0) {
+    return 'https://docs.composio.dev/api/og?variant=home';
+  }
   const encodedTitle = encodeURIComponent(title ?? 'Composio Docs');
   return `https://docs.composio.dev/api/og?title=${encodedTitle}`;
 }

--- a/docs/tests/integration/rendering.test.ts
+++ b/docs/tests/integration/rendering.test.ts
@@ -58,6 +58,21 @@ describe("Page rendering - critical pages", () => {
 });
 
 describe("Page rendering - content markers", () => {
+  test("docs homepage social metadata survives the root redirect", async () => {
+    const res = await fetchPage("/", { timeout: 30_000, headers: { "User-Agent": "facebookexternalhit/1.1" } });
+    const html = await res.text();
+    expect(res.status).toBe(200);
+    expect(new URL(res.url).pathname).toBe('/docs');
+    expect(html).toContain('<title>Build and operate AI agents | Composio Documentation</title>');
+    expect(html).toContain('<meta property="og:site_name" content="Composio Docs"');
+    expect(html).toContain('<meta property="og:title" content="Build and operate AI agents"');
+    expect(html).toContain('<meta property="og:image" content="https://docs.composio.dev/api/og?variant=home"');
+    expect(html).toContain('<meta name="twitter:image" content="https://docs.composio.dev/api/og?variant=home"');
+    const description = html.match(/<meta property="og:description" content="([^"]+)"/)?.[1];
+    expect(description).toBe('Give your agents tools, managed authentication, and secure execution. Get started with the SDK, CLI, or MCP.');
+    expect(description!.length).toBeLessThanOrEqual(125);
+  });
+
   test("docs home contains navigation elements", async () => {
     const res = await fetchPage("/docs");
     const html = await res.text();

--- a/docs/tests/static/og-image.test.ts
+++ b/docs/tests/static/og-image.test.ts
@@ -4,7 +4,7 @@ import { getOgImageUrl } from '../../lib/source';
 
 test('docs host renders a PNG for the advertised title URL', async () => {
   for (const title of ['Welcome', 'Authentication & OAuth / setup', 'Very long title '.repeat(20), '']) {
-    const url = getOgImageUrl('docs', [], title);
+    const url = getOgImageUrl('docs', ['authentication'], title);
     expect(new URL(url).origin).toBe('https://docs.composio.dev');
     const response = GET(new Request(url));
     expect(response.status).toBe(200);
@@ -14,4 +14,16 @@ test('docs host renders a PNG for the advertised title URL', async () => {
     expect(bytes.readUInt32BE(16)).toBe(1200);
     expect(bytes.readUInt32BE(20)).toBe(630);
   }
+});
+
+test('the docs homepage uses a distinct card without changing article cards', async () => {
+  const url = getOgImageUrl('docs', [], 'Welcome');
+  expect(new URL(url).searchParams.get('variant')).toBe('home');
+  expect(new URL(getOgImageUrl('reference', [], 'API Reference')).searchParams.get('title')).toBe('API Reference');
+  const response = GET(new Request(url));
+  expect(response.headers.get('content-type')).toBe('image/png');
+  const bytes = Buffer.from(await response.arrayBuffer());
+  expect(bytes.subarray(1, 4).toString()).toBe('PNG');
+  expect(bytes.readUInt32BE(16)).toBe(1200);
+  expect(bytes.readUInt32BE(20)).toBe(630);
 });


### PR DESCRIPTION
## Summary

The docs homepage used the article OG template with “Welcome” as its headline. Its page-level metadata also dropped the site name. Add a dedicated homepage card with “Build and operate AI agents,” SDK/CLI/MCP entry points, and a “Start building” prompt.

## Changes

- Route the docs homepage and default social image to the new 1200×630 card. Preserve article cards.
- Use a descriptive homepage title and shorter description, and set explicit Open Graph and Twitter metadata.
- Cover homepage image routing and rendered metadata after the root redirect with regression tests.

## Type of change

- [x] Bug fix
- [x] Documentation

## How Has This Been Tested?

Commands run from `docs/`:

- `bun test tests/static/og-image.test.ts`: 2 passed, including article and homepage PNG rendering.
- `TEST_BASE_URL=http://localhost:3123 bun test tests/integration/rendering.test.ts --test-name-pattern 'docs homepage social metadata' --timeout 60000`: passed against the local dev server.
- `bun run types:check`: passed.
- `bun run lint`: passed with warnings in unrelated files.
- Rendered and visually inspected the homepage PNG at 1200×630.
- `git diff --check`: passed.

Image tests were rerun after updating to current `next`. Remote CI and production deployment are pending.

## Checklist

- [x] Ran local checks as described above
- [x] Updated homepage metadata
- [x] Added regression tests
- [x] No changeset required: docs-only change
