### PR TITLE
docs(changelog): document core beta.1

### DIFF
--- a/docs/content/changelog/09-11-26-typescript-sdk-beta.mdx
+++ b/docs/content/changelog/09-11-26-typescript-sdk-beta.mdx
@@ -1,0 +1,28 @@
+---
+title: 'TypeScript SDK beta expands the owned client surface'
+description: 'TypeScript SDK 1.0.0-beta.1 adds webhook, logs, keyring, usage, custom toolkit, connected account, toolkit, and session APIs backed by the Composio-owned client.'
+date: '2026-09-11'
+---
+
+TypeScript SDK `@composio/core` `1.0.0-beta.1` expands the APIs backed by the Composio-owned client and updates that client to `2.0.0-rc.7`.
+
+Install the beta with:
+
+```bash
+npm install @composio/core@beta
+```
+
+### SDK versions
+
+| SDK                         | Version        |
+| --------------------------- | -------------- |
+| TypeScript `@composio/core` | `1.0.0-beta.1` |
+| TypeScript `@composio/slim` | `1.0.0-beta.1` |
+
+### What's new
+
+- Project webhooks, tool execution logs, customer-managed keyring transfer keys, usage metering, and project-owned custom toolkits.
+- Connected account revocation and deferred OAuth completion.
+- Toolkit bulk retrieval, changelogs, OAuth scope recommendations, and grant contexts.
+- Tool Router session configuration history.
+- Configurable SDK logging with redacted output and owned-client deprecation warnings.


### PR DESCRIPTION
The generated beta release branch updates `@composio/core` to `1.0.0-beta.1`, and the release guard requires that exact SDK version in the public changelog.

This adds the beta.1 entry with the owned-client APIs from #4449 and its install command.

Validation:

- `pnpm test:release-workflow`
- Prettier check for the new MDX file
