### PR TITLE
chore(ci): enforce agent guidance validators in CI

### DIFF
--- a/.agents/skills/skill-maintenance/references/skill-format.md
+++ b/.agents/skills/skill-maintenance/references/skill-format.md
@@ -41,6 +41,8 @@ pnpm validate:agent-skills
 pnpm validate:skill-routing
 ```
 
+Both validators are deterministic, and `.github/workflows/agent-substrate.yml` runs them in CI whenever agent guidance changes. If your change touches that workflow's path filters, update them in the same PR.
+
 `validate:agent-skills` checks frontmatter, names, reference links, compatibility symlink state, stale guidance references, and known command names.
 
 `validate:skill-routing` is a deterministic routing smoke test (`ts/scripts/test-skill-routing.mjs`): for representative tasks it asserts the expected skill is the unique top match by distinctive trigger phrases, and fails if any skill has no probe. When you add or rename a skill, or rewrite a `description`, add or update its probe so routing stays covered.

--- a/.agents/skills/skill-maintenance/references/skill-format.md
+++ b/.agents/skills/skill-maintenance/references/skill-format.md
@@ -41,7 +41,7 @@ pnpm validate:agent-skills
 pnpm validate:skill-routing
 ```
 
-Both validators are deterministic, and `.github/workflows/agent-substrate.yml` runs them in CI whenever agent guidance changes. If your change touches that workflow's path filters, update them in the same PR.
+Both validators are deterministic, and `.github/workflows/agent-substrate.yml` runs them in CI on every push and pull request — the stale-guidance scan covers the whole repo, so any change can affect the result.
 
 `validate:agent-skills` checks frontmatter, names, reference links, compatibility symlink state, stale guidance references, and known command names.
 

--- a/.github/workflows/agent-substrate.yml
+++ b/.github/workflows/agent-substrate.yml
@@ -1,0 +1,82 @@
+name: Agent Substrate
+
+# Guards the repo-level AI-agent guidance — the files coding agents read —
+# so it cannot silently drift from reality:
+#
+#   * `pnpm validate:agent-skills`  — SKILL.md frontmatter and reference links,
+#     the .agents/skills <-> .claude/skills compatibility symlink, required
+#     nested AGENTS.md files, stale guidance references, and every pnpm/make/
+#     nox command mentioned in guidance checked against its real definition.
+#   * `pnpm validate:skill-routing` — deterministic routing smoke test: each
+#     skill keeps a probe asserting it is the unique top match for a
+#     representative task, so description edits cannot silently break routing.
+#
+# These checks run nowhere else, so this workflow is their only enforcement
+# point. Path-filtered: it only runs when agent guidance or the validators
+# themselves change. Both scripts are dependency-free Node programs, but the
+# standard toolchain setup is kept so the pnpm script wiring is exercised too.
+
+on:
+  push:
+    branches: [master, next]
+    paths:
+      - 'AGENTS.md'
+      - '**/AGENTS.md'
+      - '**/CLAUDE.md'
+      - '.agents/**'
+      - 'docs/agent-guidance/**'
+      - 'docs/decisions/**'
+      - 'ts/scripts/validate-agent-skills.mjs'
+      - 'ts/scripts/test-skill-routing.mjs'
+      - 'python/Makefile'
+      - 'python/noxfile.py'
+      - 'package.json'
+      - 'docs/package.json'
+      - '.github/workflows/agent-substrate.yml'
+  pull_request:
+    branches: [master, next]
+    paths:
+      - 'AGENTS.md'
+      - '**/AGENTS.md'
+      - '**/CLAUDE.md'
+      - '.agents/**'
+      - 'docs/agent-guidance/**'
+      - 'docs/decisions/**'
+      - 'ts/scripts/validate-agent-skills.mjs'
+      - 'ts/scripts/test-skill-routing.mjs'
+      - 'python/Makefile'
+      - 'python/noxfile.py'
+      - 'package.json'
+      - 'docs/package.json'
+      - '.github/workflows/agent-substrate.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate agent guidance
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js, pnpm, Bun
+        uses: ./.github/actions/setup-node-pnpm-bun
+        with:
+          enable-caching: 'false'
+          cache-save: 'false'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate agent skills and guidance invariants
+        run: pnpm validate:agent-skills
+
+      - name: Validate skill routing
+        run: pnpm validate:skill-routing

--- a/.github/workflows/agent-substrate.yml
+++ b/.github/workflows/agent-substrate.yml
@@ -42,6 +42,11 @@ jobs:
 
       - name: Setup Node.js, pnpm, Bun
         uses: ./.github/actions/setup-node-pnpm-bun
+        with:
+          # Only push runs on next save caches: PR-scoped caches are invisible
+          # to other branches, so saving them costs post-job time and evicts
+          # reusable default-branch caches from the 10 GB repo quota.
+          cache-save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/agent-substrate.yml
+++ b/.github/workflows/agent-substrate.yml
@@ -12,43 +12,17 @@ name: Agent Substrate
 #     representative task, so description edits cannot silently break routing.
 #
 # These checks run nowhere else, so this workflow is their only enforcement
