### PR TITLE
fix(docs): make semantic artifact freshness advisory in PR checks

### DIFF
--- a/.github/workflows/docs-tests.yml
+++ b/.github/workflows/docs-tests.yml
@@ -47,7 +47,7 @@ jobs:
         run: bun run test
 
       - name: Check KB semantic artifact
-        run: bun run check:kb-semantic
+        run: bun run check:kb-semantic --allow-stale
 
       - name: Build
         run: bun run build

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,13 +44,15 @@ bun run test
 bun run lint
 bun run lint:links
 bun run types:check
-bun run check:kb-semantic
+bun run check:kb-semantic --allow-stale
 bun run build
 ```
 
 To check the built site's endpoints, run `bun run start` in one terminal and `bun run test:integration` in another. The integration tests use `http://localhost:3000` by default. Set `TEST_BASE_URL` if your server uses another address.
 
-A stale KB semantic artifact can follow a content change. The `Docs - Rebuild KB Semantic Artifact` workflow can rebuild it for eligible same-repository PRs after `Docs - Tests` runs. Check that workflow's result and rerun failed checks against the updated commit. If you rebuild locally with `bun run build:kb-semantic`, use an authorized `OPENAI_API_KEY`: the generator sends the indexed docs content to the embeddings service. Never edit embedding values or content hashes by hand.
+The semantic artifact covers both regular docs and KB articles, so edits to either can make it stale. PR checks use `--allow-stale` to warn about freshness while still rejecting missing or corrupt artifacts. Search falls back to keyword results until the artifact is rebuilt.
+
+The `Docs - Rebuild KB Semantic Artifact` workflow can rebuild it for eligible same-repository PRs after `Docs - Tests` runs. The scheduled support-knowledge refresh also proposes stale-artifact repairs. If you rebuild locally with `bun run build:kb-semantic`, use an authorized `OPENAI_API_KEY`: the generator sends the indexed docs content to the embeddings service. Run `bun run check:kb-semantic` without `--allow-stale` to verify a rebuild. Never edit embedding values or content hashes by hand.
 
 ## Request review and verify publication
 

--- a/docs/lib/knowledge/semantic-artifact.ts
+++ b/docs/lib/knowledge/semantic-artifact.ts
@@ -136,6 +136,9 @@ export function decodeVectors(
   return values;
 }
 
