### PR TITLE
docs: update contact links with CTA placement

### DIFF
--- a/docs/content/docs/security/data-retention.mdx
+++ b/docs/content/docs/security/data-retention.mdx
@@ -79,4 +79,4 @@ So "Don't store data" controls what Composio retains, not whether data is proces
 
 ## Stronger guarantees
 
-If your organization needs a contractual zero-data-retention arrangement or shorter retention windows, [contact sales](https://composio.dev/contact?cta_placement=docs). For our data-handling policies and sub-processor list, see the [Composio Trust Center](https://trust.composio.dev).
+If your organization needs a contractual zero-data-retention arrangement or shorter retention windows, [contact sales](https://composio.dev/contact?utm_source=docs&cta_placement=docs-data-retention). For our data-handling policies and sub-processor list, see the [Composio Trust Center](https://trust.composio.dev).

--- a/docs/content/docs/security/data-retention.mdx
+++ b/docs/content/docs/security/data-retention.mdx
@@ -79,4 +79,4 @@ So "Don't store data" controls what Composio retains, not whether data is proces
 
 ## Stronger guarantees
 
-If your organization needs a contractual zero-data-retention arrangement or shorter retention windows, [contact sales](https://composio.dev/contact?utm_source=docs). For our data-handling policies and sub-processor list, see the [Composio Trust Center](https://trust.composio.dev).
+If your organization needs a contractual zero-data-retention arrangement or shorter retention windows, [contact sales](https://composio.dev/contact?cta_placement=docs). For our data-handling policies and sub-processor list, see the [Composio Trust Center](https://trust.composio.dev).

--- a/docs/content/reference/rate-limits.mdx
+++ b/docs/content/reference/rate-limits.mdx
@@ -45,7 +45,7 @@ When you exceed the rate limit, you'll receive a `429 Too Many Requests` respons
 
 ## Need higher limits?
 
-If you hit these limits regularly, upgrade your plan or [talk to us](https://calendly.com/composiohq/enterprise) about custom limits for your use case.
+If you hit these limits regularly, upgrade your plan or [talk to us](https://composio.dev/contact?cta_placement=docs-rate-limits) about custom limits for your use case.
 
 <Cards>
   <Card title="Errors" href="/reference/errors">

--- a/docs/content/reference/rate-limits.mdx
+++ b/docs/content/reference/rate-limits.mdx
@@ -45,7 +45,7 @@ When you exceed the rate limit, you'll receive a `429 Too Many Requests` respons
 
 ## Need higher limits?
 
-If you hit these limits regularly, upgrade your plan or [talk to us](https://composio.dev/contact?cta_placement=docs-rate-limits) about custom limits for your use case.
+If you hit these limits regularly, upgrade your plan or [talk to us](https://composio.dev/contact?utm_source=docs&cta_placement=docs-rate-limits) about custom limits for your use case.
 
 <Cards>
   <Card title="Errors" href="/reference/errors">

--- a/docs/content/reference/v3/rate-limits.mdx
+++ b/docs/content/reference/v3/rate-limits.mdx
@@ -45,7 +45,7 @@ When you exceed the rate limit, you'll receive a `429 Too Many Requests` respons
 
 ## Need higher limits?
 
-If you hit these limits regularly, upgrade your plan or [talk to us](https://calendly.com/composiohq/enterprise) about custom limits for your use case.
+If you hit these limits regularly, upgrade your plan or [talk to us](https://composio.dev/contact?cta_placement=docs-rate-limits) about custom limits for your use case.
 
 <Cards>
   <Card title="Errors" href="/reference/v3/errors">

--- a/docs/content/reference/v3/rate-limits.mdx
+++ b/docs/content/reference/v3/rate-limits.mdx
@@ -45,7 +45,7 @@ When you exceed the rate limit, you'll receive a `429 Too Many Requests` respons
 
 ## Need higher limits?
 
-If you hit these limits regularly, upgrade your plan or [talk to us](https://composio.dev/contact?cta_placement=docs-rate-limits) about custom limits for your use case.
+If you hit these limits regularly, upgrade your plan or [talk to us](https://composio.dev/contact?utm_source=docs&cta_placement=docs-rate-limits) about custom limits for your use case.
 
 <Cards>
   <Card title="Errors" href="/reference/v3/errors">

--- a/docs/content/toolkits/pro-tools.mdx
+++ b/docs/content/toolkits/pro-tools.mdx
@@ -26,7 +26,7 @@ Premium tools run on paid third-party providers (web search, media generation, b
 
 ## Rate limits
 
-Premium tools have their own, lower rate limits. These apply to premium tool executions only and are separate from your organization's overall API rate limit — see [Rate Limits](/reference/rate-limits) for that. If you need more, [contact us](mailto:billing@composio.dev).
+Premium tools have their own, lower rate limits. These apply to premium tool executions only and are separate from your organization's overall API rate limit — see [Rate Limits](/reference/rate-limits) for that. If you need more, [contact us](https://composio.dev/contact?cta_placement=docs).
 
 | Plan | Premium Tool Calls Rate Limit |
 |------|-------------------------------|

--- a/docs/content/toolkits/pro-tools.mdx
+++ b/docs/content/toolkits/pro-tools.mdx
@@ -26,7 +26,7 @@ Premium tools run on paid third-party providers (web search, media generation, b
 
 ## Rate limits
 
-Premium tools have their own, lower rate limits. These apply to premium tool executions only and are separate from your organization's overall API rate limit — see [Rate Limits](/reference/rate-limits) for that. If you need more, [contact us](https://composio.dev/contact?cta_placement=docs).
+Premium tools have their own, lower rate limits. These apply to premium tool executions only and are separate from your organization's overall API rate limit — see [Rate Limits](/reference/rate-limits) for that. If you need more, [contact us](https://composio.dev/contact?utm_source=docs&cta_placement=docs-pro-tools).
 
 | Plan | Premium Tool Calls Rate Limit |
 |------|-------------------------------|


### PR DESCRIPTION
## Summary
Route documentation contact links to the Composio contact form with both `utm_source=docs` and page-specific CTA placement tracking.

## Changes
- Replace Calendly links on both rate-limit pages with `https://composio.dev/contact?utm_source=docs&cta_placement=docs-rate-limits`.
- Update the data-retention sales link to use `utm_source=docs&cta_placement=docs-data-retention`.
- Replace the premium-tools billing email link with the contact form using `utm_source=docs&cta_placement=docs-pro-tools`.

## Type of change
- [x] Documentation

## How Has This Been Tested?
Verified that all four Markdown contact links contain the expected source and page-specific placement parameters with Python URL parsing assertions. `git diff --check` passed. The docs build and test suite were not run; docs dependencies are not installed in this checkout.

## Checklist
- [x] I updated documentation as needed
- [x] I added tests or explain why not applicable

No new tests or changeset are needed for these four documentation URL replacements.
