### PR TITLE
fix(sdk): rename session config history list methods

### DIFF
--- a/.changeset/calm-lions-list.md
+++ b/.changeset/calm-lions-list.md
@@ -1,0 +1,5 @@
+---
+'@composio/core': patch
+---
+
+Rename `session.configHistory()` to `session.listConfigHistory()` to make the paginated list operation explicit.

--- a/python/composio/core/models/tool_router_session.py
+++ b/python/composio/core/models/tool_router_session.py
@@ -953,7 +953,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         )
         self.preload = _session_preload_config(response.config.preload)
 
-    def config_history(
+    def list_config_history(
         self,
         **query: te.Unpack[session_config_history_params.SessionConfigHistoryParams],
     ) -> session_config_history_response.SessionConfigHistoryResponse:
@@ -968,7 +968,7 @@ class ToolRouterSession(t.Generic[TTool, TToolCollection]):
         :return: The config versions under ``.items`` plus pagination fields.
 
         Example:
-            history = session.config_history(limit=10)
+            history = session.list_config_history(limit=10)
             for entry in history.items:
                 print(entry.version, entry.is_current)
         """

--- a/python/tests/test_tool_router.py
+++ b/python/tests/test_tool_router.py
@@ -124,18 +124,18 @@ class TestToolRouter:
         assert tool_router._client == mock_client
         assert tool_router._provider == mock_provider
 
-    def test_session_config_history(self, tool_router, mock_client):
-        """``session.config_history`` passes the session id and pagination."""
+    def test_session_list_config_history(self, tool_router, mock_client):
+        """``session.list_config_history`` passes the session id and pagination."""
         session = tool_router.create(user_id="user_123")
         mock_client.tool_router.session.config_history.return_value = "history"
 
-        assert session.config_history() == "history"
+        assert session.list_config_history() == "history"
         mock_client.tool_router.session.config_history.assert_called_once_with(
             session_id="session_123"
         )
 
         mock_client.tool_router.session.config_history.reset_mock()
-        session.config_history(limit=10, cursor="c1")
+        session.list_config_history(limit=10, cursor="c1")
         mock_client.tool_router.session.config_history.assert_called_once_with(
             session_id="session_123", limit=10, cursor="c1"
         )

--- a/ts/packages/core/src/models/ToolRouterSession.ts
+++ b/ts/packages/core/src/models/ToolRouterSession.ts
@@ -22,9 +22,9 @@ import {
   ToolRouterSessionWarning,
   ToolRouterUpdateSessionConfig,
   ToolRouterUpdateSessionConfigSchema,
-  ToolRouterSessionConfigHistoryOptions,
-  ToolRouterSessionConfigHistoryOptionsSchema,
-  type ToolRouterSessionConfigHistoryResponse,
+  ToolRouterSessionListConfigHistoryOptions,
+  ToolRouterSessionListConfigHistoryOptionsSchema,
+  type ToolRouterSessionListConfigHistoryResponse,
   type ToolRouterSessionDeleteResponse,
 } from '../types/toolRouter.types';
 import {
@@ -706,16 +706,16 @@ export class ToolRouterSession<
    *
    * @example
    * ```typescript
-   * const { items, nextCursor } = await session.configHistory({ limit: 10 });
+   * const { items, nextCursor } = await session.listConfigHistory({ limit: 10 });
    * console.log(items[0].version, items[0].isCurrent); // e.g. 3, true
    * console.log(items[1].config.toolkits);
    * ```
    */
-  async configHistory(
-    options?: ToolRouterSessionConfigHistoryOptions,
+  async listConfigHistory(
+    options?: ToolRouterSessionListConfigHistoryOptions,
     requestOptions?: ComposioRequestOptions
-  ): Promise<ToolRouterSessionConfigHistoryResponse> {
-    const parsedOptions = ToolRouterSessionConfigHistoryOptionsSchema.safeParse(options ?? {});
+  ): Promise<ToolRouterSessionListConfigHistoryResponse> {
+    const parsedOptions = ToolRouterSessionListConfigHistoryOptionsSchema.safeParse(options ?? {});
     if (!parsedOptions.success) {
       throw new ValidationError('Failed to parse config history options', {
         cause: parsedOptions.error,

--- a/ts/packages/core/src/types/toolRouter.types.ts
+++ b/ts/packages/core/src/types/toolRouter.types.ts
@@ -711,16 +711,16 @@ export const ToolRouterSessionDeleteResponseSchema = z.object({
 export type ToolRouterSessionDeleteResponse = z.infer<typeof ToolRouterSessionDeleteResponseSchema>;
 
 /**
- * Options for `session.configHistory()`.
+ * Options for `session.listConfigHistory()`.
  */
-export const ToolRouterSessionConfigHistoryOptionsSchema = z.object({
+export const ToolRouterSessionListConfigHistoryOptionsSchema = z.object({
   /** Cursor from a previous response's `nextCursor`. */
   cursor: z.string().optional(),
   /** Number of items per page, max allowed is 100. */
   limit: z.number().optional(),
 });
-export type ToolRouterSessionConfigHistoryOptions = z.infer<
-  typeof ToolRouterSessionConfigHistoryOptionsSchema
+export type ToolRouterSessionListConfigHistoryOptions = z.infer<
+  typeof ToolRouterSessionListConfigHistoryOptionsSchema
 >;
 
 /**
@@ -740,7 +740,7 @@ export type ToolRouterSessionConfigHistoryItem = {
   config: ToolRouterSessionConfigHistoryConfig;
 };
 
-export type ToolRouterSessionConfigHistoryResponse = {
+export type ToolRouterSessionListConfigHistoryResponse = {
   items: ToolRouterSessionConfigHistoryItem[];
   nextCursor: string | null;
   totalPages: number;
@@ -748,10 +748,10 @@ export type ToolRouterSessionConfigHistoryResponse = {
   totalItems: number;
 };
 
-export type ToolRouterSessionConfigHistoryFn = (
-  options?: ToolRouterSessionConfigHistoryOptions,
+export type ToolRouterSessionListConfigHistoryFn = (
+  options?: ToolRouterSessionListConfigHistoryOptions,
   requestOptions?: ComposioRequestOptions
-) => Promise<ToolRouterSessionConfigHistoryResponse>;
+) => Promise<ToolRouterSessionListConfigHistoryResponse>;
 
 export type ToolRouterSessionDeleteFn = (
   requestOptions?: ComposioRequestOptions
@@ -795,7 +795,7 @@ export interface Session<
   /** Delete the session. Deleted sessions are no longer retrievable or executable. */
   delete: ToolRouterSessionDeleteFn;
   /** Page through the session's configuration history (newest first). */
-  configHistory: ToolRouterSessionConfigHistoryFn;
+  listConfigHistory: ToolRouterSessionListConfigHistoryFn;
   /** Proxy an API call through Composio's auth layer using the session's connected account */
   proxyExecute: ToolRouterSessionProxyExecuteFn;
   /** List custom tools registered in this session, with their final slugs and schemas */

--- a/ts/packages/core/test/models/toolRouter.test.ts
+++ b/ts/packages/core/test/models/toolRouter.test.ts
@@ -3661,7 +3661,7 @@ describe('ToolRouter', () => {
     });
   });
 
-  describe('session.configHistory', () => {
+  describe('session.listConfigHistory', () => {
     const sessionId = 'session_123';
     const rawHistoryItem = {
       version: 2,
@@ -3687,7 +3687,7 @@ describe('ToolRouter', () => {
       });
 
       const session = await toolRouter.use(sessionId);
-      const result = await session.configHistory({ limit: 2 });
+      const result = await session.listConfigHistory({ limit: 2 });
 
       expect(mockClient.toolRouter.session.configHistory).toHaveBeenCalledWith(
         sessionId,
@@ -3727,7 +3727,7 @@ describe('ToolRouter', () => {
       const signal = new AbortController().signal;
 
       const session = await toolRouter.use(sessionId);
-      const result = await session.configHistory(undefined, { signal });
+      const result = await session.listConfigHistory(undefined, { signal });
 
       expect(mockClient.toolRouter.session.configHistory).toHaveBeenCalledWith(
         sessionId,
@@ -3742,9 +3742,9 @@ describe('ToolRouter', () => {
 
       const session = await toolRouter.use(sessionId);
 
-      await expect(session.configHistory({ limit: 'ten' as unknown as number })).rejects.toThrow(
-        ValidationError
-      );
+      await expect(
+        session.listConfigHistory({ limit: 'ten' as unknown as number })
+      ).rejects.toThrow(ValidationError);
       expect(mockClient.toolRouter.session.configHistory).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
This PR:

- builds on top of https://github.com/ComposioHQ/composio/pull/4449
- renames the paginated session history methods to `session.listConfigHistory()` in TypeScript and `session.list_config_history()` in Python
- keeps the generated-client delegation to `configHistory()` / `config_history()` unchanged
- renames the operation-specific TypeScript option, response, and function types for consistency
- adds an `@composio/core` patch changeset
- breaking:
  - removes `session.configHistory()` and its operation-specific TypeScript types
  - removes Python `session.config_history()`

## Context

Verified with the focused TypeScript Tool Router tests (125 passed), `@composio/core` typecheck, Python Tool Router tests (97 passed), Ruff, changeset validation, and `git diff --check`.