+/** A valid artifact that needs to be rebuilt for the current corpus. */
+export class SemanticArtifactStaleError extends Error {}
+
 export function validateSemanticArtifact(
   artifact: KnowledgeSemanticArtifact,
   expected: {
@@ -156,13 +159,6 @@ export function validateSemanticArtifact(
   if (artifact.source.repository !== 'ComposioHQ/support-knowledge') {
     throw new Error('Semantic artifact source repository mismatch');
   }
-  const supportKnowledgeCommit = expected.supportKnowledgeCommit ?? expected.sourceCommit;
-  if (!supportKnowledgeCommit || artifact.source.supportKnowledgeCommit !== supportKnowledgeCommit) {
-    throw new Error('Semantic artifact source commit mismatch');
-  }
-  if (expected.docsContentHash && artifact.source.docsContentHash !== expected.docsContentHash) {
-    throw new Error('Semantic artifact docs content hash mismatch');
-  }
   if (artifact.records.length === 0) throw new Error('Semantic artifact has no records');
 
   const seen = new Set<string>();
@@ -175,13 +171,6 @@ export function validateSemanticArtifact(
       throw new Error(`Semantic artifact has duplicate object ID: ${record.objectID}`);
     }
     seen.add(record.objectID);
-    const expectedHash = expected.contentHashes?.get(record.objectID);
-    if (expected.contentHashes && expectedHash !== record.contentHash) {
-      throw new Error(`Semantic artifact content hash mismatch for ${record.objectID}`);
-    }
-  }
-  if (expected.contentHashes && expected.contentHashes.size !== artifact.records.length) {
-    throw new Error('Semantic artifact content hash record count mismatch');
   }
 
   const vectors = decodeVectors(artifact.vectorsBase64, artifact.records.length, artifact.dimensions);
@@ -195,6 +184,24 @@ export function validateSemanticArtifact(
     }
     if (Math.abs(Math.sqrt(squaredNorm) - 1) > 0.002) {
       throw new Error(`Semantic vector for ${artifact.records[row]?.objectID} is not normalized`);
+    }
+  }
+  // Check integrity first so advisory freshness checks cannot hide corrupt artifacts.
+  const supportKnowledgeCommit = expected.supportKnowledgeCommit ?? expected.sourceCommit;
+  if (!supportKnowledgeCommit || artifact.source.supportKnowledgeCommit !== supportKnowledgeCommit) {
+    throw new SemanticArtifactStaleError('Semantic artifact source commit mismatch');
+  }
+  if (expected.docsContentHash && artifact.source.docsContentHash !== expected.docsContentHash) {
+    throw new SemanticArtifactStaleError('Semantic artifact docs content hash mismatch');
+  }
+  if (expected.contentHashes) {
+    for (const record of artifact.records) {
+      if (expected.contentHashes.get(record.objectID) !== record.contentHash) {
+        throw new SemanticArtifactStaleError(`Semantic artifact content hash mismatch for ${record.objectID}`);
+      }
+    }
+    if (expected.contentHashes.size !== artifact.records.length) {
+      throw new SemanticArtifactStaleError('Semantic artifact content hash record count mismatch');
     }
   }
   return artifact;

--- a/docs/scripts/build-kb-semantic-index.ts
+++ b/docs/scripts/build-kb-semantic-index.ts
@@ -6,6 +6,7 @@ import {
   buildSemanticArtifact,
   docsContentHashFromRecords,
   semanticRecordFromSearchRecord,
+  SemanticArtifactStaleError,
   validateSemanticArtifact,
   type KnowledgeSemanticArtifact,
 } from '@/lib/knowledge/semantic-artifact';
@@ -37,11 +38,20 @@ const docsContentHash = docsContentHashFromRecords(
 if (process.argv.includes('--check')) {
   if (!existsSync(artifactPath)) throw new Error('KB semantic artifact is missing');
   const artifact = JSON.parse(readFileSync(artifactPath, 'utf8')) as KnowledgeSemanticArtifact;
-  validateSemanticArtifact(artifact, {
-    supportKnowledgeCommit: manifest.source.commit,
-    docsContentHash,
-    contentHashes,
-  });
+  try {
+    validateSemanticArtifact(artifact, {
+      supportKnowledgeCommit: manifest.source.commit,
+      docsContentHash,
+      contentHashes,
+    });
+  } catch (error) {
+    if (!(error instanceof SemanticArtifactStaleError)) throw error;
+    const message = `${error.message}. Search falls back to keyword results until the artifact is rebuilt. ` +
+      'Run bun run build:kb-semantic with OPENAI_API_KEY, or use the Docs - Rebuild KB Semantic Artifact workflow.';
+    if (!process.argv.includes('--allow-stale')) throw new Error(message);
+    console.warn(`${process.env.GITHUB_ACTIONS === 'true' ? '::warning::' : 'Warning: '}${message}`);
+    process.exit(0);
+  }
   console.log(`KB semantic artifact is current: ${artifact.records.length} records.`);
   process.exit(0);
 }

--- a/docs/tests/static/kb-semantic-artifact.test.ts
+++ b/docs/tests/static/kb-semantic-artifact.test.ts
@@ -11,6 +11,7 @@ import {
   encodeVectors,
   rankSemanticCandidates,
   semanticRecordFromSearchRecord,
+  SemanticArtifactStaleError,
   validateSemanticArtifact,
   type KnowledgeSemanticArtifact,
   type KnowledgeSemanticRecord,
@@ -163,6 +164,43 @@ Content: Provider tokens are redacted from connected-account responses.`);
 });
 
 describe('KB semantic artifact', () => {
+  test.each([
+    { supportKnowledgeCommit: 'new-commit' },
+    { docsContentHash: 'new-docs-hash' },
+    { contentHashes: new Map([['exact-x', 'changed-hash']]) },
+    { contentHashes: new Map([
+      ['exact-x', 'hash-x'], ['diagonal', 'hash-d'], ['exact-y', 'hash-y'], ['new', 'hash-new'],
+    ]) },
+  ])('classifies corpus drift as stale: %j', drift => {
+    expect(() => validateSemanticArtifact(artifact(), {
+      dimensions: 2,
+      supportKnowledgeCommit: 'abc1234',
+      ...drift,
+    })).toThrow(SemanticArtifactStaleError);
+  });
+
+  test.each([
+    { model: 'another-model' },
+    { vectorsBase64: encodeVectors([[2, 0], [0, 1], [0, 1]]) },
+    { vectorsBase64: encodeVectors([[1, 0]]) },
+    { records: [] },
+    { records: [semanticRecord('duplicate', 'A', 'a'), semanticRecord('duplicate', 'B', 'b')] },
+    { records: [{ ...semanticRecord('private', 'Private', 'hash'), visibility: 'private' }] },
+  ])('rejects corruption even when the corpus is stale: %j', corruption => {
+    let caught: unknown;
+    try {
+      validateSemanticArtifact({ ...artifact(), ...corruption } as KnowledgeSemanticArtifact, {
+        dimensions: 2,
+        supportKnowledgeCommit: 'new-commit',
+        docsContentHash: 'new-docs-hash',
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(SemanticArtifactStaleError);
+  });
+
   test('round-trips row-major float32 vectors', () => {
     const encoded = encodeVectors([[1, 0], [0.25, -0.5]]);
     expect([...decodeVectors(encoded, 2, 2)]).toEqual([1, 0, 0.25, -0.5]);

--- a/docs/tests/static/kb-update-workflow.test.ts
+++ b/docs/tests/static/kb-update-workflow.test.ts
@@ -55,6 +55,13 @@ function workflowSteps(path: string, job: string): WorkflowStep[] {
 }
 
 describe('support knowledge refresh workflow', () => {
+  test('allows stale embeddings in PR checks without ignoring artifact errors', () => {
+    const check = workflowSteps(docsTestsWorkflowPath, 'test')
+      .find(step => step.name === 'Check KB semantic artifact');
+    expect(check?.run).toBe('bun run check:kb-semantic --allow-stale');
+    expect(check?.['continue-on-error']).not.toBe(true);
+  });
+
   test('rebuilds stale semantic artifacts from default-branch code only for trusted current pull requests', () => {
     const workflow = existsSync(semanticRefreshWorkflowPath)
       ? Bun.YAML.parse(readFileSync(semanticRefreshWorkflowPath, 'utf8')) as {
@@ -190,9 +197,11 @@ echo "head_ref=$live_head_ref" >> "$GITHUB_OUTPUT"`);
     expect(checkout?.with?.ref).toBe('${{ needs.authorize.outputs.head_sha }}');
     expect(checkout?.with?.['persist-credentials']).toBe(false);
     expect(freshness?.['continue-on-error']).toBe(true);
+    expect(freshness?.run).toBe('bun run check:kb-semantic');
     expect(build?.if).toBe("steps.freshness.outcome == 'failure'");
     expect(build?.env).toEqual({ OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}' });
     expect(verify?.if).toBe("steps.freshness.outcome == 'failure'");
+    expect(verify?.run).toBe('bun run check:kb-semantic');
     expect(writeToken?.if).toBe("steps.freshness.outcome == 'failure'");
     expect(writeToken?.with).toEqual({
       'client-id': '${{ vars.RELEASE_BOT_CLIENT_ID }}',


### PR DESCRIPTION
## Summary

Editing an indexed docs page makes the checked-in semantic artifact stale, causing `Docs - Tests` to fail until a credentialed rebuild commits new embeddings. Make freshness advisory in PR checks so docs changes can proceed while the existing refresh workflows rebuild the artifact.

## Changes

- Add `--allow-stale` to the PR semantic check. Stale artifacts emit a warning; missing artifacts and integrity failures still fail the check.
- Validate artifact integrity before reporting freshness mismatches, so stale content cannot hide corrupt vectors or invalid records.
- Keep rebuild workflows and runtime validation strict. Search uses its existing keyword fallback until a fresh artifact is available.
- Document the contributor workflow and add regression coverage for freshness, corruption, and CI wiring.

## Type of change

- [x] Bug fix
- [x] Documentation

## How Has This Been Tested?

Run from `docs/` with Bun 1.4.2:

- `bun test tests/static/kb-semantic-artifact.test.ts tests/static/kb-update-workflow.test.ts tests/static/knowledge-search.test.ts`: 72 passed.
- `bun run test`: 567 passed; one analytics test could not open its local HTTP server in the sandbox. `bun test tests/static/kb-query-analytics.test.ts` passed all 14 tests when rerun with permission to listen.
- `bun run types:check`: passed.
- `bun run lint`: passed with existing warnings.
- `bun run check:kb-semantic` and `bun run check:kb-semantic --allow-stale`: passed for the current artifact.
- CLI smoke checks with temporary artifact changes confirmed that stale content exits 1 in strict mode and exits 0 with a GitHub warning in advisory mode. A stale artifact with corrupt vector data still exits nonzero. The original artifact was restored.

## Checklist

- [x] Ran linters and tests locally, with results recorded above
- [x] Updated documentation
- [x] Added regression tests
- [x] Changeset not required: docs-site and CI changes only

## Additional context

Merging stale embeddings temporarily reduces search to keyword retrieval until a refresh lands. Embeddings are still generated by the existing background workflows, without adding API calls to ordinary PR checks or generating the corpus during search requests.
