### PR TITLE
docs: document unattended agent authentication

### DIFF
--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -23,6 +23,7 @@ If it is unclear whether the goal is to integrate Composio into the application 
 - [Platform or For You](https://docs.composio.dev/docs.md): Choose between building an application and using your own connected apps.
 - [Set up a coding agent](https://docs.composio.dev/docs/agent-setup.md): Install the Composio skill to add Composio to an existing project.
 - [SDK quickstart](https://docs.composio.dev/docs/quickstart.md): Install Python or TypeScript packages, create a session, and run an agent.
+- [Authenticate an unattended agent](https://docs.composio.dev/docs/agent-setup/unattended-authentication.md): When no human is available, use \`composio login --agent\`, configure a project API key, and verify a live tool call. Human account access still requires authorization.
 - [Native agent plugins](https://docs.composio.dev/docs/agent-plugins.md): Use your own apps from Codex or Claude Code.
 - [Connect an MCP client](https://docs.composio.dev/docs/composio-connect.md): Connect an existing client to your apps over MCP.
 

--- a/docs/content/docs/agent-setup/index.mdx
+++ b/docs/content/docs/agent-setup/index.mdx
@@ -6,6 +6,10 @@ keywords: [agent setup, agent skill, claude code, codex, cursor, copilot, gemini
 
 Install the Composio Agent Skill so your coding agent can understand your project and follow the current Platform integration path.
 
+<Callout type="info" title="Need an API key without a human present?">
+Use the supported `composio login --agent` flow. [Authenticate an unattended agent](/docs/agent-setup/unattended-authentication) covers account provisioning, application credentials, and verification with a real tool call.
+</Callout>
+
 <AgentSetupGrid />
 
 ## Install the skill

--- a/docs/content/docs/agent-setup/meta.json
+++ b/docs/content/docs/agent-setup/meta.json
@@ -2,7 +2,7 @@
   "title": "Agent setup",
   "pages": [
     "index",
-    "unattended-authentication",
+    "[Unattended Agent Auth](/docs/agent-setup/unattended-authentication)",
     "clients",
     "external:[llms.txt](/llms.txt)"
   ]

--- a/docs/content/docs/agent-setup/meta.json
+++ b/docs/content/docs/agent-setup/meta.json
@@ -2,6 +2,7 @@
   "title": "Agent setup",
   "pages": [
     "index",
+    "unattended-authentication",
     "clients",
     "external:[llms.txt](/llms.txt)"
   ]

--- a/docs/content/docs/agent-setup/unattended-authentication.mdx
+++ b/docs/content/docs/agent-setup/unattended-authentication.mdx
@@ -1,0 +1,86 @@
+---
+title: Authenticate an unattended agent
+description: Obtain a Composio API key without a browser, configure your application, and verify a live tool call.
+keywords: [unattended, autonomous coding agent, agent login, API key, headless, signup, live verification]
+llmGuardrails: none
+---
+
+Use `composio login --agent` to create a Composio agent account and sign in without a browser or a separate email signup.
+
+<Callout type="warn" title="Only when no human is available">
+Use this flow for an unattended agent. When a human is available, use their existing Composio account and the [human login flow](#log-in-with-a-human) instead. Agent signup creates a separate account; it does not grant access to a human's projects or connected apps.
+</Callout>
+
+## Install and log in
+
+Install the [Composio CLI](/docs/cli#install), then make it available in the current shell:
+
+```bash
+curl -fsSL https://composio.dev/install | sh
+export PATH="$HOME/.local/bin:$PATH"
+composio login --agent
+composio agent whoami
+```
+
+The CLI reuses a saved agent identity when it is ready, or provisions one if needed. Successful login reports `account_type: "agent"`, `status: "READY"`, and `logged_in: true`. `composio agent whoami` refreshes the saved identity and reports its status, organization, and project without printing keys.
+
+If provisioning is pending, run `composio agent whoami` again later. Retry `composio login --agent` once the status is `READY`. Treat a failed login or missing credential as a blocker to live verification.
+
+Keep these constraints in mind:
+
+- The CLI refuses agent signup while signed in as a regular human user. Preserve that session and use the existing account.
+- `--agent` cannot be combined with `--no-browser`, `--no-wait`, `--poll`, `--key`, or `--user-api-key`. `--no-browser` alone still requires a human to open a login URL.
+- Network access to the installer, `agents.composio.dev`, and `backend.composio.dev` is required. Respect service errors and rate limits. Do not create repeated accounts to work around a failure.
+- Use the supported CLI flow. Do not reverse-engineer browser signup, create disposable inboxes, or bypass browser challenges to obtain a Composio key.
+
+## Configure the application API key
+
+The CLI saves the agent identity in `~/.composio/agent.json`, or under `COMPOSIO_CACHE_DIR` if you set it. The project's API key is the `composio.api_key` field. With `jq` installed, load it into your shell without displaying it:
+
+```bash
+set +x
+COMPOSIO_API_KEY="$(jq -er '.composio.api_key | strings | select(length > 0)' \
+  "${COMPOSIO_CACHE_DIR:-$HOME/.composio}/agent.json")"
+export COMPOSIO_API_KEY
+: "${COMPOSIO_API_KEY:?No project API key found. Check composio agent whoami.}"
+```
+
+If extraction fails, stop before making API requests. Check that provisioning reached `READY` and that you are reading the same cache directory used during login.
+
+Start your application from this shell so it inherits `COMPOSIO_API_KEY`, or store the value in your application's ignored `.env` or `.env.local` file or deployment secret configuration. Check which file your environment loader reads. CLI login alone does not set the application's environment.
+
+Use `composio.api_key` for SDK calls and the REST `x-api-key` header. Do not substitute `agent_key`, `composio_agent_key`, or `composio.user_api_key`; those serve agent identity and CLI login. Keep environment files and `agent.json` out of version control, browser bundles, and logs.
+
+## Verify a live tool call
+
+First, verify the project key against a tool that needs no connected account. This example reads the public Hacker News profile for `pg`. In the shell where you exported `COMPOSIO_API_KEY`, run:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  https://backend.composio.dev/api/v3.1/tools/execute/HACKERNEWS_GET_USER \
+  -H "x-api-key: $COMPOSIO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"arguments":{"username":"pg"}}'
+```
+
+Check both the HTTP result and the response body. Require `successful: true`, no tool error, and profile data for the requested username. An HTTP 401, a tool schema lookup, or a successful build does not prove tool execution. A local mock verifies only the local code path.
+
+Then run the integration's own script or API route with the same project key and the intended application user ID. If the requested action needs an app account, complete its [connection flow](/docs/authentication) first. A Composio agent credential does not authorize GitHub, Slack, or another service on someone's behalf. OAuth consent, app permissions, and provider credentials still apply.
+
+For an authorized write action, verify the resulting object or state through a follow-up read or the provider's UI. Record the tool slug, sanitized result, and returned log ID if present. If only the Hacker News check succeeds, report that check separately from the requested integration action. If app authorization is unavailable, report the remaining connection step and leave the action unverified.
+
+## Log in with a human
+
+When a human is available but your terminal cannot open a browser, print a login URL:
+
+```bash
+composio login --no-wait
+```
+
+Share the URL with the human so they can sign in to their account, then complete login:
+
+```bash
+composio login --poll
+```
+
+The pending login expires after ten minutes. Run `composio login --no-wait` again if it expires. For a human account, obtain a [project API key](/reference/authenticating-to-composio#project-api-key) from the dashboard.

--- a/docs/content/docs/cli.mdx
+++ b/docs/content/docs/cli.mdx
@@ -8,6 +8,10 @@ The Composio CLI gives coding agents and terminals a local tool surface. Codex, 
 
 Reach for it when you want an agent to act in your connected apps directly, without building an SDK application or configuring MCP.
 
+<Callout type="info" title="Unattended agent authentication">
+When no human is available to log in, `composio login --agent` provisions or reuses an agent account without a browser. See [Authenticate an unattended agent](/docs/agent-setup/unattended-authentication) for constraints, application API key setup, and live-tool verification.
+</Callout>
+
 ## Install
 
 Install the CLI with one command:

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -10,6 +10,10 @@ Pick your framework below. A Composio [session](/docs/how-composio-works) gives 
 
 <AgentSetupActions className="not-prose my-6" />
 
+<Callout type="info" title="Running as an unattended coding agent?">
+If no human is available to log in, use `composio login --agent` to obtain a Composio credential. Follow [Authenticate an unattended agent](/docs/agent-setup/unattended-authentication) to configure `COMPOSIO_API_KEY` and verify a live tool call.
+</Callout>
+
 <Callout type="info">
 The TypeScript SDK is ESM-only and requires Node.js 22.22.3 or newer. Use `import` syntax rather than CommonJS `require()`.
 </Callout>

--- a/docs/content/reference/authenticating-to-composio/index.mdx
+++ b/docs/content/reference/authenticating-to-composio/index.mdx
@@ -20,6 +20,8 @@ A project API key authenticates to one project with full access. Use it for most
 
 Get it from the dashboard: sign in to [composio.dev](https://composio.dev), open **Settings → Project Settings**, and copy the key from the **API Keys** section.
 
+For an unattended coding agent with no human available to log in, use the [agent authentication guide](/docs/agent-setup/unattended-authentication) to provision a Composio account with `composio login --agent`, configure a project API key, and verify a live tool call.
+
 Send it in the `x-api-key` header:
 
 ```bash


### PR DESCRIPTION
## Summary

Autonomous coding agents assumed Composio signup required a human, leaving integrations without credentials or live verification. Add a prominent guide for the supported `composio login --agent` flow when no human is available.

Addresses Gauge action `cmtvu1rwe00040ip8mxhszmj1`. Reviewed the metadata, insights, logs, and diffs for [evidence run 1](https://agents.withgauge.com/composio-aclx/runs/cmtvrts3n001201ea7jwbhu4q) and [evidence run 2](https://agents.withgauge.com/composio-aclx/runs/cmtvrts3n001401eak0rwndar). Both assumed signup required human interaction; the second attempted disposable-email signup before switching to mocks.

## Changes

- Document unattended login, readiness checks, project API-key extraction, credential handling, constraints, and the human login fallback.
- Include a live Hacker News tool call and require separate verification of the requested integration, including provider authorization and confirmation of write results.
- Link the guide from the agent setup sidebar, quickstart, CLI docs, API authentication reference, and `llms.txt`.

## Type of change

- [x] Documentation

## How Has This Been Tested?

From `docs/`:

- `bun run test`: 557 passed, 0 failed. Run with loopback access for the analytics test's local server.
- `bun run lint:links`: 0 errors.
- `bun run lint`: passed with existing warnings.
- `bun run postinstall`: regenerated MDX collections successfully.

All five shell snippets pass `bash -n`. The key-extraction snippet accepts a valid local fixture and rejects missing, blank, and non-string keys without printing credentials. `git diff --check` passes. No live account was provisioned or tool executed for this documentation change.

## Checklist

- [x] I ran linters/tests locally and they passed
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable: existing docs checks and focused snippet validation cover this documentation-only change.
- [x] I added a changeset if this change affects published packages: not applicable; no published package changes.