-# point. Path-filtered: it only runs when agent guidance or the validators
-# themselves change. Both scripts are dependency-free Node programs, but the
-# standard toolchain setup is kept so the pnpm script wiring is exercised too.
+# point. It runs on every push and PR with no path filters: the
+# validate:agent-skills stale-guidance walk scans every text file in the
+# repo, so any change can affect the result. Both scripts are
+# dependency-free Node programs, but the standard toolchain setup is kept
+# so the pnpm script wiring is exercised too.
 
 on:
   push:
     branches: [master, next]
-    paths:
-      - 'AGENTS.md'
-      - '**/AGENTS.md'
-      - '**/CLAUDE.md'
-      - '.agents/**'
-      - 'docs/agent-guidance/**'
-      - 'docs/decisions/**'
-      - 'ts/scripts/validate-agent-skills.mjs'
-      - 'ts/scripts/test-skill-routing.mjs'
-      - 'python/Makefile'
-      - 'python/noxfile.py'
-      - 'package.json'
-      - 'docs/package.json'
-      - '.github/workflows/agent-substrate.yml'
   pull_request:
     branches: [master, next]
-    paths:
-      - 'AGENTS.md'
-      - '**/AGENTS.md'
-      - '**/CLAUDE.md'
-      - '.agents/**'
-      - 'docs/agent-guidance/**'
-      - 'docs/decisions/**'
-      - 'ts/scripts/validate-agent-skills.mjs'
-      - 'ts/scripts/test-skill-routing.mjs'
-      - 'python/Makefile'
-      - 'python/noxfile.py'
-      - 'package.json'
-      - 'docs/package.json'
-      - '.github/workflows/agent-substrate.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
@@ -68,9 +42,6 @@ jobs:
 
       - name: Setup Node.js, pnpm, Bun
         uses: ./.github/actions/setup-node-pnpm-bun
-        with:
-          enable-caching: 'false'
-          cache-save: 'false'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ pnpm validate:agent-skills
 pnpm validate:skill-routing
 ```
 
+Both validators are dependency-free and deterministic. `.github/workflows/agent-substrate.yml` runs them in CI whenever agent guidance changes; keep that workflow's path filters in sync when guidance moves to a new location.
+
 Python commands run from `python/` unless otherwise noted:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ pnpm validate:agent-skills
 pnpm validate:skill-routing
 ```
 
