### PR TITLE
test(docs): preserve task-critical facts across agent-readable outputs

### DIFF
--- a/docs/agent-guidance/context/markdown-components.md
+++ b/docs/agent-guidance/context/markdown-components.md
@@ -21,4 +21,4 @@ Audit for DEVREL-35, 2026-09-10. Scope: components registered in `mdx-components
 
 ## Remaining checks
 
-DEVREL-32 should exercise actual HTTP page output, the full corpus, search ingestion, and external retrieval against the same expected facts. Static converter tests cannot prove an external index refreshed. DEVREL-38 can use the remaining visual and catalog gaps to prioritize task-complete pages. Do not treat this audit as evidence of benchmark improvement.
+The [semantic parity suite](./semantic-parity.md) for DEVREL-32 checks actual HTTP page output, the full corpus, and search ingestion against the same expected facts. Its export checker applies those expectations to external retrieval captures. Static tests cannot prove an external index refreshed. DEVREL-38 can use the remaining visual and catalog gaps to prioritize task-complete pages. Do not treat this audit as evidence of benchmark improvement.

--- a/docs/agent-guidance/context/semantic-parity.md
+++ b/docs/agent-guidance/context/semantic-parity.md
@@ -1,0 +1,50 @@
+# Check semantic parity
+
+The parity suite checks that task instructions survive page rendering, corpus assembly, and search ingestion. Run these commands from `docs/`:
+
+```bash
+bun test tests/static/semantic-parity.test.ts
+bun run build
+bun run start
+```
+
+With the server running, use another terminal:
+
+```bash
+bun test tests/integration/semantic-parity.test.ts
+```
+
+Set `TEST_BASE_URL` to check a deployed site. The standard docs CI already runs both test directories against a production build.
+
+## Coverage
+
+`tests/fixtures/semantic-parity.ts` defines the same expected facts for all checks. It covers the product chooser, quickstart, Anthropic provider, For You plugins, coding-agent setup, and current and legacy REST tools pages. Expectations include complete installation commands, package selection rules, warnings, executable statements, and versioned endpoints from the [component audit](./markdown-components.md).
+
+The static suite checks the complete search replacement payload after chunking. The HTTP suite checks actual page Markdown and each page's section in `/llms-full.txt`. A fact on another page cannot satisfy the assertion. Legacy REST pages are checked individually and in search, including their legacy classification. The current full corpus must exclude them.
+
+Failures name the page, fact ID, and output that lost it. Mutation checks remove each expected fact and verify that its assertion fails. Review the source instructions before changing an expectation. Do not regenerate expectations from converter output.
+
+## Check an external export
+
+Export retrieved text or indexed records into this JSON shape. Include all fixture pages, with each page's chunks in source order:
+
+```json
+{
+  "surface": "Context7 export",
+  "capturedAt": "2026-09-11T00:00:00Z",
+  "includesLegacy": false,
+  "pages": [
+    { "url": "/docs/quickstart", "content": "Full retrieved page text goes here." }
+  ]
+}
+```
+
+This abbreviated example fails because it omits pages and facts. Set `includesLegacy` to `true` for indexes that include legacy REST pages, such as the Algolia replacement payload. URLs can be site paths or canonical `docs.composio.dev` URLs, including Markdown suffixes and section anchors.
+
+```bash
+bun scripts/check-docs-parity.ts /tmp/docs-export.json
+```
+
+The checker validates the JSON, groups chunks by page, and runs the shared expectations. Missing pages or facts return a nonzero exit status. Preserve the provider name and capture timestamp when recording results. Local tests prove the ingestion payload retains facts; they do not prove that an external service refreshed its index. External captures remain a separate check because PR CI has no external retrieval credentials.
+
+These assertions check content preservation. They do not measure retrieval ranking or agent task completion, which belong to DEVREL-37.

--- a/docs/scripts/check-docs-parity.ts
+++ b/docs/scripts/check-docs-parity.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import { readFileSync } from 'node:fs';
+import { assertPageFacts, parityPages } from '../tests/fixtures/semantic-parity';
+
+// Accept retrieved text or an exported index, with chunks in their source order.
+const snapshotSchema = z.object({
+  surface: z.string().min(1),
+  capturedAt: z.string().datetime(),
+  includesLegacy: z.boolean(),
+  pages: z.array(z.object({
+    url: z.string().refine(value => {
+      try {
+        return new URL(value, 'https://docs.composio.dev').origin === 'https://docs.composio.dev';
+      } catch {
+        return false;
+      }
+    }, 'Expected a canonical docs.composio.dev URL or site path'),
+    content: z.string(),
+  })).min(1),
+});
+
+const path = process.argv[2];
+if (!path) throw new Error('Usage: bun scripts/check-docs-parity.ts <snapshot.json>');
+const snapshot = snapshotSchema.parse(JSON.parse(readFileSync(path, 'utf8')));
+const pages = new Map<string, string>();
+for (const page of snapshot.pages) {
+  const url = new URL(page.url, 'https://docs.composio.dev').pathname.replace(/\.mdx?$/, '').replace(/\/$/, '');
+  pages.set(url, [pages.get(url), page.content].filter(Boolean).join('\n\n'));
+}
+
+const failures: string[] = [];
+for (const page of parityPages) {
+  if (!snapshot.includesLegacy && page.url.startsWith('/reference/v3/')) continue;
+  try {
+    assertPageFacts(pages.get(page.url) ?? '', page, snapshot.surface);
+  } catch (error) {
+    failures.push(error instanceof Error ? error.message : String(error));
+  }
+}
+if (failures.length) throw new Error(failures.join('\n'));
+console.log(`${snapshot.surface}: parity passed for snapshot captured ${snapshot.capturedAt}`);

--- a/docs/tests/fixtures/semantic-parity.ts
+++ b/docs/tests/fixtures/semantic-parity.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+
+// Reviewed expectations, independent of the converter and its shared constants.
+// Keep commands with their arguments and warnings with their limiting condition.
+export const parityPages = [
+  {
+    url: '/docs',
+    facts: [
+      ['platform-choice', 'Platform'],
+      ['for-you-choice', 'For You'],
+      ['build-destination', '/docs/quickstart'],
+      ['use-destination', '/docs/agent-plugins'],
+    ],
+  },
+  {
+    url: '/docs/quickstart',
+    facts: [
+      ['typescript-install', 'npm install @composio/core @composio/openai-agents @openai/agents'],
+      ['python-install', 'uv add python-dotenv composio composio-openai-agents openai-agents'],
+      ['package-choice', 'Use @composio/slim for a smaller install with the same API.'],
+      ['legacy-package-warning', 'it calls deprecated APIs and does not work with sessions'],
+      ['python-session-example', 'session = composio.sessions.create(user_id=user_id)'],
+      ['typescript-session-example', 'const session = await composio.create(userId);'],
+    ],
+  },
+  {
+    url: '/docs/providers/anthropic',
+    facts: [
+      ['typescript-provider-install', 'npm install @composio/core @composio/anthropic @anthropic-ai/sdk'],
+      ['python-provider-install', 'pip install composio composio_anthropic anthropic'],
+      ['provider-loop-example', 'results = composio.provider.handle_tool_calls(response=response, session=session)'],
+      ['provider-version-condition', 'newer than 0.19.0'],
+    ],
+  },
+  {
+    url: '/docs/agent-plugins',
+    facts: [
+      ['cli-install', 'curl -fsSL https://composio.dev/install | sh'],
+      ['login-and-setup', 'composio login\ncomposio setup --target auto'],
+      ['noninteractive-setup', 'composio setup --target auto --yes'],
+      ['sdk-alternative', '/docs/quickstart'],
+    ],
+  },
+  {
+    url: '/docs/agent-setup/clients',
+    facts: [
+      ['codex-project-skill', 'npx skills add ComposioHQ/composio --skill composio --agent codex'],
+      ['codex-prompt', 'Use the $composio skill'],
+      ['claude-prompt', 'Use the /composio skill'],
+    ],
+  },
+  {
+    url: '/reference/api-reference/tools',
+    facts: [
+      ['current-list-endpoint', '`/api/v3.1/tools`'],
+      ['toolkit-version-requirement', 'Manual tool execution requires an explicit toolkit version.'],
+      ['proxy-security-boundary', 'Proxy execute rejects cross-domain requests'],
+      ['typescript-proxy-example', "connectedAccountId: 'ca_github_user_123'"],
+    ],
+  },
+  {
+    url: '/reference/v3/api-reference/tools',
+    facts: [
+      ['legacy-list-endpoint', '`/api/v3/tools`'],
+      ['legacy-execute-endpoint', '`/api/v3/tools/execute/{tool_slug}`'],
+    ],
+  },
+] as const;
+
+export type ParityPage = (typeof parityPages)[number];
+
+export function assertPageFacts(text: string, page: ParityPage, surface: string) {
+  for (const [id, expected] of page.facts) {
+    assert.ok(text.includes(expected), `${surface} ${page.url} lost fact ${id}: ${expected}`);
+  }
+}
+
+// Scope corpus assertions to one page so another page cannot hide missing facts.
+export function corpusPages(text: string): Map<string, string> {
+  const headings = [...text.matchAll(/^# [^\n]+ \((\/[^\s)]+)\)\r?$/gm)];
+  return new Map(headings.map((heading, index) => [
+    heading[1],
+    text.slice(heading.index, headings[index + 1]?.index ?? text.length),
+  ]));
+}

--- a/docs/tests/integration/semantic-parity.test.ts
+++ b/docs/tests/integration/semantic-parity.test.ts
@@ -1,0 +1,29 @@
+import { beforeAll, expect, test } from 'bun:test';
+import { fetchPage } from './helpers';
+import { assertPageFacts, corpusPages, parityPages } from '../fixtures/semantic-parity';
+
+let corpus: Map<string, string>;
+beforeAll(async () => {
+  const response = await fetchPage('/llms-full.txt', { timeout: 30_000 });
+  expect(response.status).toBe(200);
+  corpus = corpusPages(await response.text());
+});
+
+for (const page of parityPages) {
+  test(`HTTP Markdown semantic parity ${page.url}`, async () => {
+    const response = await fetchPage(`${page.url}.md`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toMatch(/text\/(plain|markdown)/);
+    assertPageFacts(await response.text(), page, 'HTTP Markdown');
+  });
+
+  test(`full corpus semantic parity ${page.url}`, () => {
+    // The current corpus deliberately excludes legacy REST pages.
+    if (page.url.startsWith('/reference/v3/')) {
+      expect(corpus.has(page.url), `Legacy page leaked into llms-full.txt: ${page.url}`).toBe(false);
+      return;
+    }
+    expect(corpus.has(page.url), `Missing llms-full.txt page ${page.url}`).toBe(true);
+    assertPageFacts(corpus.get(page.url)!, page, 'llms-full.txt');
+  });
+}

--- a/docs/tests/static/semantic-parity.test.ts
+++ b/docs/tests/static/semantic-parity.test.ts
@@ -1,0 +1,68 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildCompleteSearchReplacement } from '../../lib/knowledge/search-replacement';
+import type { AlgoliaDocsRecord } from '../../lib/search-index';
+import { assertPageFacts, corpusPages, parityPages } from '../fixtures/semantic-parity';
+
+let records: AlgoliaDocsRecord[];
+beforeAll(async () => {
+  // This is the payload the production sync sends to Algolia, including chunking.
+  records = await buildCompleteSearchReplacement({ validateExternal: false });
+});
+
+for (const page of parityPages) {
+  describe(`semantic parity ${page.url}`, () => {
+    test('search ingestion retains each fact on the same page', () => {
+      const chunks = records.filter(record => record.page_id === page.url);
+      expect(chunks.length, `Missing search page ${page.url}`).toBeGreaterThan(0);
+      assertPageFacts(chunks.map(record => record.content).join('\n\n'), page, 'Algolia ingestion');
+      if (page.url.startsWith('/reference/v3/')) {
+        expect(chunks.every(record => record.source_type === 'legacy')).toBe(true);
+      }
+    });
+  });
+}
+
+test('a missing fact fails with its page, fact ID, and surface', () => {
+  for (const page of parityPages) {
+    for (const [missingId, missingText] of page.facts) {
+      const mutated = page.facts.map(([, text]) => text).join('\n').replace(missingText, '');
+      expect(() => assertPageFacts(mutated, page, 'mutated export')).toThrow(
+        `mutated export ${page.url} lost fact ${missingId}`,
+      );
+    }
+  }
+});
+
+test('facts on an adjacent corpus page cannot mask a missing fact', () => {
+  const page = parityPages[1];
+  const pages = corpusPages(`# Quickstart (${page.url})\nMissing install.\n\n---\n\n# Other (/docs/other)\n${page.facts.map(([, text]) => text).join('\n')}`);
+  expect(() => assertPageFacts(pages.get(page.url)!, page, 'full corpus')).toThrow('typescript-install');
+});
+
+test('export checker accepts complete chunks and rejects missing pages or invalid input', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'docs-parity-'));
+  const path = join(directory, 'snapshot.json');
+  const snapshot = {
+    surface: 'test export', capturedAt: '2026-09-11T00:00:00Z', includesLegacy: true,
+    pages: parityPages.flatMap(page => page.facts.map(([, content]) => ({
+      url: `https://docs.composio.dev${page.url}.md#chunk`, content,
+    }))),
+  };
+  const run = (input: unknown) => {
+    writeFileSync(path, JSON.stringify(input));
+    return Bun.spawnSync([process.execPath, 'scripts/check-docs-parity.ts', path]);
+  };
+  try {
+    const complete = run(snapshot);
+    expect(complete.exitCode, complete.stderr.toString()).toBe(0);
+    const missing = run({ ...snapshot, pages: snapshot.pages.filter(page => !page.url.includes('/quickstart')) });
+    expect(missing.exitCode).not.toBe(0);
+    expect(missing.stderr.toString()).toContain('test export /docs/quickstart lost fact typescript-install');
+    expect(run({ ...snapshot, pages: [{ url: '/docs', content: 42 }] }).exitCode).not.toBe(0);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Commands, warnings, and API-version details can disappear from agent-readable docs while endpoint smoke tests still pass. This adds 27 shared fact assertions across seven representative pages, checked against HTTP Markdown, each page's section in `/llms-full.txt`, and the complete Algolia ingestion payload after chunking. Failures identify the page, fact, and output; mutation checks verify that removed facts fail.

The same expectations can check external retrieval or index exports through `bun scripts/check-docs-parity.ts <snapshot.json>`. Legacy REST pages remain individually testable and excluded from the current full corpus. The contributor guide documents how to capture external results; local checks do not claim that Context7 or Algolia has refreshed.

Closes DEVREL-32.

Validation from `docs/`:

- Static suite: 578 passed. Focused parity suite rerun after final fixture edits: 10 passed.
- Production build passed. Full HTTP suite: 107 passed, 1 existing COMPOSIO_API_KEY-dependent skip, 0 failed.
- Type checking, lint, internal link validation, and whitespace checks passed. Lint retains existing warnings.
- External checker: complete synthetic export passed; missing pages and malformed input failed as expected. No live external index capture was available in this run.

No production behavior, dependency, generated artifact, or published package changes.