-Both validators are dependency-free and deterministic. `.github/workflows/agent-substrate.yml` runs them in CI whenever agent guidance changes; keep that workflow's path filters in sync when guidance moves to a new location.
+Both validators are dependency-free and deterministic. `.github/workflows/agent-substrate.yml` runs them in CI on every push and pull request — the stale-guidance scan covers the whole repo, so any change can affect the result.
 
 Python commands run from `python/` unless otherwise noted:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Use [mise](https://mise.jdx.dev) to install the toolchain:
 mise install
 ```
 
-pnpm is installed through mise's npm backend. Do not rely on Corepack for this repository.
+mise installs pnpm through its npm backend. Do not rely on Corepack for this repository.
 
 ### Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for your interest in contributing to Composio. This guide covers the r
 - [Development Setup](#development-setup)
 - [Project Structure](#project-structure)
 - [Development Commands](#development-commands)
+- [Working with AI Coding Agents](#working-with-ai-coding-agents)
 - [Coding Standards](#coding-standards)
 - [Documentation Requirements](#documentation-requirements)
 - [Pull Request Process](#pull-request-process)
@@ -148,6 +149,23 @@ These tools carry false positives (public API surface, dynamic imports,
 import-map targets), so treat their output as advisory: verify a finding is
 truly unreferenced before deleting, and suppress confirmed false positives via
 `knip.json` / `vulture_allowlist.py`.
+
+## Working with AI Coding Agents
+
+This repository ships its own agent guidance, and CI keeps it honest. You get it for free — an agent that reads this repo inherits the layout, commands, and guardrails without setup.
+
+`AGENTS.md` files live at the root and inside each subtree (`ts/`, `python/`, `docs/`, and the packages). Coding agents read the nearest one automatically, so you usually do not need to do anything beyond keeping them accurate when you move code. The canonical skill tree is `.agents/skills/` (with `.claude/skills` as a compatibility symlink): focused, task-scoped skills that route an agent to the right workflow, from `bug-fixing` to `cli-release`.
+
+Two deterministic checks guard this guidance:
+
+```bash
+pnpm validate:agent-skills    # frontmatter, reference links, stale guidance refs, command names
+pnpm validate:skill-routing   # routing smoke test over skill descriptions
+```
+
+`validate:agent-skills` parses `package.json`, `python/Makefile`, and `python/noxfile.py`, then verifies every command mentioned in guidance actually exists — so guidance cannot recommend a command that was renamed away. Both checks run in CI via `.github/workflows/agent-substrate.yml` whenever agent guidance changes.
+
+If you add or rename a skill, or rewrite a skill description, run both checks and add a routing probe in `ts/scripts/test-skill-routing.mjs` so routing stays covered. To author or edit a skill, read [`.agents/skills/skill-maintenance/SKILL.md`](.agents/skills/skill-maintenance/SKILL.md) first.
 
 ## Coding Standards
 

--- a/ts/scripts/test-skill-routing.mjs
+++ b/ts/scripts/test-skill-routing.mjs
@@ -9,7 +9,8 @@
 // obvious match, or another skill grows ambiguous overlap. It also fails if a
 // skill has no probe, so routing coverage tracks the taxonomy.
 //
-// Run: pnpm validate:skill-routing  (belongs in the verify/CI aggregate too).
+// Run: pnpm validate:skill-routing  (enforced in CI by
+// .github/workflows/agent-substrate.yml).
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/ts/scripts/validate-agent-skills.mjs
+++ b/ts/scripts/validate-agent-skills.mjs
@@ -235,6 +235,13 @@ const ignoredDirs = new Set([
   '.venv',
   'dist',
   'build',
+  // Vendored trees (see AGENTS.md "Generated And Vendored Paths") are read-only
+  // third-party snapshots. Their docs legitimately mention other tools'
+  // rule-file conventions, so the stale-guidance walk must not police them —
+  // only first-party guidance files are in scope.
+  // (Keep this comment free of the stalePatterns literals: this file is
+  // itself scanned by the walk below.)
+  'vendor',
 ]);
 
 const ignoredFiles = new Set(['GOAL.md', 'PLAN.md', 'HANDOFF.md', 'RELEASE_NOTES.md']);

--- a/ts/scripts/validate-agent-skills.mjs
+++ b/ts/scripts/validate-agent-skills.mjs
@@ -238,7 +238,9 @@ const ignoredDirs = new Set([
   // Vendored trees (see AGENTS.md "Generated And Vendored Paths") are read-only
   // third-party snapshots. Their docs legitimately mention other tools'
   // rule-file conventions, so the stale-guidance walk must not police them —
-  // only first-party guidance files are in scope.
+  // only first-party guidance files are in scope. Invariant: every `vendor`
+  // directory in this repo is third-party; revisit this skip if a first-party
+  // one ever appears.
   // (Keep this comment free of the stalePatterns literals: this file is
   // itself scanned by the walk below.)
   'vendor',
@@ -320,7 +322,8 @@ const validatePnpmCommands = (relativePath, text) => {
       command.startsWith('-') ||
       command === 'install' ||
       command === 'exec' ||
-      command === 'turbo'
+      command === 'turbo' ||
+      command === 'dlx'
     ) {
       continue;
     }
@@ -414,6 +417,7 @@ const commandFiles = [
     return files;
   }),
   ...requiredAgentFiles.map(relativePath => path.join(repoRoot, relativePath)),
+  path.join(repoRoot, 'CONTRIBUTING.md'),
 ];
 
 for (const absolutePath of commandFiles) {


### PR DESCRIPTION
This PR:
- Add `.github/workflows/agent-substrate.yml` running `pnpm validate:agent-skills` and `pnpm validate:skill-routing` on every push and pull request; both validators previously ran in no CI workflow
- No path filters on the trigger: the stale-guidance walk scans every text file in the repo, so any change can affect the result (PR runs restore caches but only `next` pushes save them, per the `setup-node-pnpm-bun` guidance)
- Skip `vendor/` directories in the `validate:agent-skills` stale-guidance walk, which was failing on read-only third-party snapshots mentioning other tools' rule conventions
- Extend the validator's command scan to `CONTRIBUTING.md` (with a `pnpm dlx` exemption), so its documented commands are checked against `package.json`, `python/Makefile`, and `python/noxfile.py` like the rest of the guidance
- Point the routing-test header, root `AGENTS.md`, and `skill-maintenance` reference docs at the new workflow, and add a "Working with AI Coding Agents" section to `CONTRIBUTING.md` covering the inherited agent setup, the two checks, and the routing-probe requirement for skill edits

## Context

These two validators are the only checks keeping repo-level agent guidance honest: command names mentioned in guidance are verified against `package.json`, `python/Makefile`, and `python/noxfile.py`, and routing probes assert each skill stays the unique top match for its representative task. Until now nothing enforced either one, and the stale-guidance walk was already red on vendored trees — a failure no guidance owner could fix, which trains people to ignore the check. This makes both checks blocking everywhere they can bite.

## Verification

- `pnpm validate:agent-skills` — 19 skills, green, now including `CONTRIBUTING.md` commands
- `pnpm validate:skill-routing` — 19 probes over 19 skills, green
- Workflow YAML parsed; oxlint and prettier clean on touched files
- `Agent Substrate` workflow ran green on this PR (42s) before the trigger change and re-runs on every push
