### PR TITLE
fix(cli): use the stored login backend and recover from rejected keys

### DIFF
--- a/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
+++ b/ts/e2e-tests/cli/toolkits/info/e2e.test.ts
@@ -29,9 +29,27 @@ e2e(import.meta.url, {
     let redirectResult: E2ETestResultWithFiles<'out.json'>;
     let invalidResult: E2ETestResult;
     let missingSlugResult: E2ETestResult;
+    let storedLoginResult: E2ETestResult;
+    let rejectedLoginResult: E2ETestResult;
+
+    // Seeds a stored login pointing at the mock backend and runs the command
+    // with no COMPOSIO_BASE_URL, so only user_data.json can select the backend.
+    const withStoredLogin = (apiKey: string, cacheDir: string, command: string) => {
+      const userData = JSON.stringify({
+        api_key: apiKey,
+        base_url: server.dockerBaseUrl,
+        web_url: 'http://host.docker.internal/',
+        org_id: 'org_mock',
+      });
+      return [
+        `mkdir -p ${cacheDir}`,
+        `printf '%s' '${userData}' > ${cacheDir}/user_data.json`,
+        `COMPOSIO_CACHE_DIR=${cacheDir} ${command}`,
+      ].join(' && ');
+    };
 
     beforeAll(async () => {
-      server = await startMockToolkitsListServer();
+      server = await startMockToolkitsListServer({ rejectedUserApiKeys: ['uak_revoked'] });
 
       const envPrefix = [
         `COMPOSIO_BASE_URL=${server.dockerBaseUrl}`,
@@ -48,6 +66,20 @@ e2e(import.meta.url, {
         `${envPrefix} composio dev toolkits info nonexistent_toolkit_xyz12345`
       );
       missingSlugResult = await runCmd(`${envPrefix} composio dev toolkits info`);
+      storedLoginResult = await runCmd(
+        withStoredLogin(
+          'uak_stored_login',
+          '/tmp/composio-stored-login',
+          'composio dev toolkits info gmail'
+        )
+      );
+      rejectedLoginResult = await runCmd(
+        withStoredLogin(
+          'uak_revoked',
+          '/tmp/composio-rejected-login',
+          'composio dev toolkits info gmail'
+        )
+      );
     }, TIMEOUTS.FIXTURE);
 
     afterAll(async () => {
@@ -144,6 +176,28 @@ e2e(import.meta.url, {
 
       it('stderr is empty', () => {
         expect(missingSlugResult.stderr).toBe('');
+      });
+    });
+
+    describe('stored login without COMPOSIO_BASE_URL', () => {
+      it('uses the stored backend and succeeds', () => {
+        expect(storedLoginResult.exitCode).toBe(0);
+        expect(storedLoginResult.stderr).toBe('');
+        const obj = parseJsonStdout(storedLoginResult) as Record<string, unknown>;
+        expect(obj.slug).toBe('gmail');
+      });
+    });
+
+    describe('stored login the backend rejects (piped)', () => {
+      it('prints the login next step on stderr', () => {
+        expect(rejectedLoginResult.stderr).toContain(
+          `Run \`COMPOSIO_BASE_URL=${server.dockerBaseUrl} composio login\` to log in again`
+        );
+        expect(rejectedLoginResult.stderr).not.toContain('Invalid or revoked user API key');
+      });
+
+      it('writes nothing to stdout', () => {
+        expect(sanitizeOutput(rejectedLoginResult.stdout)).toBe('');
       });
     });
 

--- a/ts/packages/cli/CHANGELOG.md
+++ b/ts/packages/cli/CHANGELOG.md
@@ -41,6 +41,23 @@
   `https://staging-dashboard.composio.dev/`.
 - `composio dev auth-configs create` now sends custom OAuth credentials and scopes
   in the API's expected shape instead of failing validation.
+- Commands now call the backend you logged in to. The CLI recorded that backend
+  in `user_data.json` but ignored it, so a staging login stopped working as soon
+  as `COMPOSIO_BASE_URL` or `COMPOSIO_ENVIRONMENT` was unset, and failed with
+  `Invalid or revoked user API key`. An explicit `COMPOSIO_BASE_URL` or
+  `COMPOSIO_ENVIRONMENT` still wins, and the CLI now warns when it sends your
+  stored key to a different backend. A key from `COMPOSIO_USER_API_KEY` keeps
+  using the backend the env vars select.
+- `composio login` names the backend it logs in to when it is not production,
+  and `composio orgs switch` no longer moves your login to another backend.
+  When you are already logged in, `composio login` checks the stored key and
+  logs in again if the backend rejects it.
+- A rejected API key is reported once, after the command's output, naming the
+  backend that rejected it. In an interactive terminal the CLI offers to log in
+  again and keeps your old key if you decline or the login fails. Otherwise, the
+  message gives the exact next step, for example
+  `COMPOSIO_ENVIRONMENT=staging composio login`, and reaches stderr even when it
+  is captured by a script or an agent.
 
 ## 0.3.3
 

--- a/ts/packages/cli/README.md
+++ b/ts/packages/cli/README.md
@@ -56,10 +56,10 @@ By default, both files are stored in `~/.composio`, but you can specify a custom
 
 | Environment Variable                     | JSON config                         | Description                                                                                            | Default                                                                  |
 | ---------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
-| COMPOSIO_USER_API_KEY                    | `user_data.json`: `api_key`         | Composio user API key                                                                                  | None                                                                     |
-| COMPOSIO_ENVIRONMENT                     | -                                   | Selects the production or staging URL defaults                                                         | production                                                               |
-| COMPOSIO_BASE_URL                        | `user_data.json`: `base_url`        | The base URL of the Composio backend API                                                               | https://backend.composio.dev                                             |
-| COMPOSIO_WEB_URL                         | `user_data.json`: `web_url`         | The base URL of the Composio web app                                                                   | https://dashboard.composio.dev/                                          |
+| COMPOSIO_USER_API_KEY                    | `user_data.json`: `api_key`         | Composio user API key; the env var is used instead of the stored key                                   | None                                                                     |
+| COMPOSIO_ENVIRONMENT                     | -                                   | Selects the production or staging backend and web app, overriding the stored login environment         | production                                                               |
+| COMPOSIO_BASE_URL                        | `user_data.json`: `base_url`        | The base URL of the Composio backend API, overriding the stored one                                    | Stored `base_url`, then https://backend.composio.dev                     |
+| COMPOSIO_WEB_URL                         | `user_data.json`: `web_url`         | The base URL of the Composio web app, overriding the stored one                                        | Stored `web_url`, then https://dashboard.composio.dev/                   |
 | COMPOSIO_CACHE_DIR                       | -                                   | The directory where the Composio CLI stores cache files                                                | ~/.composio                                                              |
 | COMPOSIO_SESSION_DIR                     | `config.json`: `artifact_directory` | The root directory for CLI session artifacts                                                           | `COMPOSIO_CACHE_DIR`, then `artifact_directory`, then `$TMPDIR/composio` |
 | COMPOSIO_BIN_DIR                         | -                                   | The directory `composio install` adds to `PATH` (see below)                                            | Resolved from the running binary                                         |
@@ -74,6 +74,13 @@ By default, both files are stored in `~/.composio`, but you can specify a custom
 | DEBUG_OVERRIDE_VERSION                   | -                                   | The version to use when upgrading the Composio CLI (for debugging)                                     | None                                                                     |
 | FORCE_USE_CACHE                          | -                                   | Whether to force the use of previously cached HTTP responses                                           | None                                                                     |
 | NO_COLOR                                 | -                                   | If set, disables color output in the CLI (https://no-color.org/)                                       | None                                                                     |
+
+A user API key only works on the backend that issued it, so `composio login` records that backend in `user_data.json` along with the key. The backend a command calls is resolved in this order:
+
+1. With a key from `COMPOSIO_USER_API_KEY`: `COMPOSIO_BASE_URL`, then `COMPOSIO_ENVIRONMENT`, then production. The stored `base_url` is ignored.
+2. With the stored key: `COMPOSIO_BASE_URL`, then `COMPOSIO_ENVIRONMENT`, then the stored `base_url`, then production. When an env var points the stored key at a different backend, the CLI warns before making requests.
+
+`composio login` targets `COMPOSIO_BASE_URL`, then `COMPOSIO_ENVIRONMENT`, then production, and names the backend first when it is not production. To log in to staging, run `COMPOSIO_ENVIRONMENT=staging composio login`.
 
 The CLI and its installer use these variables to coordinate nested commands. They aren't intended for manual configuration.
 

--- a/ts/packages/cli/scripts/mock-toolkits-server.ts
+++ b/ts/packages/cli/scripts/mock-toolkits-server.ts
@@ -84,18 +84,39 @@ const parseLimit = (req: IncomingMessage): number => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 30;
 };
 
+// The body the backend sends for a revoked or foreign user API key.
+const USER_API_KEY_REJECTION = {
+  error: {
+    message: 'Invalid or revoked user API key',
+    code: 2113,
+    slug: 'UserApiKey_Unauthorized',
+    status: 401,
+    request_id: 'mock-request-id',
+    suggested_fix: '',
+  },
+} as const;
+
 export async function startMockToolkitsListServer(options?: {
   host?: string;
   port?: number;
+  /** Requests carrying one of these `x-user-api-key` values get a 401 rejection. */
+  rejectedUserApiKeys?: ReadonlyArray<string>;
 }): Promise<MockToolkitsServer> {
   const host = options?.host ?? '0.0.0.0';
   const port = options?.port ?? 0;
+  const rejectedUserApiKeys = new Set(options?.rejectedUserApiKeys ?? []);
   const requests: string[] = [];
 
   const server = createServer((req, res) => {
     const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`);
     const method = req.method ?? 'GET';
     requests.push(`${method} ${url.pathname}${url.search}`);
+
+    const userApiKey = req.headers['x-user-api-key'];
+    if (typeof userApiKey === 'string' && rejectedUserApiKeys.has(userApiKey)) {
+      sendJson(res, 401, USER_API_KEY_REJECTION);
+      return;
+    }
 
     if (
       method === 'GET' &&

--- a/ts/packages/cli/src/analytics/dispatch.ts
+++ b/ts/packages/cli/src/analytics/dispatch.ts
@@ -21,6 +21,7 @@ import { extendConfigProvider } from 'src/services/config';
 import { atomicWriteFileString } from 'src/utils/atomic-write';
 import { sha256Hex } from 'src/utils/checksums';
 import { djb2Hash } from 'src/utils/djb2';
+import { type ApiKeySource, resolveBackend } from 'src/utils/backend-resolution';
 import { NodeOs } from 'src/services/node-os';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { isTelemetryDebugEnabled, TELEMETRY_DEBUG_FLAG } from 'src/services/runtime-flags';
@@ -504,18 +505,34 @@ const withCliSessionId = (event: NonNullable<TrackEvent>, cliSessionId?: string)
   },
 });
 
-export const readApiBaseUrl = Effect.gen(function* () {
-  const envBaseUrl = configuredString(
-    yield* optionalString('COMPOSIO_BASE_URL').parse(getEnvironmentProvider())
-  );
-  if (envBaseUrl) {
-    return envBaseUrl.replace(/\/+$/u, '');
-  }
+const storedString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 
+/**
+ * The backend commands would call, resolved with the same rule: the stored
+ * `base_url` for a stored key unless an env var overrides it, the ambient
+ * environment for a `COMPOSIO_USER_API_KEY` key.
+ */
+export const readApiBaseUrl = Effect.gen(function* () {
+  const provider = getEnvironmentProvider();
+  const envApiKey = configuredString(
+    yield* optionalString('COMPOSIO_USER_API_KEY').parse(provider)
+  );
   const userConfig = yield* readUserConfig;
-  return typeof userConfig?.base_url === 'string' && userConfig.base_url.trim().length > 0
-    ? userConfig.base_url.trim().replace(/\/+$/u, '')
-    : null;
+  const hasStoredKey =
+    storedString(userConfig?.api_key) !== undefined || (yield* keyringBackedLoginPresent);
+  const keySource: ApiKeySource = envApiKey ? 'env' : hasStoredKey ? 'stored' : 'none';
+
+  const { target } = resolveBackend({
+    overrides: {
+      baseURL: configuredString(yield* optionalString('COMPOSIO_BASE_URL').parse(provider)),
+      webURL: undefined,
+      environment: configuredString(yield* optionalString('COMPOSIO_ENVIRONMENT').parse(provider)),
+    },
+    stored: { baseURL: storedString(userConfig?.base_url), webURL: undefined },
+    keySource,
+  });
+  return target.baseURL.replace(/\/+$/u, '');
 }).pipe(Effect.catchCause(() => Effect.succeed(null)));
 
 const getCliCodactFailuresEndpoint = Effect.map(readApiBaseUrl, baseUrl =>

--- a/ts/packages/cli/src/analytics/events.ts
+++ b/ts/packages/cli/src/analytics/events.ts
@@ -439,7 +439,7 @@ const isSearchCommand = (commandPath: string): boolean =>
 const isLinkCommand = (commandPath: string): boolean =>
   commandPath === 'link' || commandPath === 'dev connected-accounts link';
 
-const isLoginCommand = (commandPath: string): boolean => commandPath === 'login';
+export const isLoginCommand = (commandPath: string): boolean => commandPath === 'login';
 
 const isLogoutCommand = (commandPath: string): boolean => commandPath === 'logout';
 

--- a/ts/packages/cli/src/analytics/events.ts
+++ b/ts/packages/cli/src/analytics/events.ts
@@ -181,7 +181,7 @@ const TOOL_VALIDATION_CODES: ReadonlySet<number> = new Set([
   3702, // ComposioTools_ValidationError
 ]);
 
-const extractCommandPath = (argv: ReadonlyArray<string>): string => {
+export const extractCommandPath = (argv: ReadonlyArray<string>): string => {
   const commandTokens: string[] = [];
 
   for (const token of argv.slice(2)) {

--- a/ts/packages/cli/src/cli-main.ts
+++ b/ts/packages/cli/src/cli-main.ts
@@ -109,6 +109,7 @@ import { showUpdateNotice } from 'src/services/update-check';
 import {
   configureCliAnalyticsReleaseVersion,
   createCliCommandTelemetryContext,
+  extractCommandPath,
   getExecuteCommandToolSlug,
   getPrimaryLifecycleFailedEvent,
   getPrimaryLifecycleInvokedEvent,
@@ -119,6 +120,9 @@ import { getVersion } from 'src/effects/version';
 import { toolkitFromToolSlug } from 'src/effects/toolkit-from-tool-slug';
 import { mapOnlyComposioOverrideError } from 'src/services/composio-error-overrides';
 import { AuthRejectionRecorder, recordIfUserApiKeyRejection } from 'src/services/auth-rejection';
+import { reportAuthRejection } from 'src/effects/auth-rejection-recovery';
+import { reloginWithBrowser } from 'src/commands/login.cmd';
+import { isUserApiKeyRejection } from 'src/utils/api-error-extraction';
 import { SetupSkillInstaller } from 'src/services/setup-skill-installer';
 import { SetupCommandError } from 'src/services/setup';
 import { ShellSetupAbortError } from 'src/commands/install.cmd';
@@ -315,10 +319,23 @@ export type CliBootstrapOptions = {
   readonly telemetryDebug: boolean;
 };
 
+// `composio login` is itself the recovery from a rejected key: its failures are
+// about the key it was given, so they keep the regular error output.
+const reportsAuthRejection = (argv: ReadonlyArray<string>) => extractCommandPath(argv) !== 'login';
+
 const cliProgram = (argv: ReadonlyArray<string>) =>
   showUpdateNotice.pipe(
     Effect.andThen(showPluginAcquisitionHint(argv)),
     Effect.andThen(runWithTelemetry(argv)),
+    // A rejected key is reported once, by `reportAuthRejection` below, instead
+    // of as a raw backend error.
+    Effect.catchIf(
+      error => reportsAuthRejection(argv) && isUserApiKeyRejection(error),
+      () =>
+        Effect.sync(() => {
+          process.exitCode = 1;
+        })
+    ),
     Effect.catchIf(
       (error): error is SetupCommandError => error instanceof SetupCommandError,
       error =>
@@ -418,6 +435,11 @@ const cliProgram = (argv: ReadonlyArray<string>) =>
           }
         }
       })
+    ),
+    Effect.andThen(
+      reportsAuthRejection(argv)
+        ? reportAuthRejection({ relogin: target => reloginWithBrowser({ target }) })
+        : Effect.void
     ),
     Effect.provide(layers),
     // v4 removed `Effect.withConfigProvider` (a FiberRef-scoped combinator); `ConfigProvider` is

--- a/ts/packages/cli/src/cli-main.ts
+++ b/ts/packages/cli/src/cli-main.ts
@@ -118,6 +118,7 @@ import { trackCliEventEffect } from 'src/analytics/dispatch';
 import { getVersion } from 'src/effects/version';
 import { toolkitFromToolSlug } from 'src/effects/toolkit-from-tool-slug';
 import { mapOnlyComposioOverrideError } from 'src/services/composio-error-overrides';
+import { AuthRejectionRecorder, recordIfUserApiKeyRejection } from 'src/services/auth-rejection';
 import { SetupSkillInstaller } from 'src/services/setup-skill-installer';
 import { SetupCommandError } from 'src/services/setup';
 import { ShellSetupAbortError } from 'src/commands/install.cmd';
@@ -195,6 +196,9 @@ export const SetupSkillInstallerLive = Layer.provide(
 
 const layers = Layer.mergeAll(
   CliConfigLive.pipe(Layer.provide(ConfigLive)),
+  // The same layer value that `ComposioClientSingleton.Default` provides, so the
+  // runtime shares one recorder between the SDK clients and `cliProgram`.
+  AuthRejectionRecorder.Default,
   NodeOs.Default,
   NodeProcess.Default,
   UpgradeBinaryLive,
@@ -289,6 +293,7 @@ const runWithTelemetry = (argv: ReadonlyArray<string>) =>
       Effect.mapError(error =>
         CliError.isCliError(error) ? error : mapOnlyComposioOverrideError({ error })
       ),
+      Effect.tapError(recordIfUserApiKeyRejection),
       Effect.tap(() =>
         trackCliEventEffect(getPrimaryLifecycleSucceededEvent(commandTelemetryContext))
       ),

--- a/ts/packages/cli/src/cli-main.ts
+++ b/ts/packages/cli/src/cli-main.ts
@@ -111,6 +111,7 @@ import {
   createCliCommandTelemetryContext,
   extractCommandPath,
   getExecuteCommandToolSlug,
+  isLoginCommand,
   getPrimaryLifecycleFailedEvent,
   getPrimaryLifecycleInvokedEvent,
   getPrimaryLifecycleSucceededEvent,
@@ -321,7 +322,8 @@ export type CliBootstrapOptions = {
 
 // `composio login` is itself the recovery from a rejected key: its failures are
 // about the key it was given, so they keep the regular error output.
-const reportsAuthRejection = (argv: ReadonlyArray<string>) => extractCommandPath(argv) !== 'login';
+const reportsAuthRejection = (argv: ReadonlyArray<string>) =>
+  !isLoginCommand(extractCommandPath(argv));
 
 const cliProgram = (argv: ReadonlyArray<string>) =>
   showUpdateNotice.pipe(

--- a/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
+++ b/ts/packages/cli/src/commands/connected-accounts/commands/connected-accounts.link.cmd.ts
@@ -7,6 +7,7 @@ import { TerminalUI } from 'src/services/terminal-ui';
 import { requireAuth } from 'src/effects/require-auth';
 import { resolveToolRouterSession } from 'src/effects/create-tool-router-session';
 import { extractMessage, extractSlug } from 'src/utils/api-error-extraction';
+import { reportUnlessUserApiKeyRejection } from 'src/services/auth-rejection';
 import { ProjectContext } from 'src/services/project-context';
 import { ComposioClientSingleton, getSessionInfoByUserApiKey } from 'src/services/composio-clients';
 import { linkApolloIdentityForAnalytics } from 'src/analytics/dispatch';
@@ -708,12 +709,17 @@ const handleLegacyAuthConfigLink = (params: {
         Effect.asSome,
         Effect.catch(error =>
           Effect.gen(function* () {
-            const message =
-              extractMessage(error) ??
-              `Failed to create link for auth config "${params.authConfigId}".`;
-            yield* params.ui.log.error(message);
-            yield* params.ui.log.step(
-              'Browse available auth configs:\n> composio dev auth-configs list'
+            yield* reportUnlessUserApiKeyRejection(
+              error,
+              Effect.gen(function* () {
+                const message =
+                  extractMessage(error) ??
+                  `Failed to create link for auth config "${params.authConfigId}".`;
+                yield* params.ui.log.error(message);
+                yield* params.ui.log.step(
+                  'Browse available auth configs:\n> composio dev auth-configs list'
+                );
+              })
             );
             return Option.none();
           })
@@ -928,11 +934,16 @@ const runConnectedAccountsLink = (params: {
               return Option.none();
             }
 
-            const message =
-              extractMessage(error) ?? `Failed to create link for toolkit "${toolkitSlug}".`;
-            yield* ui.log.error(message);
             yield* Effect.logDebug('Link error:', error);
-            yield* ui.log.step('Browse available toolkits:\n> composio dev toolkits list');
+            yield* reportUnlessUserApiKeyRejection(
+              error,
+              Effect.gen(function* () {
+                const message =
+                  extractMessage(error) ?? `Failed to create link for toolkit "${toolkitSlug}".`;
+                yield* ui.log.error(message);
+                yield* ui.log.step('Browse available toolkits:\n> composio dev toolkits list');
+              })
+            );
             return Option.none();
           })
         ),

--- a/ts/packages/cli/src/commands/init.cmd.ts
+++ b/ts/packages/cli/src/commands/init.cmd.ts
@@ -257,7 +257,7 @@ const initInteractiveFlow = (params: { composioDir: string; noBrowser: boolean; 
     let globalApiKey = yield* getGlobalUserApiKey();
     if (!globalApiKey) {
       yield* ui.log.step('No credentials found. Logging in...');
-      yield* browserLogin({ scope: 'project', noBrowser });
+      yield* browserLogin({ scope: 'project', noBrowser, target: ctx.backend.ambient });
       globalApiKey = yield* getGlobalUserApiKey();
     }
 

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -691,6 +691,123 @@ const loginWithKey = (params: {
     };
   });
 
+const openLoginPage = (url: string) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    yield* Effect.tryPromise({
+      try: () => open(url, { wait: false }),
+      catch: cause => new LoginBrowserOpenError({ message: 'Failed to open the browser.', cause }),
+    }).pipe(
+      Effect.catchTag('commands/LoginBrowserOpenError', error =>
+        Effect.gen(function* () {
+          yield* Effect.logDebug('Failed to open browser:', error);
+          yield* ui.log.warn('Could not open the browser automatically.');
+          yield* ui.log.info(`Tip: try using the \`--no-browser\` flag and open the URL manually.`);
+        })
+      )
+    );
+  });
+
+const awaitLinkedBrowserSession = (params: { sessionId: string; target: BackendTarget }) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    const client = yield* ComposioSessionRepository;
+    return yield* ui.useMakeSpinner('Waiting for login...', spinner =>
+      Effect.retry(
+        Effect.gen(function* () {
+          const currentSession = yield* client.getSession({
+            id: params.sessionId,
+            baseURL: params.target.baseURL,
+          });
+          if (currentSession.status === 'linked') {
+            return currentSession;
+          }
+          return yield* new LoginSessionError({
+            message: `Session status is still '${currentSession.status}', waiting for 'linked'`,
+            operation: 'poll',
+            status: currentSession.status,
+          });
+        }),
+        {
+          schedule: Schedule.max([
+            Schedule.exponential('0.3 seconds'),
+            Schedule.spaced('5 seconds'),
+          ]),
+          times: 15,
+        }
+      ).pipe(
+        Effect.tap(() => spinner.stop('Login successful')),
+        Effect.tapError(() => spinner.error('Login timed out. Please try again.'))
+      )
+    );
+  });
+
+/**
+ * Logs in again after the backend rejected the stored key, against the
+ * stored environment. It writes nothing to stdout, skips the org picker, and
+ * stores the new key only after the session is linked and verified, so a
+ * declined, cancelled, or failed login leaves the old credentials in place.
+ *
+ * The previous org and test user id are kept when the new key can still
+ * access that org; otherwise the session's default org is used and named.
+ */
+export const reloginWithBrowser = (params: { target: BackendTarget }) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    const ctx = yield* ComposioUserContext;
+    const client = yield* ComposioSessionRepository;
+    const { target } = params;
+    const previousOrgId = Option.getOrUndefined(ctx.data.orgId);
+    const previousTestUserId = Option.getOrUndefined(ctx.data.testUserId);
+
+    yield* announceLoginTarget(target);
+    const session = yield* client.createSession({ scope: 'user', baseURL: target.baseURL });
+    const url = `${target.webURL}?cliKey=${session.id}`;
+    yield* ui.log.step('Redirecting you to the login page');
+    yield* ui.note(url, 'Login URL');
+    yield* openLoginPage(url);
+
+    const linkedSession = yield* awaitLinkedBrowserSession({ sessionId: session.id, target });
+    const apiKey = linkedSession.api_key;
+
+    const previousOrgSession =
+      previousOrgId === undefined
+        ? Option.none<SessionInfoResponse>()
+        : yield* getSessionInfoByUserApiKey({
+            baseURL: target.baseURL,
+            userApiKey: apiKey,
+            orgId: previousOrgId,
+          }).pipe(Effect.option);
+
+    const sessionInfo = Option.isSome(previousOrgSession)
+      ? previousOrgSession.value
+      : yield* getSessionInfoByUserApiKey({ baseURL: target.baseURL, userApiKey: apiKey });
+    const sessionUserId = sessionInfo.org_member.user_id ?? sessionInfo.org_member.id;
+    const sessionTestUserId = sessionUserId ? `pg-test-${sessionUserId}` : undefined;
+    const keepsPreviousOrg = Option.isSome(previousOrgSession);
+    const orgId = (keepsPreviousOrg ? previousOrgId : undefined) ?? sessionInfo.project.org.id;
+    const testUserId = keepsPreviousOrg
+      ? (previousTestUserId ?? sessionTestUserId)
+      : sessionTestUserId;
+
+    yield* ctx.login({ apiKey, target, orgId, testUserId });
+    if (!keepsPreviousOrg && previousOrgId !== undefined) {
+      yield* ui.log.warn(
+        `Your previous org is not available to this account. Using "${sessionInfo.project.org.name}".`
+      );
+    }
+
+    yield* linkAnalyticsIdentityForOrg({
+      apiKey,
+      baseURL: target.baseURL,
+      orgId,
+      knownIdentity: {
+        orgId: sessionInfo.project.org.id,
+        orgMemberId: sessionInfo.org_member.id,
+      },
+    });
+  });
+
 /**
  * Runs the browser-based login flow: creates a CLI session, opens the browser,
  * polls until linked, enriches via session/info, and stores credentials.
@@ -768,51 +885,10 @@ export const browserLogin = (params: {
     yield* ui.output(url);
 
     if (!effectiveNoBrowser) {
-      yield* Effect.tryPromise({
-        try: () => open(url, { wait: false }),
-        catch: cause =>
-          new LoginBrowserOpenError({ message: 'Failed to open the browser.', cause }),
-      }).pipe(
-        Effect.catchTag('commands/LoginBrowserOpenError', error =>
-          Effect.gen(function* () {
-            yield* Effect.logDebug('Failed to open browser:', error);
-            yield* ui.log.warn('Could not open the browser automatically.');
-            yield* ui.log.info(
-              `Tip: try using the \`--no-browser\` flag and open the URL manually.`
-            );
-          })
-        )
-      );
+      yield* openLoginPage(url);
     }
 
-    const linkedSession = yield* ui.useMakeSpinner('Waiting for login...', spinner =>
-      Effect.retry(
-        Effect.gen(function* () {
-          const currentSession = yield* client.getSession({
-            id: session.id,
-            baseURL: target.baseURL,
-          });
-          if (currentSession.status === 'linked') {
-            return currentSession;
-          }
-          return yield* new LoginSessionError({
-            message: `Session status is still '${currentSession.status}', waiting for 'linked'`,
-            operation: 'poll',
-            status: currentSession.status,
-          });
-        }),
-        {
-          schedule: Schedule.max([
-            Schedule.exponential('0.3 seconds'),
-            Schedule.spaced('5 seconds'),
-          ]),
-          times: 15,
-        }
-      ).pipe(
-        Effect.tap(() => spinner.stop('Login successful')),
-        Effect.tapError(() => spinner.error('Login timed out. Please try again.'))
-      )
-    );
+    const linkedSession = yield* awaitLinkedBrowserSession({ sessionId: session.id, target });
 
     yield* Effect.logDebug(`Linked session ID: ${linkedSession.id}`);
 

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -23,7 +23,8 @@ import { inferSkillReleaseChannel, installSkillSafe } from 'src/effects/install-
 import { handleAgentAuthError } from 'src/effects/handle-agent-auth-error';
 import { APP_VERSION } from 'src/constants';
 import { announceLoginTarget } from 'src/effects/announce-login-target';
-import type { BackendTarget } from 'src/utils/backend-resolution';
+import { type BackendTarget, backendHost, currentLoginBackend } from 'src/utils/backend-resolution';
+import { isUserApiKeyRejection } from 'src/utils/api-error-extraction';
 import {
   ensureAgentSignupAllowed,
   getOrSignupReadyAgent,
@@ -318,6 +319,34 @@ const emitLoginComplete = (params: {
       yield* ui.outro("You're all set!");
     }
   });
+
+/**
+ * Recheck the stored key against the backend it belongs to. Only a
+ * `UserApiKey_Unauthorized` rejection counts: a transport or decoding failure
+ * keeps the "already logged in" answer, as before.
+ */
+const storedKeyRejected = Effect.gen(function* () {
+  const ctx = yield* ComposioUserContext;
+  const ui = yield* TerminalUI;
+  if (ctx.backend.keySource !== 'stored') return false;
+  const apiKey = Option.getOrUndefined(ctx.data.apiKey);
+  if (apiKey === undefined) return false;
+
+  const storedBackend = currentLoginBackend(ctx.backend);
+  const rejected = yield* getSessionInfoByUserApiKey({
+    baseURL: storedBackend.baseURL,
+    userApiKey: apiKey,
+  }).pipe(
+    Effect.as(false),
+    Effect.catch(error => Effect.succeed(isUserApiKeyRejection(error)))
+  );
+  if (rejected) {
+    yield* ui.log.warn(
+      `The Composio API at ${backendHost(storedBackend.baseURL)} rejected your stored API key. Logging in again.`
+    );
+  }
+  return rejected;
+});
 
 const completeAgentLogin = (identity: AgentIdentity) =>
   Effect.gen(function* () {
@@ -1112,14 +1141,16 @@ export const loginCmd = Command.make(
       }
 
       if (ctx.isLoggedIn()) {
-        if (Option.isSome(ctx.data.orgId)) {
+        if (Option.isSome(ctx.data.orgId) && !(yield* storedKeyRejected)) {
           yield* ui.log.warn(`You're already logged in!`);
           yield* ui.outro(
             'If you want to log in with a different account, please run `composio logout` first.'
           );
           return;
         }
-        yield* ui.log.step('Re-authenticating for multi-project support...');
+        if (Option.isNone(ctx.data.orgId)) {
+          yield* ui.log.step('Re-authenticating for multi-project support...');
+        }
       }
 
       // Reuse-only by design: headless login may complete with an existing

--- a/ts/packages/cli/src/commands/login.cmd.ts
+++ b/ts/packages/cli/src/commands/login.cmd.ts
@@ -22,6 +22,8 @@ import { primeConsumerConnectedToolkitsCacheInBackground } from 'src/services/co
 import { inferSkillReleaseChannel, installSkillSafe } from 'src/effects/install-skill';
 import { handleAgentAuthError } from 'src/effects/handle-agent-auth-error';
 import { APP_VERSION } from 'src/constants';
+import { announceLoginTarget } from 'src/effects/announce-login-target';
+import type { BackendTarget } from 'src/utils/backend-resolution';
 import {
   ensureAgentSignupAllowed,
   getOrSignupReadyAgent,
@@ -363,17 +365,19 @@ const resolveDirectLoginOrganization = (params: {
     return match;
   });
 
-const directLogin = (params: { userApiKey: string; org?: string }) =>
+const directLogin = (params: { userApiKey: string; org?: string; target: BackendTarget }) =>
   Effect.gen(function* () {
     const ctx = yield* ComposioUserContext;
+    const { target } = params;
+    yield* announceLoginTarget(target);
     const sessionInfo = yield* getSessionInfoByUserApiKey({
-      baseURL: ctx.data.baseURL,
+      baseURL: target.baseURL,
       userApiKey: params.userApiKey,
     });
 
     const selectedOrg = yield* resolveDirectLoginOrganization({
       apiKey: params.userApiKey,
-      baseURL: ctx.data.baseURL,
+      baseURL: target.baseURL,
       requestedOrg: params.org,
       fallbackOrgId: sessionInfo.project.org.id,
       fallbackOrgName: sessionInfo.project.org.name,
@@ -384,10 +388,10 @@ const directLogin = (params: { userApiKey: string; org?: string }) =>
       ? `pg-test-${sessionUserId}`
       : Option.getOrUndefined(ctx.data.testUserId);
 
-    yield* ctx.login(params.userApiKey, selectedOrg.id, testUserId);
+    yield* ctx.login({ apiKey: params.userApiKey, target, orgId: selectedOrg.id, testUserId });
     yield* linkAnalyticsIdentityForOrg({
       apiKey: params.userApiKey,
-      baseURL: ctx.data.baseURL,
+      baseURL: target.baseURL,
       orgId: selectedOrg.id,
       knownIdentity: {
         orgId: sessionInfo.project.org.id,
@@ -412,7 +416,7 @@ const directLogin = (params: { userApiKey: string; org?: string }) =>
  * data and avoids hand-rolled structural types.
  */
 const storeCredentials = (params: {
-  baseURL: string;
+  target: BackendTarget;
   uakApiKey: string;
   initialOrgId: string;
   initialProjectId: string;
@@ -428,7 +432,7 @@ const storeCredentials = (params: {
     const ctx = yield* ComposioUserContext;
 
     const {
-      baseURL,
+      target,
       uakApiKey,
       initialOrgId,
       initialProjectId,
@@ -441,7 +445,7 @@ const storeCredentials = (params: {
     // Call session/info to enrich the login with org/project metadata.
     // All errors are non-fatal (browser login) since the linked session is already authenticated.
     const sessionInfo: SessionInfoResponse | undefined = yield* getSessionInfo({
-      baseURL,
+      baseURL: target.baseURL,
       apiKey: uakApiKey,
       orgId: initialOrgId,
       projectId: initialProjectId,
@@ -475,12 +479,12 @@ const storeCredentials = (params: {
       }
     }
 
-    yield* ctx.login(uakApiKey, orgId, testUserId);
+    yield* ctx.login({ apiKey: uakApiKey, target, orgId, testUserId });
     // Linked only after the credential persists, so stitching cannot outlive a failed login.
     if (!deferAnalyticsIdentity) {
       yield* linkAnalyticsIdentityForOrg({
         apiKey: uakApiKey,
-        baseURL,
+        baseURL: target.baseURL,
         orgId,
         knownIdentity: sessionInfo
           ? {
@@ -518,13 +522,16 @@ const loginWithKey = (params: {
   pollRetries?: number;
   defaultToFirstOrg?: boolean;
   skipOutput?: boolean;
+  target: BackendTarget;
 }) =>
   Effect.gen(function* () {
     const ui = yield* TerminalUI;
     const ctx = yield* ComposioUserContext;
     const client = yield* ComposioSessionRepository;
+    const { target } = params;
+    yield* announceLoginTarget(target);
 
-    const getSessionEffect = client.getSession({ id: params.key }).pipe(
+    const getSessionEffect = client.getSession({ id: params.key, baseURL: target.baseURL }).pipe(
       Effect.mapError(
         cause =>
           new LoginSessionError({
@@ -583,13 +590,13 @@ const loginWithKey = (params: {
     const uakApiKey = linkedSession.api_key;
 
     const uakSessionInfo = yield* getSessionInfoByUserApiKey({
-      baseURL: ctx.data.baseURL,
+      baseURL: target.baseURL,
       userApiKey: uakApiKey,
     });
 
     const organizations = params.defaultToFirstOrg
       ? yield* listOrganizations({
-          baseURL: ctx.data.baseURL,
+          baseURL: target.baseURL,
           apiKey: uakApiKey,
         }).pipe(
           Effect.map(response => response.data),
@@ -608,7 +615,7 @@ const loginWithKey = (params: {
 
     const willRunPicker = !params.skipOrgProjectPicker;
     yield* storeCredentials({
-      baseURL: ctx.data.baseURL,
+      target,
       uakApiKey,
       initialOrgId: xOrgId,
       initialProjectId: xProjectId,
@@ -621,7 +628,7 @@ const loginWithKey = (params: {
     if (willRunPicker) {
       const result = yield* runOrgSelection({
         apiKey: uakApiKey,
-        baseURL: ctx.data.baseURL,
+        baseURL: target.baseURL,
       }).pipe(
         Effect.catch(error =>
           Effect.gen(function* () {
@@ -634,11 +641,12 @@ const loginWithKey = (params: {
       if (result) {
         const sessionUserId = uakSessionInfo.org_member.user_id ?? uakSessionInfo.org_member.id;
         const testUserId = sessionUserId ? `pg-test-${sessionUserId}` : undefined;
-        yield* ctx.login(
-          uakApiKey,
-          result.id,
-          testUserId ?? Option.getOrUndefined(ctx.data.testUserId)
-        );
+        yield* ctx.login({
+          apiKey: uakApiKey,
+          target,
+          orgId: result.id,
+          testUserId: testUserId ?? Option.getOrUndefined(ctx.data.testUserId),
+        });
         yield* primeConsumerConnectedToolkitsCacheInBackground({
           orgId: result.id,
         });
@@ -647,7 +655,7 @@ const loginWithKey = (params: {
       const finalOrgName = result?.name ?? uakSessionInfo.project.org.name ?? '';
       yield* linkAnalyticsIdentityForOrg({
         apiKey: uakApiKey,
-        baseURL: ctx.data.baseURL,
+        baseURL: target.baseURL,
         orgId: finalOrgId,
         knownIdentity: {
           orgId: uakSessionInfo.project.org.id,
@@ -701,19 +709,26 @@ export const browserLogin = (params: {
   noWait?: boolean;
   /** When true (login only), skip org/project picker and use session defaults. When false, prompt for org/project. */
   skipOrgProjectPicker?: boolean;
+  /** Backend and dashboard the login runs against and records with the new key. */
+  target: BackendTarget;
 }) =>
   Effect.gen(function* () {
     const ui = yield* TerminalUI;
     const ctx = yield* ComposioUserContext;
     const client = yield* ComposioSessionRepository;
+    const { target } = params;
 
     yield* Effect.logDebug(`Authenticating (scope: ${params.scope})...`);
+    yield* announceLoginTarget(target);
 
-    const session = yield* client.createSession({ scope: params.scope });
+    const session = yield* client.createSession({
+      scope: params.scope,
+      baseURL: target.baseURL,
+    });
 
     yield* Effect.logDebug(`Created session: ${session.id}`);
 
-    const url = `${ctx.data.webURL}?cliKey=${session.id}`;
+    const url = `${target.webURL}?cliKey=${session.id}`;
     const pollCommand = 'composio login --poll';
     const expiresAt = DateTime.formatIso(session.expiresAt);
     yield* writePendingLoginSession({
@@ -773,7 +788,10 @@ export const browserLogin = (params: {
     const linkedSession = yield* ui.useMakeSpinner('Waiting for login...', spinner =>
       Effect.retry(
         Effect.gen(function* () {
-          const currentSession = yield* client.getSession({ ...session });
+          const currentSession = yield* client.getSession({
+            id: session.id,
+            baseURL: target.baseURL,
+          });
           if (currentSession.status === 'linked') {
             return currentSession;
           }
@@ -802,7 +820,7 @@ export const browserLogin = (params: {
     const uakApiKey = linkedSession.api_key;
 
     const uakSessionInfo = yield* getSessionInfoByUserApiKey({
-      baseURL: ctx.data.baseURL,
+      baseURL: target.baseURL,
       userApiKey: uakApiKey,
     });
 
@@ -815,7 +833,7 @@ export const browserLogin = (params: {
 
     const willRunPicker = params.scope === 'user' && !params.skipOrgProjectPicker;
     yield* storeCredentials({
-      baseURL: ctx.data.baseURL,
+      target,
       uakApiKey,
       initialOrgId: xOrgId,
       initialProjectId: xProjectId,
@@ -828,7 +846,7 @@ export const browserLogin = (params: {
     if (willRunPicker) {
       const result = yield* runOrgSelection({
         apiKey: uakApiKey,
-        baseURL: ctx.data.baseURL,
+        baseURL: target.baseURL,
       }).pipe(
         Effect.catch(error =>
           Effect.gen(function* () {
@@ -841,11 +859,12 @@ export const browserLogin = (params: {
       if (result) {
         const sessionUserId = uakSessionInfo.org_member.user_id ?? uakSessionInfo.org_member.id;
         const testUserId = sessionUserId ? `pg-test-${sessionUserId}` : undefined;
-        yield* ctx.login(
-          uakApiKey,
-          result.id,
-          testUserId ?? Option.getOrUndefined(ctx.data.testUserId)
-        );
+        yield* ctx.login({
+          apiKey: uakApiKey,
+          target,
+          orgId: result.id,
+          testUserId: testUserId ?? Option.getOrUndefined(ctx.data.testUserId),
+        });
         yield* primeConsumerConnectedToolkitsCacheInBackground({
           orgId: result.id,
         });
@@ -854,7 +873,7 @@ export const browserLogin = (params: {
       const finalOrgName = result?.name ?? uakSessionInfo.project.org.name ?? '';
       yield* linkAnalyticsIdentityForOrg({
         apiKey: uakApiKey,
-        baseURL: ctx.data.baseURL,
+        baseURL: target.baseURL,
         orgId: finalOrgId,
         knownIdentity: {
           orgId: uakSessionInfo.project.org.id,
@@ -958,6 +977,7 @@ export const loginCmd = Command.make(
           pollRetries: LOGIN_POLL_RETRIES,
           defaultToFirstOrg: true,
           skipOutput: true,
+          target: ctx.backend.ambient,
         });
         yield* clearPendingLoginSession;
         const pollSummaryParams = {
@@ -995,6 +1015,7 @@ export const loginCmd = Command.make(
           key: key.value,
           noWait,
           skipOrgProjectPicker: true,
+          target: ctx.backend.ambient,
         });
         if (!noSkillInstall && canPrompt) {
           yield* installSkillSafe({ channel: inferSkillReleaseChannel(APP_VERSION) });
@@ -1006,6 +1027,7 @@ export const loginCmd = Command.make(
         yield* directLogin({
           userApiKey: userApiKey.value,
           org: Option.getOrUndefined(org),
+          target: ctx.backend.ambient,
         });
         if (!noSkillInstall && canPrompt) {
           yield* installSkillSafe({ channel: inferSkillReleaseChannel(APP_VERSION) });
@@ -1048,6 +1070,7 @@ export const loginCmd = Command.make(
         noBrowser,
         noWait,
         skipOrgProjectPicker: yes,
+        target: ctx.backend.ambient,
       });
 
       if (!noSkillInstall && !noWait && canPrompt) {

--- a/ts/packages/cli/src/commands/orgs/commands/orgs.switch.cmd.ts
+++ b/ts/packages/cli/src/commands/orgs/commands/orgs.switch.cmd.ts
@@ -5,6 +5,7 @@ import { runOrgSelection } from 'src/effects/select-org-project';
 import { linkAnalyticsIdentityForOrg } from 'src/effects/link-analytics-identity';
 import { TerminalUI } from 'src/services/terminal-ui';
 import { ComposioUserContext } from 'src/services/user-context';
+import { currentLoginBackend } from 'src/utils/backend-resolution';
 
 const orgId = Flag.string('org-id').pipe(
   Flag.optional,
@@ -49,7 +50,13 @@ export const orgsCmd$Switch = Command.make('switch', { orgId, limit }, ({ orgId,
       return;
     }
 
-    yield* ctx.login(apiKey, result.id, Option.getOrUndefined(ctx.data.testUserId));
+    // Switching orgs keeps the current login, so it keeps that login's backend.
+    yield* ctx.login({
+      apiKey,
+      target: currentLoginBackend(ctx.backend),
+      orgId: result.id,
+      testUserId: Option.getOrUndefined(ctx.data.testUserId),
+    });
     yield* linkAnalyticsIdentityForOrg({
       apiKey,
       baseURL: ctx.data.baseURL,

--- a/ts/packages/cli/src/commands/py/commands/py.generate.cmd.ts
+++ b/ts/packages/cli/src/commands/py/commands/py.generate.cmd.ts
@@ -16,6 +16,7 @@ import {
 } from 'src/effects/toolkit-version-overrides';
 import { validateToolkitVersionOverrides } from 'src/effects/validate-toolkit-versions';
 import { TerminalUI } from 'src/services/terminal-ui';
+import { warnOnBackendMismatch } from 'src/effects/backend-mismatch-warning';
 
 export class PythonGenerationWriteError extends Data.TaggedError(
   'commands/PythonGenerationWriteError'
@@ -74,6 +75,7 @@ export function generatePythonTypeStubs({
     const client = yield* ComposioToolkitsRepository;
 
     yield* ui.intro('composio generate py');
+    yield* warnOnBackendMismatch;
 
     // Determine the actual output directory
     const outputDir = yield* outputOpt.pipe(

--- a/ts/packages/cli/src/commands/run.cmd.ts
+++ b/ts/packages/cli/src/commands/run.cmd.ts
@@ -11,6 +11,7 @@ import { resolveCommandProject } from 'src/services/command-project';
 import { type RunHelperContext } from 'src/services/run-helpers-runtime';
 import { warmToolInputDefinitions } from 'src/services/tool-input-validation';
 import { ComposioUserContext } from 'src/services/user-context';
+import { warnOnBackendMismatch } from 'src/effects/backend-mismatch-warning';
 import {
   debugFlagsToChildEnv,
   isAcpOnlyEnabled,
@@ -607,6 +608,7 @@ export const runCmd = Command.make('run', {
             new MissingRunSourceError({ message: MISSING_RUN_SOURCE_MESSAGE })
           );
         }
+        yield* warnOnBackendMismatch;
 
         const fs = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;

--- a/ts/packages/cli/src/commands/run.cmd.ts
+++ b/ts/packages/cli/src/commands/run.cmd.ts
@@ -12,6 +12,7 @@ import { type RunHelperContext } from 'src/services/run-helpers-runtime';
 import { warmToolInputDefinitions } from 'src/services/tool-input-validation';
 import { ComposioUserContext } from 'src/services/user-context';
 import { warnOnBackendMismatch } from 'src/effects/backend-mismatch-warning';
+import { recordIfUserApiKeyRejection } from 'src/services/auth-rejection';
 import {
   debugFlagsToChildEnv,
   isAcpOnlyEnabled,
@@ -396,7 +397,10 @@ const resolveRunHelperContext = () =>
       return baseContext;
     }
 
-    const consumerProject = yield* resolveCommandProject({ mode: 'consumer' }).pipe(Effect.option);
+    const consumerProject = yield* resolveCommandProject({ mode: 'consumer' }).pipe(
+      Effect.tapError(recordIfUserApiKeyRejection),
+      Effect.option
+    );
     if (Option.isNone(consumerProject) || consumerProject.value.projectType !== 'CONSUMER') {
       return baseContext;
     }

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.info.cmd.ts
@@ -7,6 +7,11 @@ import { resolveToolRouterSession } from 'src/effects/create-tool-router-session
 import { extractMessage } from 'src/utils/api-error-extraction';
 import { ProjectContext } from 'src/services/project-context';
 import { ComposioUserContext } from 'src/services/user-context';
+import {
+  hasRecordedAuthRejection,
+  recordIfUserApiKeyRejection,
+  reportUnlessUserApiKeyRejection,
+} from 'src/services/auth-rejection';
 import { formatToolkitInfo, formatToolkitInfoJson } from '../format';
 
 class ToolkitsInfoRequestError extends Data.TaggedError('commands/ToolkitsInfoRequestError')<{
@@ -88,7 +93,7 @@ export const toolkitsCmd$Info = Command.make(
           Effect.gen(function* () {
             const detailedToolkitOpt = yield* repo
               .getToolkitDetailed(slugValue)
-              .pipe(Effect.option);
+              .pipe(Effect.tapError(recordIfUserApiKeyRejection), Effect.option);
 
             if (Option.isSome(resolvedUserId)) {
               const client = yield* clientSingleton.get();
@@ -126,10 +131,16 @@ export const toolkitsCmd$Info = Command.make(
           Effect.asSome,
           Effect.catch(error =>
             Effect.gen(function* () {
-              const message = extractMessage(error) ?? `Failed to fetch toolkit "${slugValue}".`;
-              yield* ui.log.error(message);
               yield* Effect.logDebug('Toolkit info error:', error);
-              yield* ui.log.step('Browse available toolkits:\n> composio dev toolkits list');
+              yield* reportUnlessUserApiKeyRejection(
+                error,
+                Effect.gen(function* () {
+                  const message =
+                    extractMessage(error) ?? `Failed to fetch toolkit "${slugValue}".`;
+                  yield* ui.log.error(message);
+                  yield* ui.log.step('Browse available toolkits:\n> composio dev toolkits list');
+                })
+              );
               return Option.none();
             })
           )
@@ -142,6 +153,11 @@ export const toolkitsCmd$Info = Command.make(
       const result = resultOpt.value;
       const toolkit = result.toolkit;
       const detailedToolkit = Option.getOrUndefined(result.detailedToolkitOpt);
+
+      // A rejected key hides the toolkit; the recovery block explains why.
+      if (!toolkit && (yield* hasRecordedAuthRejection)) {
+        return;
+      }
 
       if (!toolkit) {
         yield* ui.log.warn(`Toolkit "${slugValue}" not found.`);

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.list.cmd.ts
@@ -2,6 +2,7 @@ import process from 'node:process';
 import { Command, Flag } from 'effect/unstable/cli';
 import { Data, Effect, Option } from 'effect';
 import { TerminalUI } from 'src/services/terminal-ui';
+import { reportUnlessUserApiKeyRejection } from 'src/services/auth-rejection';
 import { requireAuth } from 'src/effects/require-auth';
 import { resolveToolRouterSession } from 'src/effects/create-tool-router-session';
 import { ComposioClientSingleton, ComposioToolkitsRepository } from 'src/services/composio-clients';
@@ -195,8 +196,9 @@ export const toolkitsCmd$List = Command.make(
       Effect.catch(error =>
         Effect.gen(function* () {
           const ui = yield* TerminalUI;
-          yield* ui.log.error(
-            extractMessage(error) ?? 'An error occurred while fetching toolkits.'
+          yield* reportUnlessUserApiKeyRejection(
+            error,
+            ui.log.error(extractMessage(error) ?? 'An error occurred while fetching toolkits.')
           );
           yield* ui.output('[]');
           process.exitCode = 1;

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.search.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.search.cmd.ts
@@ -3,6 +3,7 @@ import { Argument, Command, Flag } from 'effect/unstable/cli';
 import { Effect } from 'effect';
 import { ComposioToolkitsRepository } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
+import { reportUnlessUserApiKeyRejection } from 'src/services/auth-rejection';
 import { requireAuth } from 'src/effects/require-auth';
 import { clampLimit } from 'src/ui/clamp-limit';
 import { extractMessage } from 'src/utils/api-error-extraction';
@@ -67,7 +68,10 @@ export const toolkitsCmd$Search = Command.make('search', { query, limit }, ({ qu
     Effect.catch(error =>
       Effect.gen(function* () {
         const ui = yield* TerminalUI;
-        yield* ui.log.error(extractMessage(error) ?? 'An error occurred while searching toolkits.');
+        yield* reportUnlessUserApiKeyRejection(
+          error,
+          ui.log.error(extractMessage(error) ?? 'An error occurred while searching toolkits.')
+        );
         yield* ui.output('[]');
         process.exitCode = 1;
       })

--- a/ts/packages/cli/src/commands/toolkits/commands/toolkits.version.cmd.ts
+++ b/ts/packages/cli/src/commands/toolkits/commands/toolkits.version.cmd.ts
@@ -3,6 +3,7 @@ import { Effect, Option } from 'effect';
 import { requireAuth } from 'src/effects/require-auth';
 import { ComposioClientSingleton } from 'src/services/composio-clients';
 import { TerminalUI } from 'src/services/terminal-ui';
+import { reportUnlessUserApiKeyRejection } from 'src/services/auth-rejection';
 import { extractMessage } from 'src/utils/api-error-extraction';
 
 const slug = Argument.string('slug').pipe(Argument.withDescription('Toolkit slug (e.g. "gmail")'));
@@ -34,11 +35,16 @@ export const toolkitsCmd$Version = Command.make('version', { slug }, ({ slug }) 
         Effect.asSome,
         Effect.catch(error =>
           Effect.gen(function* () {
-            const message =
-              extractMessage(error) ?? `Failed to fetch version info for toolkit "${slug}".`;
-            yield* ui.log.error(message);
             yield* Effect.logDebug('Toolkit version error:', error);
-            yield* ui.log.step('Browse available toolkits:\n> composio dev toolkits list');
+            yield* reportUnlessUserApiKeyRejection(
+              error,
+              Effect.gen(function* () {
+                const message =
+                  extractMessage(error) ?? `Failed to fetch version info for toolkit "${slug}".`;
+                yield* ui.log.error(message);
+                yield* ui.log.step('Browse available toolkits:\n> composio dev toolkits list');
+              })
+            );
             return Option.none();
           })
         )

--- a/ts/packages/cli/src/commands/ts/commands/ts.generate.cmd.ts
+++ b/ts/packages/cli/src/commands/ts/commands/ts.generate.cmd.ts
@@ -43,6 +43,7 @@ import {
 } from 'src/effects/toolkit-version-overrides';
 import { validateToolkitVersionOverrides } from 'src/effects/validate-toolkit-versions';
 import { TerminalUI, type SpinnerHandle } from 'src/services/terminal-ui';
+import { warnOnBackendMismatch } from 'src/effects/backend-mismatch-warning';
 
 export class TypeScriptGenerationWriteError extends Data.TaggedError(
   'commands/TypeScriptGenerationWriteError'
@@ -380,6 +381,7 @@ export function generateTypescriptTypeStubs({
     const client = yield* ComposioToolkitsRepository;
 
     yield* ui.intro('composio generate ts');
+    yield* warnOnBackendMismatch;
 
     // Determine the actual output directory
     const outputDir = yield* outputOpt.pipe(

--- a/ts/packages/cli/src/commands/whoami.cmd.ts
+++ b/ts/packages/cli/src/commands/whoami.cmd.ts
@@ -8,6 +8,7 @@ import { commandHintStep } from 'src/services/command-hints';
 import { readStoredAgentIdentity } from 'src/services/agents';
 import { getOrgEnhancedControlsStatus } from 'src/services/tool-permissions';
 import { warnOnBackendMismatch } from 'src/effects/backend-mismatch-warning';
+import { hasRecordedAuthRejection, recordIfUserApiKeyRejection } from 'src/services/auth-rejection';
 
 /**
  * CLI command to display your account information.
@@ -36,7 +37,9 @@ export const whoamiCmd = Command.make('whoami', {}).pipe(
                 userApiKey: apiKey,
                 // Reflect the org selected via `composio orgs switch`, not the key's home org.
                 orgId: Option.getOrUndefined(ctx.data.orgId),
-              }).pipe(Effect.option);
+              }).pipe(Effect.tapError(recordIfUserApiKeyRejection), Effect.option);
+              // A rejected key has no account to show; the recovery block reports it.
+              if (Option.isNone(sessionInfo) && (yield* hasRecordedAuthRejection)) return;
               yield* Option.match(sessionInfo, {
                 onNone: () => Effect.void,
                 onSome: info => linkApolloIdentityForAnalytics(info.org_member.id, apiKey),

--- a/ts/packages/cli/src/commands/whoami.cmd.ts
+++ b/ts/packages/cli/src/commands/whoami.cmd.ts
@@ -7,6 +7,7 @@ import { TerminalUI } from 'src/services/terminal-ui';
 import { commandHintStep } from 'src/services/command-hints';
 import { readStoredAgentIdentity } from 'src/services/agents';
 import { getOrgEnhancedControlsStatus } from 'src/services/tool-permissions';
+import { warnOnBackendMismatch } from 'src/effects/backend-mismatch-warning';
 
 /**
  * CLI command to display your account information.
@@ -29,6 +30,7 @@ export const whoamiCmd = Command.make('whoami', {}).pipe(
           onNone: () => ui.log.warn('You are not logged in yet. Please run `composio login`.'),
           onSome: apiKey =>
             Effect.gen(function* () {
+              yield* warnOnBackendMismatch;
               const sessionInfo = yield* getSessionInfoByUserApiKey({
                 baseURL: ctx.data.baseURL,
                 userApiKey: apiKey,

--- a/ts/packages/cli/src/effects/announce-login-target.ts
+++ b/ts/packages/cli/src/effects/announce-login-target.ts
@@ -1,0 +1,14 @@
+import { Effect } from 'effect';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { type BackendTarget, backendHost, isProductionBackend } from 'src/utils/backend-resolution';
+
+/**
+ * Name the backend a login is about to target when it is not production, so a
+ * staging or custom-host login never happens silently.
+ */
+export const announceLoginTarget = (target: BackendTarget) =>
+  Effect.gen(function* () {
+    if (isProductionBackend(target.baseURL)) return;
+    const ui = yield* TerminalUI;
+    yield* ui.log.info(`Logging in to ${backendHost(target.baseURL)}`);
+  });

--- a/ts/packages/cli/src/effects/app-config.ts
+++ b/ts/packages/cli/src/effects/app-config.ts
@@ -185,6 +185,17 @@ export const APP_CONFIG = {
 } satisfies APP_CONFIG;
 
 /**
+ * The raw backend overrides, read separately from `APP_CONFIG.BASE_URL` and
+ * `APP_CONFIG.WEB_URL` so callers can tell an explicit env var from a
+ * defaulted value. Blank values count as unset.
+ */
+export const BACKEND_OVERRIDES = Config.all({
+  baseURL: optionalTrimmedString('BASE_URL'),
+  webURL: optionalTrimmedString('WEB_URL'),
+  environment: optionalTrimmedString('ENVIRONMENT'),
+});
+
+/**
  * Configuration whose keys are spelled out in full and are therefore loaded
  * through the raw `ConfigProvider.fromEnv()` provider (`loadHostConfig` in
  * `src/services/config.ts`) rather than the `COMPOSIO_`-prefixing provider that

--- a/ts/packages/cli/src/effects/auth-rejection-recovery.ts
+++ b/ts/packages/cli/src/effects/auth-rejection-recovery.ts
@@ -1,0 +1,134 @@
+import { Effect, Option } from 'effect';
+import { APP_CONFIG } from 'src/effects/app-config';
+import { type AuthRejection, AuthRejectionRecorder } from 'src/services/auth-rejection';
+import { isInteractivePermissionUiDisabled } from 'src/services/native-ui-sidecar';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { ComposioUserContext } from 'src/services/user-context';
+import {
+  type BackendResolution,
+  type BackendTarget,
+  backendHost,
+  currentLoginBackend,
+  loginCommandForBackend,
+} from 'src/utils/backend-resolution';
+
+export type AuthRejectionRecovery =
+  | { readonly kind: 'message'; readonly message: string; readonly nextStep: string }
+  | {
+      readonly kind: 'offer-relogin';
+      readonly target: BackendTarget;
+      readonly message: string;
+      readonly nextStep: string;
+    };
+
+/**
+ * Decide how to report a rejected key: which message, and whether a re-login
+ * can be offered. Re-login needs the stored key, no env override pointing
+ * elsewhere, and a real interactive session outside CI and `composio run`.
+ */
+export const decideAuthRejectionRecovery = (params: {
+  readonly rejection: AuthRejection;
+  readonly backend: BackendResolution;
+  readonly canPromptForLogin: boolean;
+  readonly invocationOrigin: string | undefined;
+}): AuthRejectionRecovery => {
+  const { rejection, backend } = params;
+  const host = backendHost(rejection.baseURL);
+
+  if (rejection.keySource === 'env') {
+    return params.invocationOrigin === 'run'
+      ? {
+          kind: 'message',
+          message: `The Composio API at ${host} rejected the API key \`composio run\` passed to this command.`,
+          nextStep: `Run \`${loginCommandForBackend(rejection.baseURL)}\`, then re-run the script.`,
+        }
+      : {
+          kind: 'message',
+          message: `The Composio API at ${host} rejected the API key in COMPOSIO_USER_API_KEY.`,
+          nextStep: 'Replace its value with a valid user API key.',
+        };
+  }
+
+  if (backend.mismatch && backend.stored !== undefined && backend.overrideVariable) {
+    return {
+      kind: 'message',
+      message: `The Composio API at ${host} rejected your stored API key: ${backend.overrideVariable} points the CLI at ${host}, but you logged in to ${backendHost(backend.stored.baseURL)}.`,
+      nextStep: `Unset ${backend.overrideVariable} to use that login.`,
+    };
+  }
+
+  const target = currentLoginBackend(backend);
+  const message = `The Composio API at ${host} rejected your stored API key.`;
+  const nextStep = `Run \`${loginCommandForBackend(target.baseURL)}\` to log in again, then re-run the command.`;
+  return params.canPromptForLogin && params.invocationOrigin !== 'run'
+    ? { kind: 'offer-relogin', target, message, nextStep }
+    : { kind: 'message', message, nextStep };
+};
+
+const printRejection = (recovery: { readonly message: string; readonly nextStep: string }) =>
+  Effect.gen(function* () {
+    const ui = yield* TerminalUI;
+    if ((yield* ui.capabilities).canDecorate) {
+      yield* ui.log.error(recovery.message);
+      yield* ui.log.step(recovery.nextStep);
+    } else {
+      // Agents and CI capture stderr; the next step must reach them undecorated.
+      yield* ui.error(`${recovery.message} ${recovery.nextStep}`);
+    }
+  });
+
+/**
+ * Report the first recorded key rejection once, after the command finished.
+ * `relogin` must store new credentials only after it fully succeeds; any
+ * failure leaves the stored login untouched.
+ */
+export const reportAuthRejection = <E, R>(params: {
+  readonly relogin: (target: BackendTarget) => Effect.Effect<void, E, R>;
+}) =>
+  Effect.gen(function* () {
+    const recorder = yield* AuthRejectionRecorder;
+    const rejection = yield* recorder.first;
+    if (Option.isNone(rejection)) return;
+
+    const ui = yield* TerminalUI;
+    const ctx = yield* ComposioUserContext;
+    const { canPrompt } = yield* ui.capabilities;
+    const promptDisabled = yield* isInteractivePermissionUiDisabled;
+    const invocationOrigin = yield* APP_CONFIG.CLI_INVOCATION_ORIGIN.pipe(
+      Effect.orElseSucceed(() => undefined)
+    );
+
+    const recovery = decideAuthRejectionRecovery({
+      rejection: rejection.value,
+      backend: ctx.backend,
+      canPromptForLogin: canPrompt && !promptDisabled,
+      invocationOrigin,
+    });
+
+    if (recovery.kind === 'message') {
+      return yield* printRejection(recovery);
+    }
+
+    yield* ui.log.error(recovery.message);
+    const host = backendHost(recovery.target.baseURL);
+    const accepted = yield* ui
+      .confirm(`Log in again to ${host}?`, { defaultValue: true })
+      .pipe(Effect.orElseSucceed(() => false));
+    if (!accepted) {
+      return yield* ui.log.step(recovery.nextStep);
+    }
+
+    yield* params.relogin(recovery.target).pipe(
+      Effect.matchCauseEffect({
+        onSuccess: () => ui.log.success(`Logged in again to ${host}. Re-run the command.`),
+        onFailure: cause =>
+          Effect.logDebug('Re-login failed:', cause).pipe(
+            Effect.andThen(
+              ui.log.warn(
+                `Login did not complete. Your stored credentials are unchanged. ${recovery.nextStep}`
+              )
+            )
+          ),
+      })
+    );
+  });

--- a/ts/packages/cli/src/effects/backend-mismatch-warning.ts
+++ b/ts/packages/cli/src/effects/backend-mismatch-warning.ts
@@ -1,0 +1,20 @@
+import { Effect } from 'effect';
+import { TerminalUI } from 'src/services/terminal-ui';
+import { ComposioUserContext } from 'src/services/user-context';
+import { backendHost } from 'src/utils/backend-resolution';
+
+/**
+ * Warn before any request when an env var sends the stored API key to a
+ * backend other than the one it was issued by; that backend will almost
+ * certainly reject it. Decoration only: stderr, no prompt, no stdout.
+ */
+export const warnOnBackendMismatch = Effect.gen(function* () {
+  const ctx = yield* ComposioUserContext;
+  const { mismatch, stored, target, overrideVariable } = ctx.backend;
+  if (!mismatch || stored === undefined || overrideVariable === undefined) return;
+
+  const ui = yield* TerminalUI;
+  yield* ui.log.warn(
+    `${overrideVariable} sends your stored API key to ${backendHost(target.baseURL)}, but you logged in to ${backendHost(stored.baseURL)}.`
+  );
+});

--- a/ts/packages/cli/src/effects/require-auth.ts
+++ b/ts/packages/cli/src/effects/require-auth.ts
@@ -1,6 +1,7 @@
 import { Effect, Option } from 'effect';
 import { ComposioUserContext } from 'src/services/user-context';
 import { TerminalUI } from 'src/services/terminal-ui';
+import { warnOnBackendMismatch } from 'src/effects/backend-mismatch-warning';
 
 /**
  * Checks that the user is authenticated. Returns `true` if an API key is present,
@@ -20,5 +21,6 @@ export const requireAuth = Effect.gen(function* () {
     return false as const;
   }
 
+  yield* warnOnBackendMismatch;
   return true as const;
 });

--- a/ts/packages/cli/src/services/agents.ts
+++ b/ts/packages/cli/src/services/agents.ts
@@ -9,6 +9,7 @@ import { ComposioUserContext } from 'src/services/user-context';
 import { getSessionInfoByUserApiKey } from 'src/services/composio-clients';
 import { primeConsumerConnectedToolkitsCacheInBackground } from 'src/services/consumer-short-term-cache';
 import { linkApolloIdentityForAnalytics } from 'src/analytics/dispatch';
+import { announceLoginTarget } from 'src/effects/announce-login-target';
 
 export const AGENT_CONFIG_FILE_NAME = 'agent.json';
 export const DEFAULT_AGENTS_BASE_URL = 'https://agents.composio.dev';
@@ -458,9 +459,13 @@ export const loginWithAgentIdentity = (identity: AgentIdentity) =>
       });
     }
 
-    yield* ctx.login(userApiKey, orgId);
+    // Agent keys are recorded with the ambient backend; the agents service does
+    // not say which backend issued them.
+    const target = ctx.backend.ambient;
+    yield* announceLoginTarget(target);
+    yield* ctx.login({ apiKey: userApiKey, target, orgId });
     // Best-effort analytics stitch after the credential persists; must never break login.
-    yield* getSessionInfoByUserApiKey({ baseURL: ctx.data.baseURL, userApiKey, orgId }).pipe(
+    yield* getSessionInfoByUserApiKey({ baseURL: target.baseURL, userApiKey, orgId }).pipe(
       Effect.flatMap(info => linkApolloIdentityForAnalytics(info.org_member.id, userApiKey)),
       Effect.catchCause(() => Effect.void)
     );

--- a/ts/packages/cli/src/services/auth-rejection.ts
+++ b/ts/packages/cli/src/services/auth-rejection.ts
@@ -1,0 +1,51 @@
+import { Context, Effect, Layer, Option, Ref } from 'effect';
+import { ComposioUserContext } from 'src/services/user-context';
+import { isUserApiKeyRejection } from 'src/utils/api-error-extraction';
+import type { ApiKeySource } from 'src/utils/backend-resolution';
+
+/**
+ * A backend rejection of the user API key in use.
+ */
+export interface AuthRejection {
+  /** Origin of the backend that rejected the key. */
+  readonly baseURL: string;
+  readonly keySource: ApiKeySource;
+}
+
+/**
+ * Holds the first user API key rejection seen in this process. Rejections are
+ * recorded where they happen, including inside commands that catch or swallow
+ * API errors, and `cliProgram` reports them once after the command finishes.
+ */
+export class AuthRejectionRecorder extends Context.Service<
+  AuthRejectionRecorder,
+  {
+    /** Keep `rejection` unless one was already recorded. */
+    readonly record: (rejection: AuthRejection) => Effect.Effect<void>;
+    readonly first: Effect.Effect<Option.Option<AuthRejection>>;
+  }
+>()('services/AuthRejectionRecorder') {
+  static readonly Default = Layer.effect(
+    AuthRejectionRecorder,
+    Effect.gen(function* () {
+      const state = yield* Ref.make(Option.none<AuthRejection>());
+      return AuthRejectionRecorder.of({
+        record: rejection =>
+          Ref.update(state, current => Option.orElse(current, () => Option.some(rejection))),
+        first: Ref.get(state),
+      });
+    })
+  );
+}
+
+/**
+ * Record `error` when it is a user API key rejection from a request made with
+ * the key in use. Call it before swallowing an API error.
+ */
+export const recordIfUserApiKeyRejection = (error: unknown) =>
+  Effect.gen(function* () {
+    if (!isUserApiKeyRejection(error)) return;
+    const recorder = yield* AuthRejectionRecorder;
+    const ctx = yield* ComposioUserContext;
+    yield* recorder.record({ baseURL: ctx.data.baseURL, keySource: ctx.backend.keySource });
+  });

--- a/ts/packages/cli/src/services/auth-rejection.ts
+++ b/ts/packages/cli/src/services/auth-rejection.ts
@@ -38,6 +38,21 @@ export class AuthRejectionRecorder extends Context.Service<
   );
 }
 
+/** True once a rejection has been recorded in this process. */
+export const hasRecordedAuthRejection = Effect.flatMap(
+  AuthRejectionRecorder,
+  recorder => recorder.first
+).pipe(Effect.map(Option.isSome));
+
+/**
+ * Run `report` for any error except a user API key rejection, which is only
+ * recorded: the recovery block at the end of the command reports it once.
+ */
+export const reportUnlessUserApiKeyRejection = <E, R>(
+  error: unknown,
+  report: Effect.Effect<void, E, R>
+) => (isUserApiKeyRejection(error) ? recordIfUserApiKeyRejection(error) : report);
+
 /**
  * Record `error` when it is a user API key rejection from a request made with
  * the key in use. Call it before swallowing an API error.

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -1562,7 +1562,11 @@ const makeComposioClientSingleton = Effect.gen(function* () {
   const getFor = (params?: { userApiKey?: string; orgId?: string; projectId?: string }) =>
     Effect.gen(function* () {
       const apiKey = normalizeApiKey(params?.userApiKey ?? Option.getOrUndefined(ctx.data.apiKey));
+      const baseURL = ctx.data.baseURL;
+      // The backend is part of the key: a re-login or override can change it
+      // within one process, and a client must never outlive its target.
       const cacheKey = JSON.stringify({
+        baseURL,
         apiKey: apiKey ?? null,
         orgId: params?.orgId ?? null,
         projectId: params?.projectId ?? null,
@@ -1580,7 +1584,7 @@ const makeComposioClientSingleton = Effect.gen(function* () {
 
       const client = new _RawComposioClient({
         apiKey: null,
-        baseURL: ctx.data.baseURL,
+        baseURL,
         defaultHeaders: buildDefaultHeaders({
           userApiKey: apiKey,
           orgId: params?.orgId,
@@ -1627,7 +1631,10 @@ export class ComposioClientSingleton extends Context.Service<
   ComposioClientSingleton,
   ComposioClientSingletonShape
 >()('services/ComposioClientSingleton') {
-  static readonly Default = Layer.effect(ComposioClientSingleton, makeComposioClientSingleton).pipe(
+  /** Requires `ComposioUserContext` from the caller. */
+  static readonly layer = Layer.effect(ComposioClientSingleton, makeComposioClientSingleton);
+
+  static readonly Default = ComposioClientSingleton.layer.pipe(
     Layer.provide(ComposioUserContextLive)
   );
 }

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -5,7 +5,6 @@ import {
   Effect,
   Layer,
   Option,
-  Result,
   Schema,
   Array,
   Order,
@@ -44,6 +43,7 @@ import { ComposioUserContext, ComposioUserContextLive } from './user-context';
 import { AuthRejectionRecorder } from './auth-rejection';
 import { ProjectContext } from './project-context';
 import { type ApiErrorDetails, isUserApiKeyRejection } from 'src/utils/api-error-extraction';
+import { backendOrigin } from 'src/utils/backend-resolution';
 import { renderPrettyError } from './utils/pretty-error';
 import { NodeOs } from './node-os';
 
@@ -679,12 +679,11 @@ const handleHttpErrorResponse = (response: Response): Effect.Effect<never, HttpS
     );
   });
 
-const requestOrigin = (input: string | URL | Request, response: Response): string => {
-  const raw =
+const requestOrigin = (input: string | URL | Request, response: Response): string =>
+  backendOrigin(
     response.url ||
-    (typeof input === 'string' ? input : input instanceof URL ? input.href : input.url);
-  return Result.try(() => new URL(raw).origin).pipe(Result.getOrElse(() => raw));
-};
+      (typeof input === 'string' ? input : input instanceof URL ? input.href : input.url)
+  );
 
 /**
  * Wrap `fetch` so a user API key rejection is recorded wherever the SDK's

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -1540,12 +1540,36 @@ const callClientWithPagination = <T, S extends PaginatedSchema>(
  */
 export interface ComposioClientSingletonShape {
   readonly get: () => Effect.Effect<_RawComposioClient, NoSuchElementError>;
-  readonly getFor: (params: {
-    userApiKey?: string;
-    orgId?: string;
-    projectId?: string;
-  }) => Effect.Effect<_RawComposioClient, NoSuchElementError>;
+  readonly getFor: (
+    params: ClientTargetParams
+  ) => Effect.Effect<_RawComposioClient, NoSuchElementError>;
 }
+
+interface ClientTargetParams {
+  readonly userApiKey?: string;
+  readonly orgId?: string;
+  readonly projectId?: string;
+  /** Backend to call instead of the resolved one. */
+  readonly baseURL?: string;
+  /** Send no user API key: login flows must not leak a stored key to another backend. */
+  readonly anonymous?: boolean;
+}
+
+/**
+ * A client for login flows: it calls `baseURL` and sends no user API key, so
+ * a stored key never reaches a backend that did not issue it and a rejected
+ * key cannot block the login that replaces it.
+ */
+const loginClientFor = (
+  clientSingleton: ComposioClientSingletonShape,
+  baseURL: string | undefined
+): ComposioClientSingletonShape =>
+  baseURL === undefined
+    ? clientSingleton
+    : {
+        get: () => clientSingleton.getFor({ baseURL, anonymous: true }),
+        getFor: params => clientSingleton.getFor({ ...params, baseURL, anonymous: true }),
+      };
 
 /**
  * Singleton service that lazily accesses `Config` only when needed, which is used to build and provide
@@ -1559,10 +1583,12 @@ const makeComposioClientSingleton = Effect.gen(function* () {
   const os = yield* NodeOs;
   const cache = new Map<string, _RawComposioClient>();
 
-  const getFor = (params?: { userApiKey?: string; orgId?: string; projectId?: string }) =>
+  const getFor = (params?: ClientTargetParams) =>
     Effect.gen(function* () {
-      const apiKey = normalizeApiKey(params?.userApiKey ?? Option.getOrUndefined(ctx.data.apiKey));
-      const baseURL = ctx.data.baseURL;
+      const apiKey = params?.anonymous
+        ? undefined
+        : normalizeApiKey(params?.userApiKey ?? Option.getOrUndefined(ctx.data.apiKey));
+      const baseURL = params?.baseURL ?? ctx.data.baseURL;
       // The backend is part of the key: a re-login or override can change it
       // within one process, and a client must never outlive its target.
       const cacheKey = JSON.stringify({
@@ -1613,17 +1639,11 @@ const makeComposioClientSingleton = Effect.gen(function* () {
           }),
       });
     }) satisfies () => Effect.Effect<_RawComposioClient, NoSuchElementError, never>,
-    getFor: Effect.fn(function* (params: {
-      userApiKey?: string;
-      orgId?: string;
-      projectId?: string;
-    }) {
+    getFor: Effect.fn(function* (params: ClientTargetParams) {
       return yield* getFor(params);
-    }) satisfies (params: {
-      userApiKey?: string;
-      orgId?: string;
-      projectId?: string;
-    }) => Effect.Effect<_RawComposioClient, NoSuchElementError, never>,
+    }) satisfies (
+      params: ClientTargetParams
+    ) => Effect.Effect<_RawComposioClient, NoSuchElementError, never>,
   };
 });
 
@@ -2044,10 +2064,10 @@ const makeComposioClientLive = Effect.gen(function* () {
        *
        * TODO: don't use `@composio/client`, wrap `fetch` directly.
        */
-      createSession: (params?: { scope?: 'user' | 'project' }) =>
+      createSession: (params?: { scope?: 'user' | 'project'; baseURL?: string }) =>
         withMetrics(
           callClient(
-            clientSingleton,
+            loginClientFor(clientSingleton, params?.baseURL),
             client =>
               client.cli.createSession(
                 { scope: params?.scope ?? 'user' },
@@ -2059,12 +2079,13 @@ const makeComposioClientLive = Effect.gen(function* () {
 
       /**
        * Retrieves the current state of a CLI session using either the session ID (UUID) or the 6-character code.
+       * With `baseURL`, the call goes to that login target without the stored key.
        */
-      getSession: (session: { id: string }) =>
+      getSession: (session: { id: string; baseURL?: string }) =>
         withMetrics(
           callClient(
-            clientSingleton,
-            client => client.cli.getSession(session),
+            loginClientFor(clientSingleton, session.baseURL),
+            client => client.cli.getSession({ id: session.id }),
             CliGetSessionResponse
           )
         ),
@@ -2325,8 +2346,10 @@ const makeComposioSessionRepository = Effect.gen(function* () {
   const client = yield* ComposioClientLive;
 
   return {
-    createSession: (params?: { scope?: 'user' | 'project' }) => client.cli.createSession(params),
-    getSession: (session: { id: string }) => client.cli.getSession({ id: session.id }),
+    createSession: (params?: { scope?: 'user' | 'project'; baseURL?: string }) =>
+      client.cli.createSession(params),
+    getSession: (session: { id: string; baseURL?: string }) =>
+      client.cli.getSession({ id: session.id, baseURL: session.baseURL }),
     getRealtimeCredentials: () => client.cli.getRealtimeCredentials(),
     authRealtimeChannel: (params: { channel_name: string; socket_id: string }) =>
       client.cli.authRealtimeChannel(params),

--- a/ts/packages/cli/src/services/composio-clients.ts
+++ b/ts/packages/cli/src/services/composio-clients.ts
@@ -5,6 +5,7 @@ import {
   Effect,
   Layer,
   Option,
+  Result,
   Schema,
   Array,
   Order,
@@ -40,7 +41,9 @@ import { TriggerType, TriggerTypes, TriggerTypesAsEnums } from 'src/models/trigg
 import * as constants from 'src/constants';
 import { getCurrentCwdSessionId } from 'src/analytics/dispatch';
 import { ComposioUserContext, ComposioUserContextLive } from './user-context';
+import { AuthRejectionRecorder } from './auth-rejection';
 import { ProjectContext } from './project-context';
+import { type ApiErrorDetails, isUserApiKeyRejection } from 'src/utils/api-error-extraction';
 import { renderPrettyError } from './utils/pretty-error';
 import { NodeOs } from './node-os';
 
@@ -66,6 +69,8 @@ export class HttpServerError extends Data.TaggedError('services/HttpServerError'
   readonly cause?: unknown;
   readonly status?: number;
   readonly details?: HttpErrorDetails;
+  /** The backend's `{ error: { message, code, slug, ... } }` body, when it sent one. */
+  readonly apiError?: ApiErrorDetails;
 }> {}
 
 /**
@@ -583,6 +588,21 @@ export const HttpErrorResponse = Schema.Struct({
 export type HttpErrorResponse = Schema.Schema.Type<typeof HttpErrorResponse>;
 
 /**
+ * The error body the v3 API sends, e.g. for a rejected user API key:
+ * `{ "error": { "message", "code", "slug", "status", "request_id", "suggested_fix" } }`.
+ */
+const ApiErrorBody = Schema.Struct({
+  error: Schema.Struct({
+    message: Schema.optional(Schema.String),
+    code: Schema.optional(Schema.Number),
+    slug: Schema.optional(Schema.String),
+    status: Schema.optional(Schema.Number),
+    request_id: Schema.optional(Schema.String),
+    suggested_fix: Schema.optional(Schema.String),
+  }),
+}).annotate({ identifier: 'ApiErrorBody' });
+
+/**
  * Result of streaming a response with byte counting.
  */
 interface StreamedResponse {
@@ -644,14 +664,50 @@ const handleHttpErrorResponse = (response: Response): Effect.Effect<never, HttpS
       }
     }
 
-    // Fallback to generic error message
+    // Fallback to generic error message, keeping the v3 error body's slug and
+    // code so callers can recognize specific failures such as a rejected key.
+    const apiError = Option.flatMap(errorBodyOpt, Schema.decodeUnknownOption(ApiErrorBody)).pipe(
+      Option.map(body => body.error),
+      Option.getOrUndefined
+    );
     return yield* Effect.fail(
       new HttpServerError({
         cause: `HTTP ${status} ${statusText}`,
         status,
+        ...(apiError ? { apiError } : {}),
       })
     );
   });
+
+const requestOrigin = (input: string | URL | Request, response: Response): string => {
+  const raw =
+    response.url ||
+    (typeof input === 'string' ? input : input instanceof URL ? input.href : input.url);
+  return Result.try(() => new URL(raw).origin).pipe(Result.getOrElse(() => raw));
+};
+
+/**
+ * Wrap `fetch` so a user API key rejection is recorded wherever the SDK's
+ * response ends up: several commands catch or swallow SDK errors themselves.
+ * The body is read from a clone, so the SDK's own error handling is unchanged.
+ */
+const rejectionRecordingFetch =
+  (onRejection: (baseURL: string) => void) =>
+  (input: string | URL | Request, init?: RequestInit): Promise<Response> =>
+    globalThis.fetch(input, init).then(response =>
+      response.status !== 401
+        ? response
+        : response
+            .clone()
+            .json()
+            .then(
+              (body: unknown) => {
+                if (isUserApiKeyRejection(body)) onRejection(requestOrigin(input, response));
+                return response;
+              },
+              () => response
+            )
+    );
 
 /**
  * Streams a Fetch Response body, counting bytes precisely and parsing JSON in a single pass.
@@ -1577,6 +1633,9 @@ const loginClientFor = (
  */
 const makeComposioClientSingleton = Effect.gen(function* () {
   const ctx = yield* ComposioUserContext;
+  const recorder = yield* AuthRejectionRecorder;
+  const recordRejection = (baseURL: string) =>
+    Effect.runSync(recorder.record({ baseURL, keySource: ctx.backend.keySource }));
   const projectContextOpt = yield* Effect.serviceOption(ProjectContext);
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -1608,6 +1667,8 @@ const makeComposioClientSingleton = Effect.gen(function* () {
         Effect.provideService(NodeOs, os)
       );
 
+      // Only a client sending the key in use reports rejections of that key.
+      const sendsKeyInUse = !params?.anonymous && params?.userApiKey === undefined;
       const client = new _RawComposioClient({
         apiKey: null,
         baseURL,
@@ -1617,6 +1678,7 @@ const makeComposioClientSingleton = Effect.gen(function* () {
           projectId: params?.projectId,
           cliSessionId,
         }),
+        ...(sendsKeyInUse ? { fetch: rejectionRecordingFetch(recordRejection) } : {}),
       });
 
       cache.set(cacheKey, client);
@@ -1655,7 +1717,7 @@ export class ComposioClientSingleton extends Context.Service<
   static readonly layer = Layer.effect(ComposioClientSingleton, makeComposioClientSingleton);
 
   static readonly Default = ComposioClientSingleton.layer.pipe(
-    Layer.provide(ComposioUserContextLive)
+    Layer.provide(Layer.mergeAll(ComposioUserContextLive, AuthRejectionRecorder.Default))
   );
 }
 

--- a/ts/packages/cli/src/services/user-context.ts
+++ b/ts/packages/cli/src/services/user-context.ts
@@ -10,13 +10,19 @@ import {
 import { JsonRecordSchema } from 'src/effects/json';
 import { setupCacheDir } from 'src/effects/setup-cache-dir';
 import * as constants from 'src/constants';
-import { APP_CONFIG } from 'src/effects/app-config';
+import { APP_CONFIG, BACKEND_OVERRIDES } from 'src/effects/app-config';
 import { KeyringService, KeyringLiveWithBackend } from '@composio/cli-keyring/effect';
 import type { KeyringServiceShape } from '@composio/cli-keyring/effect';
 import { KeyringError, type MacOSBackend } from '@composio/cli-keyring';
 import { ComposioCliUserConfig, ComposioCliUserConfigLive } from 'src/services/cli-user-config';
 import { atomicWritePrivateFileString, ensurePrivateFileMode } from 'src/utils/atomic-write';
 import { redactSensitiveLogValue } from 'src/utils/redact-sensitive';
+import {
+  type ApiKeySource,
+  type BackendResolution,
+  resolveAmbientBackend,
+  resolveBackend,
+} from 'src/utils/backend-resolution';
 
 /**
  * Keyring specifier for the Composio API key. `service` is a reverse
@@ -27,6 +33,9 @@ import { redactSensitiveLogValue } from 'src/utils/redact-sensitive';
  */
 const KEYRING_SERVICE = 'com.composio.cli';
 const KEYRING_USER = 'default';
+const nonBlank = (value: Option.Option<string>): string | undefined =>
+  Option.getOrUndefined(Option.filter(value, url => url.trim().length > 0));
+
 const decodeUserDataJsonObject = Schema.decodeUnknownEffect(
   Schema.fromJsonString(JsonRecordSchema)
 );
@@ -148,7 +157,10 @@ const deleteKeyring = (deps: KeyringDeps) =>
 export class ComposioUserContext extends Context.Service<
   ComposioUserContext,
   {
+    /** User data, with `baseURL`/`webURL` resolved for this invocation. */
     readonly data: UserDataWithDefaults;
+    /** How `data.baseURL` was chosen: key source, stored and ambient targets, mismatch. */
+    readonly backend: BackendResolution;
     isLoggedIn: () => boolean;
     logout: Effect.Effect<void, Schema.SchemaError | PlatformError.PlatformError, never>;
     login: (
@@ -168,8 +180,8 @@ export const rawComposioUserContextLive = Layer.effect(
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const apiKey = yield* APP_CONFIG['USER_API_KEY'];
-    const baseURL = yield* APP_CONFIG['BASE_URL'];
-    const webURL = yield* APP_CONFIG['WEB_URL'];
+    const overrides = yield* BACKEND_OVERRIDES;
+    const ambient = resolveAmbientBackend(overrides);
     const cliConfig = yield* ComposioCliUserConfig;
     const keyring = yield* KeyringService;
 
@@ -184,10 +196,11 @@ export const rawComposioUserContextLive = Layer.effect(
     const cacheDir = yield* setupCacheDir;
     const jsonUserConfigPath = path.join(cacheDir, constants.USER_CONFIG_FILE_NAME);
 
+    // No `base_url` until a login records the backend that validated the key.
     let userData = UserData.make({
       apiKey,
-      baseURL: Option.some(baseURL),
-      webURL: Option.some(webURL),
+      baseURL: Option.none(),
+      webURL: Option.some(ambient.webURL),
       orgId: Option.none(),
       projectId: Option.none(),
       testUserId: Option.none(),
@@ -213,7 +226,7 @@ export const rawComposioUserContextLive = Layer.effect(
       const cleared: UserData = {
         apiKey: Option.none(),
         baseURL: Option.none(),
-        webURL: Option.some(webURL),
+        webURL: Option.some(ambient.webURL),
         orgId: Option.none(),
         projectId: Option.none(),
         testUserId: Option.none(),
@@ -228,8 +241,8 @@ export const rawComposioUserContextLive = Layer.effect(
         const next: UserData = {
           ...userData,
           apiKey: Option.some(apiKey),
-          baseURL: Option.some(baseURL),
-          webURL: Option.some(webURL),
+          baseURL: Option.some(ambient.baseURL),
+          webURL: Option.some(ambient.webURL),
           orgId: Option.fromNullishOr(orgId),
           projectId: userData.projectId,
           testUserId: Option.fromNullishOr(testUserId),
@@ -274,19 +287,19 @@ export const rawComposioUserContextLive = Layer.effect(
       const parsedUserData = (yield* userDataFromJSON(userDataJson)) satisfies UserData;
       yield* Effect.logDebug('User data (parsed):', redactSensitiveLogValue(parsedUserData));
 
+      // Keep the stored `base_url`/`web_url`: `snapshot` resolves the effective
+      // backend per invocation, and every write must preserve the recorded login.
       const overriddenUserData = {
         ...userData,
         ...parsedUserData,
         apiKey: apiKey.pipe(Option.orElse(() => parsedUserData.apiKey)),
-        baseURL: Option.some(baseURL),
-        webURL: Option.some(webURL),
         orgId: parsedUserData.orgId,
         projectId: parsedUserData.projectId,
         testUserId: parsedUserData.testUserId,
       } satisfies UserData;
 
       yield* Effect.logDebug(
-        'User data (overridden from env vars):',
+        'User data (API key overridden from env vars):',
         redactSensitiveLogValue(overriddenUserData)
       );
       userData = overriddenUserData;
@@ -334,18 +347,39 @@ export const rawComposioUserContextLive = Layer.effect(
 
     const isLoggedIn = () => Option.isSome(userData.apiKey);
 
-    const snapshot = (): UserDataWithDefaults => ({
-      ...userData,
-      baseURL: Option.getOrElse(userData.baseURL, () => baseURL),
-      webURL: Option.getOrElse(userData.webURL, () => webURL),
-      orgId: userData.orgId,
-      projectId: userData.projectId,
-      testUserId: userData.testUserId,
-    });
+    const keySource = (): ApiKeySource => {
+      if (Option.isSome(apiKey)) return 'env';
+      return Option.isSome(userData.apiKey) ? 'stored' : 'none';
+    };
+
+    const resolution = (): BackendResolution =>
+      resolveBackend({
+        overrides,
+        stored: {
+          baseURL: nonBlank(userData.baseURL),
+          webURL: nonBlank(userData.webURL),
+        },
+        keySource: keySource(),
+      });
+
+    const snapshot = (): UserDataWithDefaults => {
+      const { target } = resolution();
+      return {
+        ...userData,
+        baseURL: target.baseURL,
+        webURL: target.webURL,
+        orgId: userData.orgId,
+        projectId: userData.projectId,
+        testUserId: userData.testUserId,
+      };
+    };
 
     return ComposioUserContext.of({
       get data() {
         return snapshot();
+      },
+      get backend() {
+        return resolution();
       },
       isLoggedIn,
       update,

--- a/ts/packages/cli/src/services/user-context.ts
+++ b/ts/packages/cli/src/services/user-context.ts
@@ -20,6 +20,7 @@ import { redactSensitiveLogValue } from 'src/utils/redact-sensitive';
 import {
   type ApiKeySource,
   type BackendResolution,
+  type BackendTarget,
   resolveAmbientBackend,
   resolveBackend,
 } from 'src/utils/backend-resolution';
@@ -163,11 +164,17 @@ export class ComposioUserContext extends Context.Service<
     readonly backend: BackendResolution;
     isLoggedIn: () => boolean;
     logout: Effect.Effect<void, Schema.SchemaError | PlatformError.PlatformError, never>;
-    login: (
-      apiKey: string,
-      orgId?: string,
-      testUserId?: string
-    ) => Effect.Effect<void, Schema.SchemaError | PlatformError.PlatformError, never>;
+    /**
+     * Store a new key together with the backend that issued it. Every caller
+     * names the target: login flows pass the ambient environment, and flows
+     * that keep the current login pass its stored environment.
+     */
+    login: (params: {
+      readonly apiKey: string;
+      readonly target: BackendTarget;
+      readonly orgId?: string;
+      readonly testUserId?: string;
+    }) => Effect.Effect<void, Schema.SchemaError | PlatformError.PlatformError, never>;
     update: (
       data: UserData
     ) => Effect.Effect<void, Schema.SchemaError | PlatformError.PlatformError, never>;
@@ -235,14 +242,24 @@ export const rawComposioUserContextLive = Layer.effect(
       yield* writeJson(cleared);
     });
 
-    const login = (apiKey: string, orgId?: string, testUserId?: string) =>
+    const login = ({
+      apiKey,
+      target,
+      orgId,
+      testUserId,
+    }: {
+      readonly apiKey: string;
+      readonly target: BackendTarget;
+      readonly orgId?: string;
+      readonly testUserId?: string;
+    }) =>
       Effect.gen(function* () {
         const keyringOk = yield* writeKeyring(kDeps, apiKey);
         const next: UserData = {
           ...userData,
           apiKey: Option.some(apiKey),
-          baseURL: Option.some(ambient.baseURL),
-          webURL: Option.some(ambient.webURL),
+          baseURL: Option.some(target.baseURL),
+          webURL: Option.some(target.webURL),
           orgId: Option.fromNullishOr(orgId),
           projectId: userData.projectId,
           testUserId: Option.fromNullishOr(testUserId),

--- a/ts/packages/cli/src/utils/api-error-extraction.ts
+++ b/ts/packages/cli/src/utils/api-error-extraction.ts
@@ -165,3 +165,20 @@ export const extractApiErrorDetails = (value: unknown): ApiErrorDetails | undefi
 
   return fallback;
 };
+
+const USER_API_KEY_REJECTION_SLUG = 'UserApiKey_Unauthorized';
+const USER_API_KEY_REJECTION_CODE = 2113;
+
+const isRejectionDetails = (details: ApiErrorDetails | undefined): boolean =>
+  details?.slug === USER_API_KEY_REJECTION_SLUG || details?.code === USER_API_KEY_REJECTION_CODE;
+
+/**
+ * True when the Composio backend rejected the user API key itself
+ * (`UserApiKey_Unauthorized`, code 2113). Matches by slug or code only: a 403,
+ * or a 401 from an upstream service behind `proxy` or a tool, never matches.
+ * `HttpServerError.apiError` carries the decoded body for plain-fetch helpers.
+ */
+export const isUserApiKeyRejection = (error: unknown): boolean =>
+  isRejectionDetails(extractApiErrorDetails(error)) ||
+  (Predicate.hasProperty(error, 'apiError') &&
+    isRejectionDetails(extractApiErrorDetails(error.apiError)));

--- a/ts/packages/cli/src/utils/backend-resolution.ts
+++ b/ts/packages/cli/src/utils/backend-resolution.ts
@@ -1,0 +1,171 @@
+import { Data, Result } from 'effect';
+import {
+  DEFAULT_BASE_URL,
+  DEFAULT_WEB_URL,
+  STAGING_BASE_URL,
+  STAGING_WEB_URL,
+} from 'src/constants';
+
+/**
+ * Where the API key in use came from. The stored login environment only
+ * applies to the stored key: a user API key works only on the backend that
+ * issued it, and the CLI does not know which backend issued an env key.
+ */
+export type ApiKeySource = 'env' | 'stored' | 'none';
+
+/**
+ * The environment variable that explicitly selected a backend for this
+ * invocation.
+ */
+export type BackendOverrideVariable = 'COMPOSIO_BASE_URL' | 'COMPOSIO_ENVIRONMENT';
+
+export interface BackendTarget {
+  readonly baseURL: string;
+  readonly webURL: string;
+}
+
+/**
+ * Raw environment overrides. Blank values must already be normalized to
+ * `undefined`.
+ */
+export interface BackendOverrides {
+  readonly baseURL: string | undefined;
+  readonly webURL: string | undefined;
+  readonly environment: string | undefined;
+}
+
+/**
+ * The `base_url` / `web_url` recorded in `user_data.json` at login.
+ */
+export interface StoredBackend {
+  readonly baseURL: string | undefined;
+  readonly webURL: string | undefined;
+}
+
+export interface BackendResolution {
+  /** Backend and web URL the invocation uses. */
+  readonly target: BackendTarget;
+  /** Backend selected by env vars, then production. Login flows target this. */
+  readonly ambient: BackendTarget;
+  /** The recorded login environment, when `user_data.json` has a `base_url`. */
+  readonly stored: BackendTarget | undefined;
+  readonly keySource: ApiKeySource;
+  /** The env var that explicitly selected a backend, when one did. */
+  readonly overrideVariable: BackendOverrideVariable | undefined;
+  /** The stored key is in use, but an override sends it to another backend. */
+  readonly mismatch: boolean;
+}
+
+export const resolveAmbientBackend = (overrides: BackendOverrides): BackendTarget => {
+  const staging = overrides.environment === 'staging';
+  return {
+    baseURL: overrides.baseURL ?? (staging ? STAGING_BASE_URL : DEFAULT_BASE_URL),
+    webURL: overrides.webURL ?? (staging ? STAGING_WEB_URL : DEFAULT_WEB_URL),
+  };
+};
+
+const explicitOverrideVariable = (
+  overrides: BackendOverrides
+): BackendOverrideVariable | undefined => {
+  if (overrides.baseURL !== undefined) return 'COMPOSIO_BASE_URL';
+  if (overrides.environment !== undefined) return 'COMPOSIO_ENVIRONMENT';
+  return undefined;
+};
+
+class BackendUrlParseError extends Data.TaggedError('BackendUrlParseError')<{
+  readonly cause: unknown;
+}> {}
+
+const parseBackendUrl = (value: string) =>
+  Result.try({
+    try: () => new URL(value),
+    catch: cause => new BackendUrlParseError({ cause }),
+  });
+
+const normalizeBackend = (value: string): string => {
+  const trimmed = value.trim();
+  return parseBackendUrl(trimmed).pipe(
+    Result.map(url => url.origin),
+    Result.filterOrFail(
+      origin => origin !== 'null',
+      () => new BackendUrlParseError({ cause: 'opaque origin' })
+    ),
+    Result.getOrElse(() => trimmed.replace(/\/+$/u, ''))
+  );
+};
+
+/**
+ * Compare two backend URLs by origin. A value that does not parse as a URL
+ * compares as a trimmed string without trailing slashes.
+ */
+export const isSameBackend = (left: string, right: string): boolean =>
+  normalizeBackend(left) === normalizeBackend(right);
+
+/**
+ * Resolve the backend for this invocation.
+ *
+ *   key in use          explicit override   stored base_url   → backend
+ *   stored              no                  present           → stored
+ *   stored              no                  absent            → ambient default
+ *   stored              yes                 any               → override (mismatch when origins differ)
+ *   env or none         any                 any               → ambient
+ *
+ * `COMPOSIO_WEB_URL` alone overrides only the web URL.
+ */
+export const resolveBackend = (params: {
+  readonly overrides: BackendOverrides;
+  readonly stored: StoredBackend;
+  readonly keySource: ApiKeySource;
+}): BackendResolution => {
+  const { overrides, keySource } = params;
+  const ambient = resolveAmbientBackend(overrides);
+  const overrideVariable = explicitOverrideVariable(overrides);
+  const stored: BackendTarget | undefined =
+    params.stored.baseURL === undefined
+      ? undefined
+      : { baseURL: params.stored.baseURL, webURL: params.stored.webURL ?? ambient.webURL };
+
+  const base = { ambient, stored, keySource, overrideVariable };
+
+  if (keySource !== 'stored' || stored === undefined) {
+    return { ...base, target: ambient, mismatch: false };
+  }
+
+  if (overrideVariable === undefined) {
+    return {
+      ...base,
+      target: { baseURL: stored.baseURL, webURL: overrides.webURL ?? stored.webURL },
+      mismatch: false,
+    };
+  }
+
+  return { ...base, target: ambient, mismatch: !isSameBackend(ambient.baseURL, stored.baseURL) };
+};
+
+export const isProductionBackend = (baseURL: string): boolean =>
+  isSameBackend(baseURL, DEFAULT_BASE_URL);
+
+/**
+ * Host name to show users for a backend URL.
+ */
+export const backendHost = (baseURL: string): string =>
+  parseBackendUrl(baseURL.trim()).pipe(
+    Result.map(url => url.host),
+    Result.filterOrFail(
+      host => host.length > 0,
+      () => new BackendUrlParseError({ cause: 'empty host' })
+    ),
+    Result.getOrElse(() => baseURL.trim())
+  );
+
+/**
+ * The `composio login` invocation that targets `baseURL`, spelling out the
+ * environment when it is not production.
+ */
+export const loginCommandForBackend = (baseURL: string): string => {
+  if (isProductionBackend(baseURL)) return 'composio login';
+  if (isSameBackend(baseURL, STAGING_BASE_URL)) {
+    return 'COMPOSIO_ENVIRONMENT=staging composio login';
+  }
+  return `COMPOSIO_BASE_URL=${baseURL.trim()} composio login`;
+};

--- a/ts/packages/cli/src/utils/backend-resolution.ts
+++ b/ts/packages/cli/src/utils/backend-resolution.ts
@@ -142,6 +142,16 @@ export const resolveBackend = (params: {
   return { ...base, target: ambient, mismatch: !isSameBackend(ambient.baseURL, stored.baseURL) };
 };
 
+/**
+ * The environment the current login belongs to: the stored one while the
+ * stored key is in use, otherwise the resolved target. Flows that keep the
+ * current key, such as an org switch, record this instead of the ambient one.
+ */
+export const currentLoginBackend = (resolution: BackendResolution): BackendTarget =>
+  resolution.keySource === 'stored' && resolution.stored !== undefined
+    ? resolution.stored
+    : resolution.target;
+
 export const isProductionBackend = (baseURL: string): boolean =>
   isSameBackend(baseURL, DEFAULT_BASE_URL);
 

--- a/ts/packages/cli/src/utils/backend-resolution.ts
+++ b/ts/packages/cli/src/utils/backend-resolution.ts
@@ -82,7 +82,11 @@ const parseBackendUrl = (value: string) =>
     catch: cause => new BackendUrlParseError({ cause }),
   });
 
-const normalizeBackend = (value: string): string => {
+/**
+ * Origin of a backend or request URL. A value that does not parse as a URL is
+ * returned trimmed, without trailing slashes.
+ */
+export const backendOrigin = (value: string): string => {
   const trimmed = value.trim();
   return parseBackendUrl(trimmed).pipe(
     Result.map(url => url.origin),
@@ -99,7 +103,7 @@ const normalizeBackend = (value: string): string => {
  * compares as a trimmed string without trailing slashes.
  */
 export const isSameBackend = (left: string, right: string): boolean =>
-  normalizeBackend(left) === normalizeBackend(right);
+  backendOrigin(left) === backendOrigin(right);
 
 /**
  * Resolve the backend for this invocation.

--- a/ts/packages/cli/test/__utils__/models/user-api-key-rejection.ts
+++ b/ts/packages/cli/test/__utils__/models/user-api-key-rejection.ts
@@ -1,0 +1,20 @@
+/**
+ * The body the Composio backend returns for a rejected user API key, captured
+ * from `GET /api/v3/auth/session/info` on 2026-09-11.
+ */
+export const userApiKeyRejectionBody = {
+  error: {
+    message: 'Invalid or revoked user API key',
+    code: 2113,
+    slug: 'UserApiKey_Unauthorized',
+    status: 401,
+    request_id: '1c3ccc6f-42a4-4fab-a18a-0b370c4ad27d',
+    suggested_fix: '',
+  },
+};
+
+export const userApiKeyRejectionResponse = () =>
+  new Response(JSON.stringify(userApiKeyRejectionBody), {
+    status: 401,
+    headers: { 'Content-Type': 'application/json' },
+  });

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import * as tempy from 'tempy';
 import * as constants from 'src/constants';
+import { AuthRejectionRecorder } from 'src/services/auth-rejection';
 import { Composio as RawComposioClient } from '@composio/client';
 import type { AuthConfigCreateParams } from '@composio/client/resources/auth-configs';
 import * as BunFileSystem from '@effect/platform-bun/BunFileSystem';
@@ -1320,6 +1321,7 @@ export const TestLayer = (input?: TestLiveInput) =>
       ComposioCliUserConfigTest,
       ComposioUserContextTest,
       ComposioClientSingletonTest,
+      AuthRejectionRecorder.Default,
       ComposioSessionRepositoryTest,
       TriggersRealtimeTest,
       ComposioToolkitsRepositoryTest,

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import * as tempy from 'tempy';
+import * as constants from 'src/constants';
 import { Composio as RawComposioClient } from '@composio/client';
 import type { AuthConfigCreateParams } from '@composio/client/resources/auth-configs';
 import * as BunFileSystem from '@effect/platform-bun/BunFileSystem';
@@ -94,6 +95,12 @@ export interface TestLiveInput {
    * TODO: consider extracting `fixture` into another `Effect`.
    */
   fixture?: string;
+
+  /**
+   * Seed `~/.composio/user_data.json` (snake_case keys) before the user context
+   * loads it.
+   */
+  userData?: Record<string, unknown>;
 
   /**
    * Override the running-executable path reported by `NodeProcess`.
@@ -349,6 +356,9 @@ export const TestLayer = (input?: TestLiveInput) =>
 
     const tempDir = tempy.temporaryDirectory({ prefix: 'test' });
     const cwd = (yield* setupFixtureFolder({ fixture, tempDir })) ?? tempDir;
+    if (input?.userData) {
+      yield* seedUserData(cwd, input.userData);
+    }
 
     const ComposioToolkitsRepositoryTest = Layer.succeed(
       ComposioToolkitsRepository,
@@ -1523,6 +1533,18 @@ function breakSymlinksInNodeModules(
       yield* breakSymlinksUnix;
     }
   }).pipe(Effect.catch(() => Effect.void));
+}
+
+function seedUserData(cwd: string, userData: Record<string, unknown>) {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const composioDir = path.join(cwd, constants.USER_COMPOSIO_DIR);
+    yield* fs.makeDirectory(composioDir, { recursive: true });
+    yield* fs.writeFileString(
+      path.join(composioDir, constants.USER_CONFIG_FILE_NAME),
+      JSON.stringify(userData)
+    );
+  }).pipe(Effect.provide(BunFileSystem.layer), Effect.orDie);
 }
 
 function setupComposioSessionRepository() {

--- a/ts/packages/cli/test/__utils__/services/test-layer.ts
+++ b/ts/packages/cli/test/__utils__/services/test-layer.ts
@@ -33,6 +33,7 @@ import {
   ComposioClientSingleton,
   ComposioSessionRepository,
   ComposioToolkitsRepository,
+  type ComposioToolkitsRepositoryShape,
   HttpServerError,
   InvalidToolkitsError,
   InvalidToolkitVersionsError,
@@ -102,6 +103,12 @@ export interface TestLiveInput {
    * loads it.
    */
   userData?: Record<string, unknown>;
+
+  /**
+   * Make every `ComposioToolkitsRepository` method fail with this error, e.g. a
+   * rejected user API key.
+   */
+  toolkitsRepositoryFailure?: unknown;
 
   /**
    * Override the running-executable path reported by `NodeProcess`.
@@ -363,7 +370,7 @@ export const TestLayer = (input?: TestLiveInput) =>
 
     const ComposioToolkitsRepositoryTest = Layer.succeed(
       ComposioToolkitsRepository,
-      ComposioToolkitsRepository.of({
+      failAllWhenSet(input?.toolkitsRepositoryFailure, {
         getToolkits: () => Effect.succeed(toolkitsData.toolkits),
         getToolkitsBySlugs: (slugs: ReadonlyArray<string>) => {
           const normalizedSlugs = new Set(slugs.map(s => String.toLowerCase(s)));
@@ -805,7 +812,7 @@ export const TestLayer = (input?: TestLiveInput) =>
         enableTrigger: () => Effect.succeed({ status: 'success' as const }),
         disableTrigger: () => Effect.succeed({ status: 'success' as const }),
         deleteTrigger: triggerId => Effect.succeed({ trigger_id: triggerId }),
-      })
+      } satisfies ComposioToolkitsRepositoryShape)
     );
     const ComposioSessionRepositoryTest = yield* setupComposioSessionRepository();
     const TriggersRealtimeTest = Layer.succeed(
@@ -1535,6 +1542,17 @@ function breakSymlinksInNodeModules(
       yield* breakSymlinksUnix;
     }
   }).pipe(Effect.catch(() => Effect.void));
+}
+
+function failAllWhenSet(
+  failure: unknown,
+  repository: ComposioToolkitsRepositoryShape
+): ComposioToolkitsRepositoryShape {
+  if (failure === undefined) return repository;
+  // Every method returns an Effect; the test only needs each call to fail.
+  return Object.fromEntries(
+    Object.keys(repository).map(name => [name, () => Effect.fail(failure)])
+  ) as unknown as ComposioToolkitsRepositoryShape;
 }
 
 function seedUserData(cwd: string, userData: Record<string, unknown>) {

--- a/ts/packages/cli/test/src/analytics.dispatch.test.ts
+++ b/ts/packages/cli/test/src/analytics.dispatch.test.ts
@@ -137,7 +137,7 @@ describe('CLI analytics dispatch', () => {
         const path = yield* Path.Path;
         yield* fs.writeFileString(
           path.join(cacheDir, USER_CONFIG_FILE_NAME),
-          JSON.stringify({ base_url: 'https://backend.example.test///' })
+          JSON.stringify({ api_key: 'uak_stored', base_url: 'https://backend.example.test///' })
         );
         yield* fs.writeFileString(
           path.join(cacheDir, 'consumer-short-term-cache.json'),
@@ -168,6 +168,56 @@ describe('CLI analytics dispatch', () => {
       }).pipe(Effect.provide(makePlatformLayer(home)));
     }
   );
+
+  describe('readApiBaseUrl uses the same backend rule as commands', () => {
+    const readWith = (params: {
+      readonly env: Record<string, string>;
+      readonly userData: Record<string, unknown>;
+    }) => {
+      const home = tempy.temporaryDirectory();
+      const cacheDir = tempy.temporaryDirectory();
+      vi.stubEnv('COMPOSIO_CACHE_DIR', cacheDir);
+      for (const name of ['COMPOSIO_BASE_URL', 'COMPOSIO_ENVIRONMENT', 'COMPOSIO_USER_API_KEY']) {
+        vi.stubEnv(name, params.env[name] ?? '');
+      }
+      writeFileSync(path.join(cacheDir, USER_CONFIG_FILE_NAME), JSON.stringify(params.userData));
+      return readApiBaseUrl.pipe(Effect.provide(makePlatformLayer(home)));
+    };
+
+    it.effect('[Given] a stored key and a stored staging backend [Then] uses staging', () =>
+      Effect.gen(function* () {
+        const baseUrl = yield* readWith({
+          env: {},
+          userData: { api_key: 'uak_stored', base_url: 'https://staging-backend.composio.dev' },
+        });
+        expect(baseUrl).toBe('https://staging-backend.composio.dev');
+      })
+    );
+
+    it.effect(
+      '[Given] COMPOSIO_USER_API_KEY and a stored staging backend [Then] uses the ambient backend',
+      () =>
+        Effect.gen(function* () {
+          const baseUrl = yield* readWith({
+            env: { COMPOSIO_USER_API_KEY: 'uak_env' },
+            userData: { api_key: 'uak_stored', base_url: 'https://staging-backend.composio.dev' },
+          });
+          expect(baseUrl).toBe('https://backend.composio.dev');
+        })
+    );
+
+    it.effect(
+      '[Given] COMPOSIO_ENVIRONMENT=staging and no stored base_url [Then] uses staging',
+      () =>
+        Effect.gen(function* () {
+          const baseUrl = yield* readWith({
+            env: { COMPOSIO_ENVIRONMENT: 'staging' },
+            userData: { api_key: 'uak_stored', base_url: null },
+          });
+          expect(baseUrl).toBe('https://staging-backend.composio.dev');
+        })
+    );
+  });
 
   it.effect('ignores malformed worker payloads', () => {
     const home = tempy.temporaryDirectory();

--- a/ts/packages/cli/test/src/cli-main.test.ts
+++ b/ts/packages/cli/test/src/cli-main.test.ts
@@ -1,8 +1,26 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 import * as tempy from 'tempy';
+import { withHttpServer } from 'test/__utils__/http-server';
+import { userApiKeyRejectionBody } from 'test/__utils__/models/user-api-key-rejection';
+
+// Asynchronous so an in-process test server can answer the CLI's requests.
+const runCli = (args: ReadonlyArray<string>, env: NodeJS.ProcessEnv) =>
+  new Promise<{ status: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+    const child = spawn('bun', ['run', 'src/bin.ts', ...args], {
+      cwd: process.cwd(),
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', chunk => (stdout += chunk));
+    child.stderr.on('data', chunk => (stderr += chunk));
+    child.once('error', reject);
+    child.once('close', status => resolve({ status, stdout, stderr }));
+  });
 
 describe('CLI process error handling', () => {
   it('prints unreported ToolExecutionError failures and exits non-zero', () => {
@@ -73,6 +91,48 @@ describe('CLI process error handling', () => {
     expect(output).not.toContain('MissingRunSourceError');
     expect(output).not.toContain('Sources');
     expect(output).not.toContain('RUN_LOG_FILE=');
+  });
+
+  it('reports a rejected stored key once with the login step instead of a defect dump', async () => {
+    await withHttpServer(
+      (_req, res) => {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(userApiKeyRejectionBody));
+      },
+      async baseUrl => {
+        const configDirectory = tempy.temporaryDirectory();
+        fs.writeFileSync(
+          path.join(configDirectory, 'user_data.json'),
+          JSON.stringify({
+            api_key: 'uak_revoked',
+            base_url: baseUrl,
+            web_url: 'http://127.0.0.1:3000/',
+            org_id: 'org_test',
+          })
+        );
+        const env = Object.fromEntries(
+          Object.entries(process.env).filter(
+            ([name]) =>
+              !['COMPOSIO_BASE_URL', 'COMPOSIO_ENVIRONMENT', 'COMPOSIO_USER_API_KEY'].includes(name)
+          )
+        );
+
+        const result = await runCli(['orgs', 'list'], {
+          ...env,
+          CI: '1',
+          NO_COLOR: '1',
+          COMPOSIO_CACHE_DIR: configDirectory,
+        });
+
+        const host = new URL(baseUrl).host;
+        const expected = `The Composio API at ${host} rejected your stored API key. Run \`COMPOSIO_BASE_URL=${baseUrl} composio login\` to log in again, then re-run the command.`;
+        expect(result.status).toBe(1);
+        expect(result.stdout).toBe('');
+        expect(result.stderr.split(expected)).toHaveLength(2);
+        expect(result.stderr).not.toContain('HttpServerError');
+        expect(result.stderr).not.toContain('Invalid or revoked user API key');
+      }
+    );
   });
 
   it('normalizes telemetry debug before dispatching a background worker', () => {

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.link.cmd.test.ts
@@ -367,7 +367,12 @@ describe('CLI: composio dev connected-accounts link', () => {
     it.effect('passes the active org to session info before linking analytics identity', () =>
       Effect.gen(function* () {
         const userContext = yield* ComposioUserContext;
-        yield* userContext.login('test_api_key', 'org_selected', 'consumer-user-org_selected');
+        yield* userContext.login({
+          apiKey: 'test_api_key',
+          target: userContext.backend.ambient,
+          orgId: 'org_selected',
+          testUserId: 'consumer-user-org_selected',
+        });
 
         const originalFetch = globalThis.fetch;
         const sessionInfoRequests: Headers[] = [];

--- a/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connected-accounts/connected-accounts.list.cmd.test.ts
@@ -79,7 +79,11 @@ describe('CLI: composio dev connected-accounts list', () => {
       it.effect('lists all connected accounts with table', () =>
         Effect.gen(function* () {
           const userContext = yield* ComposioUserContext;
-          yield* userContext.login('test_api_key', 'org_test');
+          yield* userContext.login({
+            apiKey: 'test_api_key',
+            target: userContext.backend.ambient,
+            orgId: 'org_test',
+          });
           yield* cli(['dev', 'connected-accounts', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
@@ -99,7 +103,11 @@ describe('CLI: composio dev connected-accounts list', () => {
       it.effect('filters by toolkit', () =>
         Effect.gen(function* () {
           const userContext = yield* ComposioUserContext;
-          yield* userContext.login('test_api_key', 'org_test');
+          yield* userContext.login({
+            apiKey: 'test_api_key',
+            target: userContext.backend.ambient,
+            orgId: 'org_test',
+          });
           yield* cli(['dev', 'connected-accounts', 'list', '--toolkits', 'gmail']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
@@ -118,7 +126,11 @@ describe('CLI: composio dev connected-accounts list', () => {
       it.effect('filters by user ID', () =>
         Effect.gen(function* () {
           const userContext = yield* ComposioUserContext;
-          yield* userContext.login('test_api_key', 'org_test');
+          yield* userContext.login({
+            apiKey: 'test_api_key',
+            target: userContext.backend.ambient,
+            orgId: 'org_test',
+          });
           yield* cli(['dev', 'connected-accounts', 'list', '--user-id', 'default']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
@@ -138,7 +150,11 @@ describe('CLI: composio dev connected-accounts list', () => {
       it.effect('filters by status', () =>
         Effect.gen(function* () {
           const userContext = yield* ComposioUserContext;
-          yield* userContext.login('test_api_key', 'org_test');
+          yield* userContext.login({
+            apiKey: 'test_api_key',
+            target: userContext.backend.ambient,
+            orgId: 'org_test',
+          });
           yield* cli(['dev', 'connected-accounts', 'list', '--status', 'ACTIVE']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
@@ -158,7 +174,11 @@ describe('CLI: composio dev connected-accounts list', () => {
       it.effect('respects limit', () =>
         Effect.gen(function* () {
           const userContext = yield* ComposioUserContext;
-          yield* userContext.login('test_api_key', 'org_test');
+          yield* userContext.login({
+            apiKey: 'test_api_key',
+            target: userContext.backend.ambient,
+            orgId: 'org_test',
+          });
           yield* cli(['dev', 'connected-accounts', 'list', '--limit', '1']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
@@ -199,7 +219,11 @@ describe('CLI: composio dev connected-accounts list', () => {
       it.effect('shows no connected accounts found', () =>
         Effect.gen(function* () {
           const userContext = yield* ComposioUserContext;
-          yield* userContext.login('test_api_key', 'org_test');
+          yield* userContext.login({
+            apiKey: 'test_api_key',
+            target: userContext.backend.ambient,
+            orgId: 'org_test',
+          });
           yield* cli(['dev', 'connected-accounts', 'list']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
@@ -216,7 +240,11 @@ describe('CLI: composio dev connected-accounts list', () => {
       it.effect('shows toolkit hint', () =>
         Effect.gen(function* () {
           const userContext = yield* ComposioUserContext;
-          yield* userContext.login('test_api_key', 'org_test');
+          yield* userContext.login({
+            apiKey: 'test_api_key',
+            target: userContext.backend.ambient,
+            orgId: 'org_test',
+          });
           yield* cli(['dev', 'connected-accounts', 'list', '--toolkits', 'nonexistent']);
           const lines = yield* MockConsole.getLines({ stripAnsi: true });
           const output = lines.join('\n');
@@ -247,7 +275,11 @@ describe('CLI: composio dev connected-accounts list', () => {
     it.effect('does not crash on unknown status', () =>
       Effect.gen(function* () {
         const userContext = yield* ComposioUserContext;
-        yield* userContext.login('test_api_key', 'org_test');
+        yield* userContext.login({
+          apiKey: 'test_api_key',
+          target: userContext.backend.ambient,
+          orgId: 'org_test',
+        });
         yield* cli(['dev', 'connected-accounts', 'list']);
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
         const output = lines.join('\n');

--- a/ts/packages/cli/test/src/commands/connections/connections.list.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/connections/connections.list.cmd.test.ts
@@ -135,7 +135,11 @@ describe('CLI: composio connections list', () => {
     it.effect('[Given] no filter [Then] prints connection JSON with aliases for duplicates', () =>
       Effect.gen(function* () {
         const userContext = yield* ComposioUserContext;
-        yield* userContext.login('test_api_key', 'org_test');
+        yield* userContext.login({
+          apiKey: 'test_api_key',
+          target: userContext.backend.ambient,
+          orgId: 'org_test',
+        });
         yield* cli(['connections', 'list']);
 
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
@@ -162,7 +166,11 @@ describe('CLI: composio connections list', () => {
     it.effect('[Given] interactive stdout [Then] still prints the JSON payload', () =>
       Effect.gen(function* () {
         const userContext = yield* ComposioUserContext;
-        yield* userContext.login('test_api_key', 'org_test');
+        yield* userContext.login({
+          apiKey: 'test_api_key',
+          target: userContext.backend.ambient,
+          orgId: 'org_test',
+        });
         yield* cli(['connections', 'list']);
 
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
@@ -183,7 +191,11 @@ describe('CLI: composio connections list', () => {
     it.effect('[Given] --toolkit github [Then] filters the JSON output', () =>
       Effect.gen(function* () {
         const userContext = yield* ComposioUserContext;
-        yield* userContext.login('test_api_key', 'org_test');
+        yield* userContext.login({
+          apiKey: 'test_api_key',
+          target: userContext.backend.ambient,
+          orgId: 'org_test',
+        });
         yield* cli(['connections', 'list', '--toolkit', 'github']);
 
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
@@ -231,7 +243,11 @@ describe('CLI: composio connections list', () => {
     it.effect('[Given] mixed user scopes [Then] only consumer-project connections are listed', () =>
       Effect.gen(function* () {
         const userContext = yield* ComposioUserContext;
-        yield* userContext.login('test_api_key', 'org_test');
+        yield* userContext.login({
+          apiKey: 'test_api_key',
+          target: userContext.backend.ambient,
+          orgId: 'org_test',
+        });
         yield* cli(['connections', 'list']);
 
         const lines = yield* MockConsole.getLines({ stripAnsi: true });
@@ -260,7 +276,11 @@ describe('CLI: composio connections remove', () => {
         confirmedDeleteCalls.length = 0;
 
         const userContext = yield* ComposioUserContext;
-        yield* userContext.login('test_api_key', 'org_test');
+        yield* userContext.login({
+          apiKey: 'test_api_key',
+          target: userContext.backend.ambient,
+          orgId: 'org_test',
+        });
         yield* cli(['connections', 'remove', 'gmail']);
 
         expect(confirmedDeleteCalls).toEqual(['con_gmail_active']);
@@ -287,7 +307,11 @@ describe('CLI: composio connections remove', () => {
         deniedDeleteCalls.length = 0;
 
         const userContext = yield* ComposioUserContext;
-        yield* userContext.login('test_api_key', 'org_test');
+        yield* userContext.login({
+          apiKey: 'test_api_key',
+          target: userContext.backend.ambient,
+          orgId: 'org_test',
+        });
         yield* cli(['connections', 'remove', 'work']);
 
         expect(deniedDeleteCalls).toEqual([]);
@@ -316,7 +340,11 @@ describe('CLI: composio connections remove', () => {
           ambiguousDeleteCalls.length = 0;
 
           const userContext = yield* ComposioUserContext;
-          yield* userContext.login('test_api_key', 'org_test');
+          yield* userContext.login({
+            apiKey: 'test_api_key',
+            target: userContext.backend.ambient,
+            orgId: 'org_test',
+          });
           yield* cli(['connections', 'remove', 'github']);
 
           expect(ambiguousDeleteCalls).toEqual([]);

--- a/ts/packages/cli/test/src/commands/login.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/login.cmd.test.ts
@@ -782,20 +782,18 @@ describe('CLI: composio login', () => {
     const stagingLogin = { ...stagingLoginWithoutOrg, org_id: 'org_staging' };
 
     layer(TestLive({ terminalUI: headlessStdinUI, userData: stagingLogin }))(it => {
-      it.effect(
-        'Covers AE7. [Given] a stored key the backend accepts [Then] reports already logged in',
-        () =>
-          Effect.gen(function* () {
-            const requestedUrls = spyOnSessionInfo();
+      it.effect('[Given] a stored key the backend accepts [Then] reports already logged in', () =>
+        Effect.gen(function* () {
+          const requestedUrls = spyOnSessionInfo();
 
-            yield* cli(['login']);
+          yield* cli(['login']);
 
-            expect(requestedUrls).toHaveLength(1);
-            expect(new URL(requestedUrls[0]!).origin).toBe(constants.STAGING_BASE_URL);
-            const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
-            expect(output).toContain("You're already logged in!");
-            expect(output).not.toContain('Open this URL in your browser to log in:');
-          })
+          expect(requestedUrls).toHaveLength(1);
+          expect(new URL(requestedUrls[0]!).origin).toBe(constants.STAGING_BASE_URL);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+          expect(output).toContain("You're already logged in!");
+          expect(output).not.toContain('Open this URL in your browser to log in:');
+        })
       );
     });
 
@@ -821,7 +819,7 @@ describe('CLI: composio login', () => {
 
     layer(TestLive({ terminalUI: headlessStdinUI, userData: stagingLogin }))(it => {
       it.effect(
-        'Covers AE7. [Given] the stored staging key is rejected [Then] login proceeds against production',
+        '[Given] the stored staging key is rejected [Then] login proceeds against production',
         () =>
           Effect.gen(function* () {
             rejectStoredKey();
@@ -848,7 +846,7 @@ describe('CLI: composio login', () => {
       })
     )(it => {
       it.effect(
-        'Covers AE7. [Given] a rejected key and COMPOSIO_ENVIRONMENT=staging [Then] names the staging host first',
+        '[Given] a rejected key and COMPOSIO_ENVIRONMENT=staging [Then] names the staging host first',
         () =>
           Effect.gen(function* () {
             rejectStoredKey();

--- a/ts/packages/cli/test/src/commands/login.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/login.cmd.test.ts
@@ -12,6 +12,7 @@ import { writeStoredAgentIdentity } from 'src/services/agents';
 import { ComposioUserContext } from 'src/services/user-context';
 import { ComposioSessionRepository } from 'src/services/composio-clients';
 import { extendConfigProvider } from 'src/services/config';
+import { userApiKeyRejectionResponse } from 'test/__utils__/models/user-api-key-rejection';
 
 vi.mock('open', () => ({
   default: vi.fn(async () => undefined),
@@ -774,6 +775,93 @@ describe('CLI: composio login', () => {
             );
             expect(announcement).toBeGreaterThanOrEqual(0);
             expect(announcement).toBeLessThan(instructions);
+          })
+      );
+    });
+
+    const stagingLogin = { ...stagingLoginWithoutOrg, org_id: 'org_staging' };
+
+    layer(TestLive({ terminalUI: headlessStdinUI, userData: stagingLogin }))(it => {
+      it.effect(
+        'Covers AE7. [Given] a stored key the backend accepts [Then] reports already logged in',
+        () =>
+          Effect.gen(function* () {
+            const requestedUrls = spyOnSessionInfo();
+
+            yield* cli(['login']);
+
+            expect(requestedUrls).toHaveLength(1);
+            expect(new URL(requestedUrls[0]!).origin).toBe(constants.STAGING_BASE_URL);
+            const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+            expect(output).toContain("You're already logged in!");
+            expect(output).not.toContain('Open this URL in your browser to log in:');
+          })
+      );
+    });
+
+    layer(TestLive({ terminalUI: headlessStdinUI, userData: stagingLogin }))(it => {
+      it.effect(
+        '[Given] the stored key cannot be checked [Then] reports already logged in as before',
+        () =>
+          Effect.gen(function* () {
+            vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network unreachable'));
+
+            yield* cli(['login']);
+
+            const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+            expect(output).toContain("You're already logged in!");
+          })
+      );
+    });
+
+    const rejectStoredKey = () =>
+      vi
+        .spyOn(globalThis, 'fetch')
+        .mockImplementation(() => Promise.resolve(userApiKeyRejectionResponse()));
+
+    layer(TestLive({ terminalUI: headlessStdinUI, userData: stagingLogin }))(it => {
+      it.effect(
+        'Covers AE7. [Given] the stored staging key is rejected [Then] login proceeds against production',
+        () =>
+          Effect.gen(function* () {
+            rejectStoredKey();
+            const calls: Array<{ readonly baseURL?: string }> = [];
+            const sessionRepository = yield* recordingSessionRepository(calls);
+
+            yield* cli(['login']).pipe(
+              Effect.provideService(ComposioSessionRepository, sessionRepository)
+            );
+
+            expect(calls).toEqual([{ baseURL: constants.DEFAULT_BASE_URL }]);
+            const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+            expect(output).not.toContain("You're already logged in!");
+            expect(output).toContain(`${constants.DEFAULT_WEB_URL}?cliKey=target-session-id`);
+          })
+      );
+    });
+
+    layer(
+      TestLive({
+        terminalUI: headlessStdinUI,
+        userData: stagingLogin,
+        baseConfigProvider: stagingEnv,
+      })
+    )(it => {
+      it.effect(
+        'Covers AE7. [Given] a rejected key and COMPOSIO_ENVIRONMENT=staging [Then] names the staging host first',
+        () =>
+          Effect.gen(function* () {
+            rejectStoredKey();
+            const calls: Array<{ readonly baseURL?: string }> = [];
+            const sessionRepository = yield* recordingSessionRepository(calls);
+
+            yield* cli(['login']).pipe(
+              Effect.provideService(ComposioSessionRepository, sessionRepository)
+            );
+
+            expect(calls).toEqual([{ baseURL: constants.STAGING_BASE_URL }]);
+            const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+            expect(output).toContain('Logging in to staging-backend.composio.dev');
           })
       );
     });

--- a/ts/packages/cli/test/src/commands/login.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/login.cmd.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, layer } from '@effect/vitest';
 import { vi, afterEach } from 'vitest';
-import { Console, DateTime, Effect, Exit, Option } from 'effect';
+import { ConfigProvider, Console, DateTime, Effect, Exit, Option } from 'effect';
 import path from 'node:path';
 import * as FileSystem from 'effect/FileSystem';
 import { cli, MockConsole, TestLive } from 'test/__utils__';
@@ -11,6 +11,7 @@ import { getTerminalCapabilities, TerminalUI } from 'src/services/terminal-ui';
 import { writeStoredAgentIdentity } from 'src/services/agents';
 import { ComposioUserContext } from 'src/services/user-context';
 import { ComposioSessionRepository } from 'src/services/composio-clients';
+import { extendConfigProvider } from 'src/services/config';
 
 vi.mock('open', () => ({
   default: vi.fn(async () => undefined),
@@ -603,5 +604,197 @@ describe('CLI: composio login', () => {
           ]);
         })
     );
+  });
+
+  describe('login target environment', () => {
+    const stagingLoginWithoutOrg = {
+      api_key: 'uak_old_staging',
+      base_url: constants.STAGING_BASE_URL,
+      web_url: constants.STAGING_WEB_URL,
+    };
+
+    const sessionInfoBody = {
+      project: {
+        name: 'Default Project',
+        id: 'project_id_default',
+        org_id: 'org_default',
+        nano_id: 'project_default',
+        email: 'project@example.com',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        org: { id: 'org_default', name: 'Example Org', plan: 'enterprise' },
+      },
+      org_member: {
+        id: 'member_default',
+        user_id: 'user_123',
+        email: 'cli@example.com',
+        name: 'CLI User',
+        role: 'admin',
+      },
+      api_key: null,
+    };
+
+    const readStoredUserConfig = Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const cacheDir = yield* setupCacheDir;
+      const raw = yield* fs.readFileString(
+        path.join(cacheDir, constants.USER_CONFIG_FILE_NAME),
+        'utf8'
+      );
+      return JSON.parse(raw) as Record<string, unknown>;
+    });
+
+    const spyOnSessionInfo = () => {
+      const requestedUrls: string[] = [];
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async requestInput => {
+        const url = requestUrl(requestInput);
+        requestedUrls.push(url);
+        return url.includes('/api/v3/auth/session/info')
+          ? mockFetchResponse(sessionInfoBody)
+          : mockFetchResponse({});
+      });
+      return requestedUrls;
+    };
+
+    layer(TestLive({ userData: stagingLoginWithoutOrg }))(it => {
+      it.effect(
+        '[Given] a stored staging login and no env vars [When] logging in with --user-api-key [Then] validates against and records production',
+        () =>
+          Effect.gen(function* () {
+            const requestedUrls = spyOnSessionInfo();
+
+            yield* cli(['login', '--user-api-key', 'uak_new', '--no-skill-install']);
+
+            const sessionInfoUrl = requestedUrls.find(url =>
+              url.includes('/api/v3/auth/session/info')
+            );
+            expect(sessionInfoUrl).toBeDefined();
+            expect(new URL(sessionInfoUrl!).origin).toBe(constants.DEFAULT_BASE_URL);
+
+            const userConfig = yield* readStoredUserConfig;
+            expect(userConfig.api_key).toBe('uak_new');
+            expect(userConfig.base_url).toBe(constants.DEFAULT_BASE_URL);
+            expect(userConfig.web_url).toBe(constants.DEFAULT_WEB_URL);
+
+            const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+            expect(output).not.toContain('Logging in to');
+          })
+      );
+    });
+
+    const stagingEnv = ConfigProvider.fromEnvRecord({ COMPOSIO_ENVIRONMENT: 'staging' }).pipe(
+      extendConfigProvider
+    );
+
+    layer(TestLive({ baseConfigProvider: stagingEnv }))(it => {
+      it.effect(
+        '[Given] COMPOSIO_ENVIRONMENT=staging [When] logging in with --user-api-key [Then] names the staging host first and records staging',
+        () =>
+          Effect.gen(function* () {
+            const requestedUrls = spyOnSessionInfo();
+
+            yield* cli(['login', '--user-api-key', 'uak_new', '--no-skill-install']);
+
+            expect(
+              requestedUrls.every(url => new URL(url).origin === constants.STAGING_BASE_URL)
+            ).toBe(true);
+            const userConfig = yield* readStoredUserConfig;
+            expect(userConfig.base_url).toBe(constants.STAGING_BASE_URL);
+            expect(userConfig.web_url).toBe(constants.STAGING_WEB_URL);
+
+            const lines = yield* MockConsole.getLines({ stripAnsi: true });
+            const announcement = lines.findIndex(line =>
+              line.includes('Logging in to staging-backend.composio.dev')
+            );
+            const success = lines.findIndex(line => line.includes('Logged in as'));
+            expect(announcement).toBeGreaterThanOrEqual(0);
+            expect(announcement).toBeLessThan(success);
+          })
+      );
+    });
+
+    const recordingSessionRepository = (calls: Array<{ readonly baseURL?: string }>) =>
+      Effect.gen(function* () {
+        const expiresAt = DateTime.add(yield* DateTime.now, { minutes: 10 });
+        return ComposioSessionRepository.of({
+          createSession: params => {
+            calls.push({ baseURL: params?.baseURL });
+            return Effect.succeed({
+              id: 'target-session-id',
+              code: '001122',
+              expiresAt,
+              status: 'pending',
+            });
+          },
+          getSession: () => Effect.die(new Error('test: not polled')),
+          getRealtimeCredentials: () => Effect.die(new Error('test: unused')),
+          authRealtimeChannel: () => Effect.die(new Error('test: unused')),
+        });
+      });
+
+    layer(TestLive({ terminalUI: headlessStdinUI, userData: stagingLoginWithoutOrg }))(it => {
+      it.effect(
+        '[Given] a stored staging web_url [When] browser login starts [Then] it uses the production dashboard and backend',
+        () =>
+          Effect.gen(function* () {
+            const calls: Array<{ readonly baseURL?: string }> = [];
+            const sessionRepository = yield* recordingSessionRepository(calls);
+
+            yield* cli(['login']).pipe(
+              Effect.provideService(ComposioSessionRepository, sessionRepository)
+            );
+
+            expect(calls).toEqual([{ baseURL: constants.DEFAULT_BASE_URL }]);
+            const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+            expect(output).toContain(`${constants.DEFAULT_WEB_URL}?cliKey=target-session-id`);
+            expect(output).not.toContain('staging-dashboard');
+          })
+      );
+    });
+
+    layer(TestLive({ terminalUI: headlessStdinUI, baseConfigProvider: stagingEnv }))(it => {
+      it.effect(
+        '[Given] COMPOSIO_ENVIRONMENT=staging [When] browser login starts [Then] names the staging host before the URL',
+        () =>
+          Effect.gen(function* () {
+            const calls: Array<{ readonly baseURL?: string }> = [];
+            const sessionRepository = yield* recordingSessionRepository(calls);
+
+            yield* cli(['login']).pipe(
+              Effect.provideService(ComposioSessionRepository, sessionRepository)
+            );
+
+            expect(calls).toEqual([{ baseURL: constants.STAGING_BASE_URL }]);
+            const lines = yield* MockConsole.getLines({ stripAnsi: true });
+            const announcement = lines.findIndex(line =>
+              line.includes('Logging in to staging-backend.composio.dev')
+            );
+            const instructions = lines.findIndex(line =>
+              line.includes(`${constants.STAGING_WEB_URL}?cliKey=target-session-id`)
+            );
+            expect(announcement).toBeGreaterThanOrEqual(0);
+            expect(announcement).toBeLessThan(instructions);
+          })
+      );
+    });
+
+    layer(TestLive({ terminalUI: headlessStdinUI }))(it => {
+      it.effect('[Given] no env vars [When] an agent logs in [Then] production is recorded', () =>
+        Effect.gen(function* () {
+          yield* writeStoredAgentIdentity(storedAgentIdentity);
+          vi.spyOn(globalThis, 'fetch').mockImplementation(async requestInput =>
+            requestUrl(requestInput).includes('/api/whoami')
+              ? mockFetchResponse(storedAgentIdentity)
+              : mockFetchResponse({})
+          );
+
+          yield* cli(['login']);
+
+          const userConfig = yield* readStoredUserConfig;
+          expect(userConfig.api_key).toBe('uak_agent');
+          expect(userConfig.base_url).toBe(constants.DEFAULT_BASE_URL);
+        })
+      );
+    });
   });
 });

--- a/ts/packages/cli/test/src/commands/logout.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/logout.cmd.test.ts
@@ -66,7 +66,7 @@ const setupLoggedInAgent = Effect.gen(function* () {
       user_api_key: 'uak_agent',
     },
   });
-  yield* ctx.login('uak_agent', 'org_agent');
+  yield* ctx.login({ apiKey: 'uak_agent', target: ctx.backend.ambient, orgId: 'org_agent' });
   return ctx;
 });
 

--- a/ts/packages/cli/test/src/commands/orgs.switch.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/orgs.switch.cmd.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, layer } from '@effect/vitest';
 import { ConfigProvider, Effect } from 'effect';
+import * as FileSystem from 'effect/FileSystem';
+import path from 'node:path';
 import { afterEach, vi } from 'vitest';
+import { STAGING_BASE_URL, STAGING_WEB_URL, USER_CONFIG_FILE_NAME } from 'src/constants';
+import { setupCacheDir } from 'src/effects/setup-cache-dir';
 import { extendConfigProvider } from 'src/services/config';
 import { cli, TestLive } from 'test/__utils__';
 
@@ -69,4 +73,63 @@ describe('CLI: composio orgs switch', () => {
       })
     );
   });
+
+  layer(
+    TestLive({
+      userData: {
+        api_key: 'uak_staging',
+        base_url: STAGING_BASE_URL,
+        web_url: STAGING_WEB_URL,
+        org_id: 'org_old',
+      },
+    })
+  )(it => {
+    it.effect('[Given] a stored staging login and no env vars [Then] keeps staging stored', () =>
+      Effect.gen(function* () {
+        const requestedOrigins: string[] = [];
+        vi.spyOn(globalThis, 'fetch').mockImplementation(async requestInput => {
+          const url = requestInput instanceof Request ? requestInput.url : String(requestInput);
+          requestedOrigins.push(new URL(url).origin);
+          return new Response(JSON.stringify(sessionInfoFor('org_selected')), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        });
+
+        yield* cli(['orgs', 'switch', '--org-id', 'org_selected']);
+
+        const fs = yield* FileSystem.FileSystem;
+        const cacheDir = yield* setupCacheDir;
+        const userConfig = JSON.parse(
+          yield* fs.readFileString(path.join(cacheDir, USER_CONFIG_FILE_NAME), 'utf8')
+        ) as Record<string, unknown>;
+        expect(userConfig.org_id).toBe('org_selected');
+        expect(userConfig.base_url).toBe(STAGING_BASE_URL);
+        expect(userConfig.web_url).toBe(STAGING_WEB_URL);
+        expect(requestedOrigins.length).toBeGreaterThan(0);
+        expect(new Set(requestedOrigins)).toEqual(new Set([STAGING_BASE_URL]));
+      })
+    );
+  });
+});
+
+const sessionInfoFor = (orgId: string) => ({
+  project: {
+    name: 'Selected Project',
+    id: 'project_selected',
+    org_id: orgId,
+    nano_id: 'project_selected',
+    email: 'project@example.com',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    org: { id: orgId, name: 'Selected Org', plan: 'enterprise' },
+  },
+  org_member: {
+    id: 'member_selected',
+    user_id: 'user_123',
+    email: 'cli@example.com',
+    name: 'CLI User',
+    role: 'admin',
+  },
+  api_key: null,
 });

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
@@ -4,6 +4,10 @@ import { extendConfigProvider } from 'src/services/config';
 import { cli, TestLive, MockConsole } from 'test/__utils__';
 import type { TestLiveInput } from 'test/__utils__/services/test-layer';
 import type { Toolkits, ToolkitDetailed } from 'src/models/toolkits';
+import { APIError } from '@composio/client';
+import { hasRecordedAuthRejection } from 'src/services/auth-rejection';
+import { HttpServerError } from 'src/services/composio-clients';
+import { userApiKeyRejectionBody } from 'test/__utils__/models/user-api-key-rejection';
 
 const testToolkits: Toolkits = [
   {
@@ -270,5 +274,89 @@ describe('CLI: composio dev toolkits info', () => {
         expect(output).toContain('not logged in');
       })
     );
+  });
+
+  describe('[Given] the backend rejects the stored key', () => {
+    const storedStagingLogin = {
+      api_key: 'uak_revoked',
+      base_url: 'https://staging-backend.composio.dev',
+      web_url: 'https://staging-dashboard.composio.dev/',
+      org_id: 'org_staging',
+    };
+    const sdkRejection = () =>
+      APIError.generate(401, userApiKeyRejectionBody, undefined, new Headers());
+
+    layer(
+      TestLive({
+        toolkitsData,
+        userData: storedStagingLogin,
+        toolRouter: { create: () => Promise.reject(sdkRejection()) },
+      })
+    )(it => {
+      it.effect(
+        'Covers AE1. [When] session creation is rejected [Then] defers to the recovery block',
+        () =>
+          Effect.gen(function* () {
+            yield* cli(['dev', 'toolkits', 'info', 'slack', '--user-id', 'alice']);
+            const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+            expect(output).not.toContain('Invalid or revoked user API key');
+            expect(output).not.toContain('Browse available toolkits');
+            expect(yield* hasRecordedAuthRejection).toBe(true);
+          })
+      );
+    });
+
+    layer(
+      TestLive({
+        toolkitsData,
+        userData: storedStagingLogin,
+        toolkitsRepositoryFailure: new HttpServerError({
+          status: 401,
+          cause: 'HTTP 401 Unauthorized',
+          apiError: userApiKeyRejectionBody.error,
+        }),
+      })
+    )(it => {
+      it.effect('[When] the toolkit lookup is rejected [Then] prints no "not found" line', () =>
+        Effect.gen(function* () {
+          yield* cli(['dev', 'toolkits', 'info', 'slack']);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+          expect(output).not.toContain('Toolkit "slack" not found.');
+          expect(output).not.toContain('Did you mean?');
+          expect(yield* hasRecordedAuthRejection).toBe(true);
+        })
+      );
+    });
+
+    layer(
+      TestLive({
+        toolkitsData,
+        userData: storedStagingLogin,
+        toolRouter: {
+          create: () =>
+            Promise.reject(
+              APIError.generate(
+                500,
+                { error: { message: 'Session service unavailable', slug: 'Internal_Error' } },
+                undefined,
+                new Headers()
+              )
+            ),
+        },
+      })
+    )(it => {
+      it.effect('[When] another API error occurs [Then] still prints its message', () =>
+        Effect.gen(function* () {
+          yield* cli(['dev', 'toolkits', 'info', 'slack', '--user-id', 'alice']);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+
+          expect(output).toContain('Session service unavailable');
+          expect(output).toContain('Browse available toolkits');
+          expect(yield* hasRecordedAuthRejection).toBe(false);
+        })
+      );
+    });
   });
 });

--- a/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/toolkits/toolkits.info.cmd.test.ts
@@ -293,17 +293,15 @@ describe('CLI: composio dev toolkits info', () => {
         toolRouter: { create: () => Promise.reject(sdkRejection()) },
       })
     )(it => {
-      it.effect(
-        'Covers AE1. [When] session creation is rejected [Then] defers to the recovery block',
-        () =>
-          Effect.gen(function* () {
-            yield* cli(['dev', 'toolkits', 'info', 'slack', '--user-id', 'alice']);
-            const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
+      it.effect('[When] session creation is rejected [Then] defers to the recovery block', () =>
+        Effect.gen(function* () {
+          yield* cli(['dev', 'toolkits', 'info', 'slack', '--user-id', 'alice']);
+          const output = (yield* MockConsole.getLines({ stripAnsi: true })).join('\n');
 
-            expect(output).not.toContain('Invalid or revoked user API key');
-            expect(output).not.toContain('Browse available toolkits');
-            expect(yield* hasRecordedAuthRejection).toBe(true);
-          })
+          expect(output).not.toContain('Invalid or revoked user API key');
+          expect(output).not.toContain('Browse available toolkits');
+          expect(yield* hasRecordedAuthRejection).toBe(true);
+        })
       );
     });
 

--- a/ts/packages/cli/test/src/commands/whoami.cmd.test.ts
+++ b/ts/packages/cli/test/src/commands/whoami.cmd.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, layer } from '@effect/vitest';
 import { ConfigProvider, Effect } from 'effect';
 import { extendConfigProvider } from 'src/services/config';
 import { cli, TestLive, MockConsole } from 'test/__utils__';
+import { hasRecordedAuthRejection } from 'src/services/auth-rejection';
+import { userApiKeyRejectionResponse } from 'test/__utils__/models/user-api-key-rejection';
 import { afterEach, vi } from 'vitest';
 
 describe('CLI: composio whoami', () => {
@@ -16,6 +18,7 @@ describe('CLI: composio whoami', () => {
   layer(TestLive({ baseConfigProvider: testConfigProvider }))('with config override', it => {
     it.effect('[Given] `COMPOSIO_USER_API_KEY` [Then] prints global user context JSON', () =>
       Effect.gen(function* () {
+        vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network unreachable'));
         const args = ['whoami'];
         yield* cli(args);
 
@@ -33,6 +36,7 @@ describe('CLI: composio whoami', () => {
   layer(TestLive({ fixture: 'user-config-example' }))('with fixture', it => {
     it.effect('[Given] user_data.json in fixture [Then] prints global user context JSON', () =>
       Effect.gen(function* () {
+        vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network unreachable'));
         const args = ['whoami'];
         yield* cli(args);
 
@@ -93,6 +97,34 @@ describe('CLI: composio whoami', () => {
         expect(output).not.toContain('Default Org');
         expect(output).not.toContain('Test User ID');
       })
+    );
+  });
+
+  layer(
+    TestLive({
+      userData: {
+        api_key: 'uak_revoked',
+        base_url: 'https://staging-backend.composio.dev',
+        web_url: 'https://staging-dashboard.composio.dev/',
+        org_id: 'org_staging',
+      },
+    })
+  )('with a rejected stored key', it => {
+    it.effect(
+      '[Given] the backend rejects the key [Then] records it and prints no account note',
+      () =>
+        Effect.gen(function* () {
+          vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+            Promise.resolve(userApiKeyRejectionResponse())
+          );
+
+          yield* cli(['whoami']);
+
+          const output = (yield* MockConsole.getLines()).join('\n');
+          expect(output).not.toContain('Email: unknown');
+          expect(output).not.toContain('"account_type"');
+          expect(yield* hasRecordedAuthRejection).toBe(true);
+        })
     );
   });
 });

--- a/ts/packages/cli/test/src/effects/auth-rejection-recovery.test.ts
+++ b/ts/packages/cli/test/src/effects/auth-rejection-recovery.test.ts
@@ -63,7 +63,7 @@ describe('decideAuthRejectionRecovery', () => {
       invocationOrigin: params.invocationOrigin,
     });
 
-  it('Covers AE5. [Given] a rejected stored staging key and no prompt [Then] spells out the staging login', () => {
+  it('[Given] a rejected stored staging key and no prompt [Then] spells out the staging login', () => {
     const recovery = decide({ rejection: { baseURL: STAGING_BASE_URL, keySource: 'stored' } });
 
     expect(recovery.kind).toBe('message');
@@ -100,7 +100,7 @@ describe('decideAuthRejectionRecovery', () => {
     expect(recovery).toMatchObject({ kind: 'offer-relogin', target: storedStaging });
   });
 
-  it('Covers AE3. [Given] COMPOSIO_BASE_URL points away from the stored backend [Then] explains the mismatch without re-login', () => {
+  it('[Given] COMPOSIO_BASE_URL points away from the stored backend [Then] explains the mismatch without re-login', () => {
     const recovery = decide({
       rejection: { baseURL: DEFAULT_BASE_URL, keySource: 'stored' },
       overrides: { ...noOverrides, baseURL: DEFAULT_BASE_URL },
@@ -114,7 +114,7 @@ describe('decideAuthRejectionRecovery', () => {
     expect(recovery.nextStep).toBe('Unset COMPOSIO_BASE_URL to use that login.');
   });
 
-  it('Covers AE6. [Given] a rejected COMPOSIO_USER_API_KEY [Then] asks to replace it without re-login', () => {
+  it('[Given] a rejected COMPOSIO_USER_API_KEY [Then] asks to replace it without re-login', () => {
     const recovery = decide({
       rejection: { baseURL: DEFAULT_BASE_URL, keySource: 'env' },
       canPromptForLogin: true,
@@ -125,7 +125,7 @@ describe('decideAuthRejectionRecovery', () => {
     expect(recovery.nextStep).toBe('Replace its value with a valid user API key.');
   });
 
-  it('Covers AE8. [Given] a composio run child call [Then] asks to run composio login', () => {
+  it('[Given] a composio run child call [Then] asks to run composio login', () => {
     const recovery = decide({
       rejection: { baseURL: STAGING_BASE_URL, keySource: 'env' },
       invocationOrigin: 'run',
@@ -291,7 +291,7 @@ describe('reportAuthRejection', () => {
 
   layer(TestLive({ userData: stagingLogin }))(it => {
     it.effect(
-      'Covers AE5. [Given] stderr is not a terminal [Then] writes one undecorated line with the staging login step',
+      '[Given] stderr is not a terminal [Then] writes one undecorated line with the staging login step',
       () =>
         Effect.gen(function* () {
           yield* recordThenReport(stagingRejection);
@@ -331,26 +331,24 @@ describe('reportAuthRejection', () => {
       baseConfigProvider: stagingOverrideToProduction,
     })
   )(it => {
-    it.effect(
-      'Covers AE3. [Given] a mismatch in a terminal [Then] explains it and never prompts',
-      () =>
-        Effect.gen(function* () {
-          vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
-          confirmCalls.length = 0;
+    it.effect('[Given] a mismatch in a terminal [Then] explains it and never prompts', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
+        confirmCalls.length = 0;
 
-          yield* recordThenReport({ baseURL: DEFAULT_BASE_URL, keySource: 'stored' });
+        yield* recordThenReport({ baseURL: DEFAULT_BASE_URL, keySource: 'stored' });
 
-          expect(confirmCalls).toEqual([]);
-          const output = (yield* MockConsole.getLines()).join('\n');
-          expect(output).toContain('COMPOSIO_BASE_URL points the CLI at backend.composio.dev');
-          expect(output).toContain('Unset COMPOSIO_BASE_URL');
-        })
+        expect(confirmCalls).toEqual([]);
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('COMPOSIO_BASE_URL points the CLI at backend.composio.dev');
+        expect(output).toContain('Unset COMPOSIO_BASE_URL');
+      })
     );
   });
 
   layer(TestLive({ userData: stagingLogin, terminalUI: interactiveUI(true) }))(it => {
     it.effect(
-      'Covers AE4. [Given] an accepted re-login [Then] replaces the key, keeps staging and the org, and asks to re-run',
+      '[Given] an accepted re-login [Then] replaces the key, keeps staging and the org, and asks to re-run',
       () =>
         Effect.gen(function* () {
           vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
@@ -410,7 +408,7 @@ describe('reportAuthRejection', () => {
   });
 
   layer(TestLive({ userData: stagingLogin, terminalUI: interactiveUI(false) }))(it => {
-    it.effect('Covers AE4. [Given] a declined re-login [Then] keeps the stored credentials', () =>
+    it.effect('[Given] a declined re-login [Then] keeps the stored credentials', () =>
       Effect.gen(function* () {
         vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
         confirmCalls.length = 0;
@@ -426,7 +424,7 @@ describe('reportAuthRejection', () => {
   });
 
   layer(TestLive({ userData: stagingLogin, terminalUI: interactiveUI(true) }))(it => {
-    it.effect('Covers AE4. [Given] a failed re-login [Then] keeps the stored credentials', () =>
+    it.effect('[Given] a failed re-login [Then] keeps the stored credentials', () =>
       Effect.gen(function* () {
         vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
         const { repository } = yield* linkedSessionRepository({ failCreate: true });
@@ -447,19 +445,17 @@ describe('reportAuthRejection', () => {
   );
 
   layer(TestLive({ baseConfigProvider: envKey, terminalUI: interactiveUI(true) }))(it => {
-    it.effect(
-      'Covers AE6. [Given] a rejected env key [Then] names the env var and never prompts',
-      () =>
-        Effect.gen(function* () {
-          vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
-          confirmCalls.length = 0;
+    it.effect('[Given] a rejected env key [Then] names the env var and never prompts', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
+        confirmCalls.length = 0;
 
-          yield* recordThenReport({ baseURL: DEFAULT_BASE_URL, keySource: 'env' });
+        yield* recordThenReport({ baseURL: DEFAULT_BASE_URL, keySource: 'env' });
 
-          expect(confirmCalls).toEqual([]);
-          const output = (yield* MockConsole.getLines()).join('\n');
-          expect(output).toContain('rejected the API key in COMPOSIO_USER_API_KEY');
-        })
+        expect(confirmCalls).toEqual([]);
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('rejected the API key in COMPOSIO_USER_API_KEY');
+      })
     );
   });
 
@@ -470,16 +466,14 @@ describe('reportAuthRejection', () => {
   }).pipe(extendConfigProvider);
 
   layer(TestLive({ baseConfigProvider: runChild }))(it => {
-    it.effect(
-      'Covers AE8. [Given] a composio run child call [Then] asks to run composio login',
-      () =>
-        Effect.gen(function* () {
-          yield* recordThenReport({ baseURL: STAGING_BASE_URL, keySource: 'env' });
+    it.effect('[Given] a composio run child call [Then] asks to run composio login', () =>
+      Effect.gen(function* () {
+        yield* recordThenReport({ baseURL: STAGING_BASE_URL, keySource: 'env' });
 
-          const output = (yield* MockConsole.getLines()).join('\n');
-          expect(output).toContain('`COMPOSIO_ENVIRONMENT=staging composio login`');
-          expect(output).not.toContain('Replace its value');
-        })
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('`COMPOSIO_ENVIRONMENT=staging composio login`');
+        expect(output).not.toContain('Replace its value');
+      })
     );
   });
 });

--- a/ts/packages/cli/test/src/effects/auth-rejection-recovery.test.ts
+++ b/ts/packages/cli/test/src/effects/auth-rejection-recovery.test.ts
@@ -1,0 +1,485 @@
+import { describe, expect, it, layer } from '@effect/vitest';
+import { afterEach, vi } from 'vitest';
+import { ConfigProvider, DateTime, Effect } from 'effect';
+import * as FileSystem from 'effect/FileSystem';
+import path from 'node:path';
+import * as constants from 'src/constants';
+import { reloginWithBrowser } from 'src/commands/login.cmd';
+import {
+  decideAuthRejectionRecovery,
+  reportAuthRejection,
+} from 'src/effects/auth-rejection-recovery';
+import { setupCacheDir } from 'src/effects/setup-cache-dir';
+import { type AuthRejection, AuthRejectionRecorder } from 'src/services/auth-rejection';
+import { ComposioSessionRepository, HttpServerError } from 'src/services/composio-clients';
+import { extendConfigProvider } from 'src/services/config';
+import { getTerminalCapabilities, TerminalUI } from 'src/services/terminal-ui';
+import { type BackendOverrides, resolveBackend } from 'src/utils/backend-resolution';
+import { MockConsole, TestLive } from 'test/__utils__';
+import { terminalUITestImpl } from 'test/__utils__/services/terminal-ui-test';
+
+vi.mock('open', () => ({
+  default: vi.fn(async () => undefined),
+}));
+
+vi.mock('src/analytics/dispatch', async importOriginal => {
+  const actual = await importOriginal<typeof import('src/analytics/dispatch')>();
+  const { Effect } = await import('effect');
+  return {
+    ...actual,
+    analyticsIdentityLinkingEnabled: Effect.succeed(false),
+    linkApolloIdentityForAnalytics: (() =>
+      Effect.void) as unknown as typeof actual.linkApolloIdentityForAnalytics,
+  };
+});
+
+const { DEFAULT_BASE_URL, STAGING_BASE_URL, STAGING_WEB_URL } = constants;
+const CUSTOM_BASE_URL = 'http://localhost:9900';
+
+const noOverrides: BackendOverrides = {
+  baseURL: undefined,
+  webURL: undefined,
+  environment: undefined,
+};
+
+const storedStaging = { baseURL: STAGING_BASE_URL, webURL: STAGING_WEB_URL };
+
+describe('decideAuthRejectionRecovery', () => {
+  const decide = (params: {
+    readonly rejection: AuthRejection;
+    readonly overrides?: BackendOverrides;
+    readonly stored?: { readonly baseURL: string; readonly webURL: string };
+    readonly canPromptForLogin?: boolean;
+    readonly invocationOrigin?: string;
+  }) =>
+    decideAuthRejectionRecovery({
+      rejection: params.rejection,
+      backend: resolveBackend({
+        overrides: params.overrides ?? noOverrides,
+        stored: params.stored ?? storedStaging,
+        keySource: params.rejection.keySource,
+      }),
+      canPromptForLogin: params.canPromptForLogin ?? false,
+      invocationOrigin: params.invocationOrigin,
+    });
+
+  it('Covers AE5. [Given] a rejected stored staging key and no prompt [Then] spells out the staging login', () => {
+    const recovery = decide({ rejection: { baseURL: STAGING_BASE_URL, keySource: 'stored' } });
+
+    expect(recovery.kind).toBe('message');
+    expect(recovery.message).toBe(
+      'The Composio API at staging-backend.composio.dev rejected your stored API key.'
+    );
+    expect(recovery.nextStep).toContain('`COMPOSIO_ENVIRONMENT=staging composio login`');
+  });
+
+  it('[Given] a rejected stored production key [Then] suggests a bare composio login', () => {
+    const recovery = decide({
+      rejection: { baseURL: DEFAULT_BASE_URL, keySource: 'stored' },
+      stored: { baseURL: DEFAULT_BASE_URL, webURL: constants.DEFAULT_WEB_URL },
+    });
+
+    expect(recovery.nextStep).toContain('Run `composio login` to log in again');
+  });
+
+  it('[Given] a rejected key stored for a custom host [Then] spells out COMPOSIO_BASE_URL', () => {
+    const recovery = decide({
+      rejection: { baseURL: CUSTOM_BASE_URL, keySource: 'stored' },
+      stored: { baseURL: CUSTOM_BASE_URL, webURL: 'http://localhost:3000/' },
+    });
+
+    expect(recovery.nextStep).toContain(`\`COMPOSIO_BASE_URL=${CUSTOM_BASE_URL} composio login\``);
+  });
+
+  it('[Given] an interactive session [Then] offers re-login against the stored backend', () => {
+    const recovery = decide({
+      rejection: { baseURL: STAGING_BASE_URL, keySource: 'stored' },
+      canPromptForLogin: true,
+    });
+
+    expect(recovery).toMatchObject({ kind: 'offer-relogin', target: storedStaging });
+  });
+
+  it('Covers AE3. [Given] COMPOSIO_BASE_URL points away from the stored backend [Then] explains the mismatch without re-login', () => {
+    const recovery = decide({
+      rejection: { baseURL: DEFAULT_BASE_URL, keySource: 'stored' },
+      overrides: { ...noOverrides, baseURL: DEFAULT_BASE_URL },
+      canPromptForLogin: true,
+    });
+
+    expect(recovery.kind).toBe('message');
+    expect(recovery.message).toContain('backend.composio.dev');
+    expect(recovery.message).toContain('staging-backend.composio.dev');
+    expect(recovery.message).toContain('COMPOSIO_BASE_URL');
+    expect(recovery.nextStep).toBe('Unset COMPOSIO_BASE_URL to use that login.');
+  });
+
+  it('Covers AE6. [Given] a rejected COMPOSIO_USER_API_KEY [Then] asks to replace it without re-login', () => {
+    const recovery = decide({
+      rejection: { baseURL: DEFAULT_BASE_URL, keySource: 'env' },
+      canPromptForLogin: true,
+    });
+
+    expect(recovery.kind).toBe('message');
+    expect(recovery.message).toContain('COMPOSIO_USER_API_KEY');
+    expect(recovery.nextStep).toBe('Replace its value with a valid user API key.');
+  });
+
+  it('Covers AE8. [Given] a composio run child call [Then] asks to run composio login', () => {
+    const recovery = decide({
+      rejection: { baseURL: STAGING_BASE_URL, keySource: 'env' },
+      invocationOrigin: 'run',
+      canPromptForLogin: true,
+    });
+
+    expect(recovery.kind).toBe('message');
+    expect(recovery.nextStep).toContain('`COMPOSIO_ENVIRONMENT=staging composio login`');
+    expect(`${recovery.message} ${recovery.nextStep}`).not.toContain('COMPOSIO_USER_API_KEY');
+  });
+
+  it('[Given] a stored key rejected inside composio run [Then] never offers re-login', () => {
+    const recovery = decide({
+      rejection: { baseURL: STAGING_BASE_URL, keySource: 'stored' },
+      invocationOrigin: 'run',
+      canPromptForLogin: true,
+    });
+
+    expect(recovery.kind).toBe('message');
+  });
+});
+
+describe('reportAuthRejection', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  const stagingLogin = {
+    api_key: 'uak_old',
+    base_url: STAGING_BASE_URL,
+    web_url: STAGING_WEB_URL,
+    org_id: 'org_prev',
+    test_user_id: 'pg-test-prev',
+  };
+
+  const stagingRejection: AuthRejection = { baseURL: STAGING_BASE_URL, keySource: 'stored' };
+
+  const confirmCalls: string[] = [];
+  // `ui.output` is the stdout data channel; the test UI's other methods also
+  // log through `Console.log`, so stdout writes are captured here instead.
+  const stdoutWrites: string[] = [];
+  const interactiveUI = (answer: boolean) =>
+    TerminalUI.of({
+      ...terminalUITestImpl,
+      output: data =>
+        Effect.sync(() => {
+          stdoutWrites.push(data);
+        }),
+      capabilities: Effect.succeed(
+        getTerminalCapabilities({
+          stdin: { isTTY: true },
+          stdout: { isTTY: true },
+          stderr: { isTTY: true },
+        })
+      ),
+      confirm: message =>
+        Effect.sync(() => {
+          confirmCalls.push(message);
+          return answer;
+        }),
+    });
+
+  const report = reportAuthRejection({ relogin: target => reloginWithBrowser({ target }) });
+
+  const recordThenReport = (rejection: AuthRejection) =>
+    Effect.gen(function* () {
+      const recorder = yield* AuthRejectionRecorder;
+      yield* recorder.record(rejection);
+      yield* report;
+    });
+
+  const readStoredUserConfig = Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const cacheDir = yield* setupCacheDir;
+    return JSON.parse(
+      yield* fs.readFileString(path.join(cacheDir, constants.USER_CONFIG_FILE_NAME), 'utf8')
+    ) as Record<string, unknown>;
+  });
+
+  const sessionInfoFor = (orgId: string, memberId: string) => ({
+    project: {
+      name: 'Project',
+      id: `project_${orgId}`,
+      org_id: orgId,
+      nano_id: `pr_${orgId}`,
+      email: 'project@example.com',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      org: { id: orgId, name: `Org ${orgId}`, plan: 'enterprise' },
+    },
+    org_member: {
+      id: memberId,
+      user_id: 'user_new',
+      email: 'cli@example.com',
+      name: 'CLI User',
+      role: 'admin',
+    },
+    api_key: null,
+  });
+
+  const jsonResponse = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  // Session info succeeds for the default org; for `x-org-id` it succeeds only
+  // when `previousOrgAccessible`.
+  const mockSessionInfo = (params: { readonly previousOrgAccessible: boolean }) => {
+    const requestedOrigins: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      requestedOrigins.push(new URL(url).origin);
+      const orgId = new Headers(init?.headers).get('x-org-id');
+      if (orgId === null) return jsonResponse(sessionInfoFor('org_default', 'member_default'));
+      return params.previousOrgAccessible
+        ? jsonResponse(sessionInfoFor(orgId, 'member_prev'))
+        : jsonResponse({ error: { message: 'Forbidden', status: 403 } }, 403);
+    });
+    return requestedOrigins;
+  };
+
+  const linkedSessionRepository = (params: { readonly failCreate?: boolean } = {}) =>
+    Effect.gen(function* () {
+      const expiresAt = DateTime.add(yield* DateTime.now, { minutes: 10 });
+      const createCalls: Array<string | undefined> = [];
+      const repository = ComposioSessionRepository.of({
+        createSession: options => {
+          createCalls.push(options?.baseURL);
+          return params.failCreate
+            ? Effect.fail(new HttpServerError({ status: 503, cause: 'unavailable' }))
+            : Effect.succeed({
+                id: 'relogin-session',
+                code: '001122',
+                expiresAt,
+                status: 'pending',
+              });
+        },
+        getSession: () =>
+          Effect.succeed({
+            id: 'relogin-session',
+            code: '001122',
+            expiresAt,
+            status: 'linked',
+            api_key: 'uak_new',
+            account: { id: 'account', name: 'CLI User', email: 'cli@example.com' },
+          }),
+        getRealtimeCredentials: () => Effect.die(new Error('test: unused')),
+        authRealtimeChannel: () => Effect.die(new Error('test: unused')),
+      });
+      return { repository, createCalls };
+    });
+
+  layer(TestLive({ userData: stagingLogin }))(it => {
+    it.effect('[Given] no recorded rejection [Then] prints nothing', () =>
+      Effect.gen(function* () {
+        yield* report;
+        expect(yield* MockConsole.getLines()).toEqual([]);
+      })
+    );
+  });
+
+  layer(TestLive({ userData: stagingLogin }))(it => {
+    it.effect(
+      'Covers AE5. [Given] stderr is not a terminal [Then] writes one undecorated line with the staging login step',
+      () =>
+        Effect.gen(function* () {
+          yield* recordThenReport(stagingRejection);
+
+          const stderr = yield* MockConsole.getLines({ stream: 'stderr' });
+          expect(stderr).toEqual([
+            'The Composio API at staging-backend.composio.dev rejected your stored API key. Run `COMPOSIO_ENVIRONMENT=staging composio login` to log in again, then re-run the command.',
+          ]);
+          expect(yield* MockConsole.getLines({ stream: 'stdout' })).toEqual([]);
+        })
+    );
+  });
+
+  layer(TestLive({ userData: stagingLogin, terminalUI: interactiveUI(true) }))(it => {
+    it.effect('[Given] CI or Vitest with a terminal [Then] does not prompt', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('CI', 'true');
+        confirmCalls.length = 0;
+
+        yield* recordThenReport(stagingRejection);
+
+        expect(confirmCalls).toEqual([]);
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('COMPOSIO_ENVIRONMENT=staging composio login');
+      })
+    );
+  });
+
+  const stagingOverrideToProduction = ConfigProvider.fromEnvRecord({
+    COMPOSIO_BASE_URL: DEFAULT_BASE_URL,
+  }).pipe(extendConfigProvider);
+
+  layer(
+    TestLive({
+      userData: stagingLogin,
+      terminalUI: interactiveUI(true),
+      baseConfigProvider: stagingOverrideToProduction,
+    })
+  )(it => {
+    it.effect(
+      'Covers AE3. [Given] a mismatch in a terminal [Then] explains it and never prompts',
+      () =>
+        Effect.gen(function* () {
+          vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
+          confirmCalls.length = 0;
+
+          yield* recordThenReport({ baseURL: DEFAULT_BASE_URL, keySource: 'stored' });
+
+          expect(confirmCalls).toEqual([]);
+          const output = (yield* MockConsole.getLines()).join('\n');
+          expect(output).toContain('COMPOSIO_BASE_URL points the CLI at backend.composio.dev');
+          expect(output).toContain('Unset COMPOSIO_BASE_URL');
+        })
+    );
+  });
+
+  layer(TestLive({ userData: stagingLogin, terminalUI: interactiveUI(true) }))(it => {
+    it.effect(
+      'Covers AE4. [Given] an accepted re-login [Then] replaces the key, keeps staging and the org, and asks to re-run',
+      () =>
+        Effect.gen(function* () {
+          vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
+          confirmCalls.length = 0;
+          stdoutWrites.length = 0;
+          const requestedOrigins = mockSessionInfo({ previousOrgAccessible: true });
+          const { repository, createCalls } = yield* linkedSessionRepository();
+
+          yield* recordThenReport(stagingRejection).pipe(
+            Effect.provideService(ComposioSessionRepository, repository)
+          );
+
+          expect(confirmCalls).toEqual(['Log in again to staging-backend.composio.dev?']);
+          expect(createCalls).toEqual([STAGING_BASE_URL]);
+          expect(new Set(requestedOrigins)).toEqual(new Set([STAGING_BASE_URL]));
+          expect(yield* readStoredUserConfig).toMatchObject({
+            api_key: 'uak_new',
+            base_url: STAGING_BASE_URL,
+            web_url: STAGING_WEB_URL,
+            org_id: 'org_prev',
+            test_user_id: 'pg-test-prev',
+          });
+          const output = (yield* MockConsole.getLines()).join('\n');
+          expect(output).toContain(
+            'Logged in again to staging-backend.composio.dev. Re-run the command.'
+          );
+          expect(output).toContain(`${STAGING_WEB_URL}?cliKey=relogin-session`);
+          expect(stdoutWrites).toEqual([]);
+        })
+    );
+  });
+
+  layer(TestLive({ userData: stagingLogin, terminalUI: interactiveUI(true) }))(it => {
+    it.effect(
+      '[Given] the previous org is not accessible [Then] uses the default org and says so',
+      () =>
+        Effect.gen(function* () {
+          vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
+          mockSessionInfo({ previousOrgAccessible: false });
+          const { repository } = yield* linkedSessionRepository();
+
+          yield* recordThenReport(stagingRejection).pipe(
+            Effect.provideService(ComposioSessionRepository, repository)
+          );
+
+          expect(yield* readStoredUserConfig).toMatchObject({
+            api_key: 'uak_new',
+            org_id: 'org_default',
+            test_user_id: 'pg-test-user_new',
+          });
+          const output = (yield* MockConsole.getLines()).join('\n');
+          expect(output).toContain(
+            'Your previous org is not available to this account. Using "Org org_default".'
+          );
+        })
+    );
+  });
+
+  layer(TestLive({ userData: stagingLogin, terminalUI: interactiveUI(false) }))(it => {
+    it.effect('Covers AE4. [Given] a declined re-login [Then] keeps the stored credentials', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
+        confirmCalls.length = 0;
+
+        yield* recordThenReport(stagingRejection);
+
+        expect(confirmCalls).toHaveLength(1);
+        expect(yield* readStoredUserConfig).toMatchObject(stagingLogin);
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('COMPOSIO_ENVIRONMENT=staging composio login');
+      })
+    );
+  });
+
+  layer(TestLive({ userData: stagingLogin, terminalUI: interactiveUI(true) }))(it => {
+    it.effect('Covers AE4. [Given] a failed re-login [Then] keeps the stored credentials', () =>
+      Effect.gen(function* () {
+        vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
+        const { repository } = yield* linkedSessionRepository({ failCreate: true });
+
+        yield* recordThenReport(stagingRejection).pipe(
+          Effect.provideService(ComposioSessionRepository, repository)
+        );
+
+        expect(yield* readStoredUserConfig).toMatchObject(stagingLogin);
+        const output = (yield* MockConsole.getLines()).join('\n');
+        expect(output).toContain('Login did not complete. Your stored credentials are unchanged.');
+      })
+    );
+  });
+
+  const envKey = ConfigProvider.fromEnvRecord({ COMPOSIO_USER_API_KEY: 'uak_env' }).pipe(
+    extendConfigProvider
+  );
+
+  layer(TestLive({ baseConfigProvider: envKey, terminalUI: interactiveUI(true) }))(it => {
+    it.effect(
+      'Covers AE6. [Given] a rejected env key [Then] names the env var and never prompts',
+      () =>
+        Effect.gen(function* () {
+          vi.stubEnv('COMPOSIO_DISABLE_PERMISSION_UI', '0');
+          confirmCalls.length = 0;
+
+          yield* recordThenReport({ baseURL: DEFAULT_BASE_URL, keySource: 'env' });
+
+          expect(confirmCalls).toEqual([]);
+          const output = (yield* MockConsole.getLines()).join('\n');
+          expect(output).toContain('rejected the API key in COMPOSIO_USER_API_KEY');
+        })
+    );
+  });
+
+  const runChild = ConfigProvider.fromEnvRecord({
+    COMPOSIO_USER_API_KEY: 'uak_parent',
+    COMPOSIO_BASE_URL: STAGING_BASE_URL,
+    COMPOSIO_CLI_INVOCATION_ORIGIN: 'run',
+  }).pipe(extendConfigProvider);
+
+  layer(TestLive({ baseConfigProvider: runChild }))(it => {
+    it.effect(
+      'Covers AE8. [Given] a composio run child call [Then] asks to run composio login',
+      () =>
+        Effect.gen(function* () {
+          yield* recordThenReport({ baseURL: STAGING_BASE_URL, keySource: 'env' });
+
+          const output = (yield* MockConsole.getLines()).join('\n');
+          expect(output).toContain('`COMPOSIO_ENVIRONMENT=staging composio login`');
+          expect(output).not.toContain('Replace its value');
+        })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/effects/backend-mismatch-warning.test.ts
+++ b/ts/packages/cli/test/src/effects/backend-mismatch-warning.test.ts
@@ -27,7 +27,7 @@ describe('warnOnBackendMismatch', () => {
     })
   )(it => {
     it.effect(
-      'Covers AE2. [Given] a stored staging login and COMPOSIO_BASE_URL on production [Then] warns once on stderr',
+      '[Given] a stored staging login and COMPOSIO_BASE_URL on production [Then] warns once on stderr',
       () =>
         Effect.gen(function* () {
           yield* warnOnBackendMismatch;

--- a/ts/packages/cli/test/src/effects/backend-mismatch-warning.test.ts
+++ b/ts/packages/cli/test/src/effects/backend-mismatch-warning.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, layer } from '@effect/vitest';
+import { ConfigProvider, Effect } from 'effect';
+import { DEFAULT_BASE_URL, STAGING_BASE_URL, STAGING_WEB_URL } from 'src/constants';
+import { warnOnBackendMismatch } from 'src/effects/backend-mismatch-warning';
+import { requireAuth } from 'src/effects/require-auth';
+import { extendConfigProvider } from 'src/services/config';
+import { MockConsole, TestLive } from 'test/__utils__';
+
+const stagingLogin = {
+  api_key: 'uak_staging',
+  base_url: STAGING_BASE_URL,
+  web_url: STAGING_WEB_URL,
+  org_id: 'org_staging',
+};
+
+const withEnv = (env: Record<string, string>) =>
+  ConfigProvider.fromEnvRecord(env).pipe(extendConfigProvider);
+
+const expectedWarning =
+  'COMPOSIO_BASE_URL sends your stored API key to backend.composio.dev, but you logged in to staging-backend.composio.dev.';
+
+describe('warnOnBackendMismatch', () => {
+  layer(
+    TestLive({
+      userData: stagingLogin,
+      baseConfigProvider: withEnv({ COMPOSIO_BASE_URL: DEFAULT_BASE_URL }),
+    })
+  )(it => {
+    it.effect(
+      'Covers AE2. [Given] a stored staging login and COMPOSIO_BASE_URL on production [Then] warns once on stderr',
+      () =>
+        Effect.gen(function* () {
+          yield* warnOnBackendMismatch;
+
+          expect(yield* MockConsole.getLines({ stream: 'stderr' })).toEqual([expectedWarning]);
+          expect(yield* MockConsole.getLines({ stream: 'stdout' })).toEqual([]);
+        })
+    );
+  });
+
+  layer(
+    TestLive({
+      userData: stagingLogin,
+      baseConfigProvider: withEnv({ COMPOSIO_BASE_URL: DEFAULT_BASE_URL }),
+    })
+  )(it => {
+    it.effect('[Given] a command gated by requireAuth [Then] it warns before running', () =>
+      Effect.gen(function* () {
+        expect(yield* requireAuth).toBe(true);
+        expect(yield* MockConsole.getLines({ stream: 'stderr' })).toEqual([expectedWarning]);
+      })
+    );
+  });
+
+  layer(TestLive({ userData: stagingLogin }))(it => {
+    it.effect('[Given] no override [Then] stays silent', () =>
+      Effect.gen(function* () {
+        yield* warnOnBackendMismatch;
+        expect(yield* MockConsole.getLines()).toEqual([]);
+      })
+    );
+  });
+
+  layer(
+    TestLive({
+      userData: stagingLogin,
+      baseConfigProvider: withEnv({ COMPOSIO_ENVIRONMENT: 'production' }),
+    })
+  )(it => {
+    it.effect('[Given] COMPOSIO_ENVIRONMENT=production [Then] names COMPOSIO_ENVIRONMENT', () =>
+      Effect.gen(function* () {
+        yield* warnOnBackendMismatch;
+        const stderr = (yield* MockConsole.getLines({ stream: 'stderr' })).join('\n');
+        expect(stderr).toContain('COMPOSIO_ENVIRONMENT sends your stored API key');
+      })
+    );
+  });
+
+  layer(
+    TestLive({
+      userData: stagingLogin,
+      baseConfigProvider: withEnv({
+        COMPOSIO_BASE_URL: DEFAULT_BASE_URL,
+        COMPOSIO_USER_API_KEY: 'uak_env',
+      }),
+    })
+  )(it => {
+    it.effect('[Given] the key comes from COMPOSIO_USER_API_KEY [Then] stays silent', () =>
+      Effect.gen(function* () {
+        yield* warnOnBackendMismatch;
+        expect(yield* MockConsole.getLines()).toEqual([]);
+      })
+    );
+  });
+
+  layer(
+    TestLive({
+      userData: stagingLogin,
+      baseConfigProvider: withEnv({ COMPOSIO_WEB_URL: 'https://dashboard.composio.dev/' }),
+    })
+  )(it => {
+    it.effect('[Given] only COMPOSIO_WEB_URL is set [Then] stays silent', () =>
+      Effect.gen(function* () {
+        yield* warnOnBackendMismatch;
+        expect(yield* MockConsole.getLines()).toEqual([]);
+      })
+    );
+  });
+});

--- a/ts/packages/cli/test/src/services/auth-rejection.test.ts
+++ b/ts/packages/cli/test/src/services/auth-rejection.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from '@effect/vitest';
+import { Context, Effect, Layer, Option } from 'effect';
+import { AuthRejectionRecorder } from 'src/services/auth-rejection';
+
+// A second service built on the recorder, to check that both see one instance.
+class Probe extends Context.Service<
+  Probe,
+  { readonly first: AuthRejectionRecorder['Service']['first'] }
+>()('test/Probe') {}
+
+describe('AuthRejectionRecorder', () => {
+  it.effect('[Given] nothing recorded [Then] reports none', () =>
+    Effect.gen(function* () {
+      const recorder = yield* AuthRejectionRecorder;
+      expect(Option.isNone(yield* recorder.first)).toBe(true);
+    }).pipe(Effect.provide(AuthRejectionRecorder.Default))
+  );
+
+  it.effect('[Given] several rejections [Then] keeps the first', () =>
+    Effect.gen(function* () {
+      const recorder = yield* AuthRejectionRecorder;
+      yield* recorder.record({
+        baseURL: 'https://staging-backend.composio.dev',
+        keySource: 'stored',
+      });
+      yield* recorder.record({ baseURL: 'https://backend.composio.dev', keySource: 'env' });
+
+      expect(yield* recorder.first).toEqual(
+        Option.some({ baseURL: 'https://staging-backend.composio.dev', keySource: 'stored' })
+      );
+    }).pipe(Effect.provide(AuthRejectionRecorder.Default))
+  );
+
+  it.effect('[Given] the layer is provided twice by reference [Then] both share one recorder', () =>
+    Effect.gen(function* () {
+      const recorder = yield* AuthRejectionRecorder;
+      yield* recorder.record({ baseURL: 'https://backend.composio.dev', keySource: 'stored' });
+      const fromDependent = yield* Effect.flatMap(Probe, probe => probe.first);
+      expect(Option.isSome(fromDependent)).toBe(true);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          AuthRejectionRecorder.Default,
+          Layer.effect(
+            Probe,
+            Effect.map(AuthRejectionRecorder, recorder => ({ first: recorder.first }))
+          ).pipe(Layer.provide(AuthRejectionRecorder.Default))
+        )
+      )
+    )
+  );
+});

--- a/ts/packages/cli/test/src/services/composio-client-singleton.test.ts
+++ b/ts/packages/cli/test/src/services/composio-client-singleton.test.ts
@@ -260,7 +260,7 @@ describe('ComposioClientSingleton headers', () => {
 
         const stagingClient = yield* clientSingleton.get();
         yield* listTools(stagingClient);
-        yield* ctx.login('uak_same');
+        yield* ctx.login({ apiKey: 'uak_same', target: ctx.backend.ambient });
         const productionClient = yield* clientSingleton.get();
         yield* listTools(productionClient);
 

--- a/ts/packages/cli/test/src/services/composio-client-singleton.test.ts
+++ b/ts/packages/cli/test/src/services/composio-client-singleton.test.ts
@@ -3,11 +3,13 @@ import * as FileSystem from 'effect/FileSystem';
 import * as Path from 'effect/Path';
 import * as BunFileSystem from '@effect/platform-bun/BunFileSystem';
 import * as BunPath from '@effect/platform-bun/BunPath';
-import { ConfigProvider, Effect, Layer } from 'effect';
+import { ConfigProvider, Effect, Layer, Option } from 'effect';
 import { execSync } from 'node:child_process';
 import * as tempy from 'tempy';
 import { ComposioClientSingleton } from 'src/services/composio-clients';
 import { ComposioUserContext, ComposioUserContextLive } from 'src/services/user-context';
+import { AuthRejectionRecorder } from 'src/services/auth-rejection';
+import { userApiKeyRejectionResponse } from 'test/__utils__/models/user-api-key-rejection';
 import { APP_VERSION, STAGING_BASE_URL, STAGING_WEB_URL } from 'src/constants';
 import { defaultNodeOs, NodeOs } from 'src/services/node-os';
 import { extendConfigProvider } from 'src/services/config';
@@ -270,11 +272,113 @@ describe('ComposioClientSingleton headers', () => {
       }).pipe(
         Effect.provide(
           ComposioClientSingleton.layer.pipe(
+            Layer.provideMerge(AuthRejectionRecorder.Default),
             Layer.provideMerge(ComposioUserContextLive),
             Layer.provideMerge(withConfigLayer(new Map(), homedir))
           )
         )
       );
     }).pipe(Effect.provide(Layer.mergeAll(BunFileSystem.layer, BunPath.layer)));
+  });
+});
+
+describe('ComposioClientSingleton rejection recording', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const listTools = (client: { tools: { list: (params: object) => Promise<unknown> } }) =>
+    Effect.promise(() =>
+      client.tools
+        .list({ limit: 1, toolkit_versions: 'latest' })
+        .then(() => undefined)
+        .catch(() => undefined)
+    );
+
+  // Runs `body` with a stored staging login and the recorder in scope.
+  const withStoredStagingLogin = <A, E>(
+    body: Effect.Effect<A, E, ComposioClientSingleton | AuthRejectionRecorder>
+  ) => {
+    const homedir = tempy.temporaryDirectory();
+    return Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const cacheDir = path.join(homedir, '.composio');
+      yield* fs.makeDirectory(cacheDir, { recursive: true });
+      yield* fs.writeFileString(
+        path.join(cacheDir, 'user_data.json'),
+        JSON.stringify({
+          api_key: 'uak_revoked',
+          base_url: STAGING_BASE_URL,
+          web_url: STAGING_WEB_URL,
+        })
+      );
+      return yield* body.pipe(
+        Effect.provide(
+          ComposioClientSingleton.layer.pipe(
+            Layer.provideMerge(AuthRejectionRecorder.Default),
+            Layer.provide(ComposioUserContextLive),
+            Layer.provide(withConfigLayer(new Map(), homedir))
+          )
+        )
+      );
+    }).pipe(Effect.provide(Layer.mergeAll(BunFileSystem.layer, BunPath.layer)));
+  };
+
+  it.effect(
+    '[Given] the backend rejects the stored key [Then] records the rejecting host once',
+    () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+        Promise.resolve(userApiKeyRejectionResponse())
+      );
+
+      return withStoredStagingLogin(
+        Effect.gen(function* () {
+          const client = yield* Effect.flatMap(ComposioClientSingleton, singleton =>
+            singleton.get()
+          );
+          yield* Effect.all([listTools(client), listTools(client)], { concurrency: 'unbounded' });
+
+          const recorder = yield* AuthRejectionRecorder;
+          expect(yield* recorder.first).toEqual(
+            Option.some({ baseURL: STAGING_BASE_URL, keySource: 'stored' })
+          );
+        })
+      );
+    }
+  );
+
+  it.effect('[Given] a successful response [Then] records nothing', () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => Promise.resolve(okResponse()));
+
+    return withStoredStagingLogin(
+      Effect.gen(function* () {
+        const client = yield* Effect.flatMap(ComposioClientSingleton, singleton => singleton.get());
+        yield* listTools(client);
+
+        const recorder = yield* AuthRejectionRecorder;
+        expect(Option.isNone(yield* recorder.first)).toBe(true);
+      })
+    );
+  });
+
+  it.effect('[Given] an anonymous login client [Then] a rejection is not recorded', () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => Promise.resolve(userApiKeyRejectionResponse()));
+
+    return withStoredStagingLogin(
+      Effect.gen(function* () {
+        const client = yield* Effect.flatMap(ComposioClientSingleton, singleton =>
+          singleton.getFor({ baseURL: 'https://backend.composio.dev', anonymous: true })
+        );
+        yield* listTools(client);
+
+        const [, init] = fetchSpy.mock.calls[0]!;
+        expect(new Headers((init as RequestInit).headers).get('x-user-api-key')).toBeNull();
+        const recorder = yield* AuthRejectionRecorder;
+        expect(Option.isNone(yield* recorder.first)).toBe(true);
+      })
+    );
   });
 });

--- a/ts/packages/cli/test/src/services/composio-client-singleton.test.ts
+++ b/ts/packages/cli/test/src/services/composio-client-singleton.test.ts
@@ -7,7 +7,8 @@ import { ConfigProvider, Effect, Layer } from 'effect';
 import { execSync } from 'node:child_process';
 import * as tempy from 'tempy';
 import { ComposioClientSingleton } from 'src/services/composio-clients';
-import { APP_VERSION } from 'src/constants';
+import { ComposioUserContext, ComposioUserContextLive } from 'src/services/user-context';
+import { APP_VERSION, STAGING_BASE_URL, STAGING_WEB_URL } from 'src/constants';
 import { defaultNodeOs, NodeOs } from 'src/services/node-os';
 import { extendConfigProvider } from 'src/services/config';
 
@@ -223,5 +224,57 @@ describe('ComposioClientSingleton headers', () => {
         Layer.provide(ComposioClientSingleton.Default, withConfigLayer(configMap, homedir))
       )
     );
+  });
+
+  it.effect('builds a new client when the backend changes for the same key', () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => Promise.resolve(okResponse()));
+    const homedir = tempy.temporaryDirectory();
+    const requestedHost = (call: number) => new URL(String(fetchSpy.mock.calls[call]![0])).host;
+    const listTools = (client: { tools: { list: (params: object) => Promise<unknown> } }) =>
+      Effect.promise(() =>
+        client.tools
+          .list({ limit: 1, toolkit_versions: 'latest' })
+          .then(() => undefined)
+          .catch(() => undefined)
+      );
+
+    return Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const cacheDir = path.join(homedir, '.composio');
+      yield* fs.makeDirectory(cacheDir, { recursive: true });
+      yield* fs.writeFileString(
+        path.join(cacheDir, 'user_data.json'),
+        JSON.stringify({
+          api_key: 'uak_same',
+          base_url: STAGING_BASE_URL,
+          web_url: STAGING_WEB_URL,
+        })
+      );
+
+      yield* Effect.gen(function* () {
+        const ctx = yield* ComposioUserContext;
+        const clientSingleton = yield* ComposioClientSingleton;
+
+        const stagingClient = yield* clientSingleton.get();
+        yield* listTools(stagingClient);
+        yield* ctx.login('uak_same');
+        const productionClient = yield* clientSingleton.get();
+        yield* listTools(productionClient);
+
+        expect(productionClient).not.toBe(stagingClient);
+        expect(requestedHost(0)).toBe(new URL(STAGING_BASE_URL).host);
+        expect(requestedHost(1)).toBe('backend.composio.dev');
+      }).pipe(
+        Effect.provide(
+          ComposioClientSingleton.layer.pipe(
+            Layer.provideMerge(ComposioUserContextLive),
+            Layer.provideMerge(withConfigLayer(new Map(), homedir))
+          )
+        )
+      );
+    }).pipe(Effect.provide(Layer.mergeAll(BunFileSystem.layer, BunPath.layer)));
   });
 });

--- a/ts/packages/cli/test/src/services/composio-clients.test.ts
+++ b/ts/packages/cli/test/src/services/composio-clients.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from '@effect/vitest';
 import { afterEach, vi } from 'vitest';
 import { Effect } from 'effect';
-import { getSessionInfoByUserApiKey } from 'src/services/composio-clients';
+import { getSessionInfoByUserApiKey, HttpServerError } from 'src/services/composio-clients';
+import { isUserApiKeyRejection } from 'src/utils/api-error-extraction';
+import { userApiKeyRejectionResponse } from 'test/__utils__/models/user-api-key-rejection';
 
 const emptyOkResponse = () =>
   new Response(JSON.stringify({}), {
@@ -52,6 +54,30 @@ describe('getSessionInfoByUserApiKey org context', () => {
       const headers = new Headers((init as RequestInit).headers);
       expect(headers.get('x-user-api-key')).toBe('uak_test');
       expect(headers.has('x-org-id')).toBe(false);
+    })
+  );
+});
+
+describe('plain-fetch helpers on a rejected user API key', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.effect('[Given] the backend rejection body [Then] the error keeps its slug and code', () =>
+    Effect.gen(function* () {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(userApiKeyRejectionResponse());
+
+      const error = yield* getSessionInfoByUserApiKey({
+        baseURL: 'https://backend.composio.dev',
+        userApiKey: 'uak_revoked',
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(HttpServerError);
+      expect(error).toMatchObject({
+        status: 401,
+        apiError: { slug: 'UserApiKey_Unauthorized', code: 2113 },
+      });
+      expect(isUserApiKeyRejection(error)).toBe(true);
     })
   );
 });

--- a/ts/packages/cli/test/src/services/user-context.test.ts
+++ b/ts/packages/cli/test/src/services/user-context.test.ts
@@ -11,6 +11,7 @@ import { UserData, UserDataWithDefaults, userDataToJSON } from 'src/models/user-
 import { extendConfigProvider } from 'src/services/config';
 import { CliUserConfig } from 'src/models/cli-user-config';
 import { ComposioCliUserConfig } from 'src/services/cli-user-config';
+import { STAGING_BASE_URL, STAGING_WEB_URL } from 'src/constants';
 import { makeKeyringService, KeyringService } from '@composio/cli-keyring/effect';
 import {
   type CredentialStore,
@@ -20,8 +21,13 @@ import {
 } from '@composio/cli-keyring';
 import path from 'node:path';
 
-const InMemoryKeyringLayer = (() => {
-  const items = new Map<string, Uint8Array>();
+const makeInMemoryKeyringLayer = (initial: Record<string, string> = {}) => {
+  const items = new Map<string, Uint8Array>(
+    Object.entries(initial).map(([user, secret]) => [
+      `com.composio.cli\0${user}`,
+      new TextEncoder().encode(secret),
+    ])
+  );
   const key = (s: string, u: string) => `${s}\0${u}`;
   const store: CredentialStore = {
     id: 'memory',
@@ -40,39 +46,93 @@ const InMemoryKeyringLayer = (() => {
     },
   };
   return Layer.succeed(KeyringService, makeKeyringService(store));
-})();
+};
 
-const MockCliUserConfigLayer = Layer.succeed(
-  ComposioCliUserConfig,
-  ComposioCliUserConfig.of({
-    data: {
+const InMemoryKeyringLayer = makeInMemoryKeyringLayer();
+
+const makeMockCliUserConfigLayer = (security: 'auto' | 'keychain-subprocess') =>
+  Layer.succeed(
+    ComposioCliUserConfig,
+    ComposioCliUserConfig.of({
+      data: {
+        channel: 'beta',
+        developerModeEnabled: true,
+        developerDangerousCommandsEnabled: false,
+        experimentalFeatures: {},
+        artifactDirectory: undefined,
+        experimentalSubagentTarget: 'auto',
+        security,
+      },
+      raw: CliUserConfig.make({
+        developer: { enabled: true, destructiveActions: false },
+        experimentalFeatures: {},
+        artifactDirectory: Option.none(),
+        experimentalSubagent: Option.none(),
+        security,
+      }),
       channel: 'beta',
-      developerModeEnabled: true,
-      developerDangerousCommandsEnabled: false,
-      experimentalFeatures: {},
-      artifactDirectory: undefined,
-      experimentalSubagentTarget: 'auto',
-      security: 'auto',
-    },
-    raw: CliUserConfig.make({
-      developer: { enabled: true, destructiveActions: false },
-      experimentalFeatures: {},
-      artifactDirectory: Option.none(),
-      experimentalSubagent: Option.none(),
-      security: 'auto',
-    }),
-    channel: 'beta',
-    isDevModeEnabled: () => true,
-    areDeveloperDangerousCommandsEnabled: () => false,
-    isExperimentalFeatureEnabled: () => true,
-    update: () => Effect.void,
-  })
-);
+      isDevModeEnabled: () => true,
+      areDeveloperDangerousCommandsEnabled: () => false,
+      isExperimentalFeatureEnabled: () => true,
+      update: () => Effect.void,
+    })
+  );
+
+const MockCliUserConfigLayer = makeMockCliUserConfigLayer('auto');
 
 const ComposioUserContextLive = Layer.provide(
   rawComposioUserContextLive,
   Layer.mergeAll(InMemoryKeyringLayer, MockCliUserConfigLayer)
 );
+
+const withEnvConfigProvider = (env: Record<string, string>) =>
+  Layer.succeed(
+    ConfigProvider.ConfigProvider,
+    extendConfigProvider(ConfigProvider.fromEnv({ env }))
+  );
+
+// The layer reads `user_data.json` while it is built, so a test must write the
+// file before providing the layer.
+const makeUserContextLayer = (
+  cwd: string,
+  env: Record<string, string> = {},
+  deps: Layer.Layer<KeyringService | ComposioCliUserConfig> = Layer.mergeAll(
+    InMemoryKeyringLayer,
+    MockCliUserConfigLayer
+  )
+) =>
+  Layer.provideMerge(
+    Layer.provide(rawComposioUserContextLive, deps),
+    Layer.mergeAll(
+      BunFileSystem.layer,
+      BunPath.layer,
+      Layer.succeed(NodeOs, defaultNodeOs({ homedir: cwd })),
+      withEnvConfigProvider(env)
+    )
+  );
+
+const writeUserDataFile = (cwd: string, contents: string, mode = 0o600) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const userDataPath = path.join(cwd, '.composio', 'user_data.json');
+    yield* fs.makeDirectory(path.join(cwd, '.composio'), { recursive: true });
+    yield* fs.writeFileString(userDataPath, contents);
+    yield* fs.chmod(userDataPath, mode);
+  }).pipe(Effect.provide(BunFileSystem.layer));
+
+const readUserDataFile = (cwd: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const raw = yield* fs.readFileString(path.join(cwd, '.composio', 'user_data.json'), 'utf8');
+    return JSON.parse(raw) as Record<string, unknown>;
+  }).pipe(Effect.provide(BunFileSystem.layer));
+
+const stagingLogin = {
+  api_key: 'uak_staging',
+  base_url: STAGING_BASE_URL,
+  web_url: STAGING_WEB_URL,
+  org_id: 'org_staging',
+};
 
 describe('ComposioUserContext', () => {
   const withMapConfigProvider = (map: Map<string, string>) =>
@@ -161,83 +221,67 @@ describe('ComposioUserContext', () => {
 
   describe('[When] `~/.composio/user_data.json` config file exists', () => {
     describe('[When] no dynamic `Config` is set', () => {
-      // Note: this test only passes when using `it`, not `it.scoped`
-      it('[Then] it reflects the config file', () => {
+      it.effect('[Then] it reflects the config file', () => {
         const cwd = tempy.temporaryDirectory();
-        const map = new Map([]) satisfies Map<string, string>;
-
-        const NodeOsTest = Layer.succeed(NodeOs, defaultNodeOs({ homedir: cwd }));
-        const ComposioUserContextTest = Layer.provideMerge(
-          ComposioUserContextLive,
-          Layer.mergeAll(BunFileSystem.layer, BunPath.layer, NodeOsTest, withMapConfigProvider(map))
-        );
+        const userDataPath = path.join(cwd, '.composio', 'user_data.json');
+        const expectedUserData = UserData.make({
+          apiKey: Option.some('api_key'),
+          baseURL: Option.some('https://test.composio.localhost'),
+          webURL: Option.some('https://dashboard.composio.dev/'),
+          orgId: Option.none(),
+          projectId: Option.none(),
+          testUserId: Option.none(),
+        });
 
         return Effect.gen(function* () {
-          const expectedUserData = UserData.make({
-            apiKey: Option.some('api_key'),
-            baseURL: Option.some('https://test.composio.localhost'),
-            webURL: Option.some('https://dashboard.composio.dev/'),
-            orgId: Option.none(),
-            projectId: Option.none(),
-            testUserId: Option.none(),
-          });
           const userDataAsJson = yield* userDataToJSON(expectedUserData);
+          yield* writeUserDataFile(cwd, userDataAsJson, 0o644);
 
-          const fs = yield* FileSystem.FileSystem;
-          const userDataPath = path.join(cwd, '.composio', 'user_data.json');
-          yield* fs.makeDirectory(path.join(cwd, '.composio'), { recursive: true });
-          yield* fs.writeFileString(userDataPath, userDataAsJson);
-          yield* fs.chmod(userDataPath, 0o644);
-          assertEquals((yield* fs.stat(userDataPath)).mode & 0o777, 0o644);
-
-          const ctx = yield* ComposioUserContext;
-          deepStrictEqual(ctx.data, {
-            ...expectedUserData,
-            baseURL: expectedUserData.baseURL.pipe(Option.getOrUndefined),
-            webURL: expectedUserData.webURL.pipe(Option.getOrUndefined),
-          });
-          deepStrictEqual(ctx.isLoggedIn(), true);
-          assertEquals(yield* fs.readFileString(userDataPath, 'utf8'), userDataAsJson);
-          assertEquals((yield* fs.stat(userDataPath)).mode & 0o777, 0o600);
-        }).pipe(Effect.provide(ComposioUserContextTest));
+          yield* Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const ctx = yield* ComposioUserContext;
+            deepStrictEqual(ctx.data, {
+              ...expectedUserData,
+              baseURL: expectedUserData.baseURL.pipe(Option.getOrUndefined),
+              webURL: expectedUserData.webURL.pipe(Option.getOrUndefined),
+            });
+            deepStrictEqual(ctx.isLoggedIn(), true);
+            assertEquals(yield* fs.readFileString(userDataPath, 'utf8'), userDataAsJson);
+            assertEquals((yield* fs.stat(userDataPath)).mode & 0o777, 0o600);
+          }).pipe(Effect.provide(makeUserContextLayer(cwd)));
+        });
       });
     });
 
     describe('[When] dynamic `APP_CONFIG` is set', () => {
-      it.effect('[Then] it overrides the config file', () => {
+      it.effect('[Then] the env key uses the ambient backend, not the stored one', () => {
         const cwd = tempy.temporaryDirectory();
-        const map = new Map([['COMPOSIO_USER_API_KEY', 'api_key']]) satisfies Map<string, string>;
-
-        const NodeOsTest = Layer.succeed(NodeOs, defaultNodeOs({ homedir: cwd }));
-        const ComposioUserContextTest = Layer.provideMerge(
-          ComposioUserContextLive,
-          Layer.mergeAll(BunFileSystem.layer, BunPath.layer, NodeOsTest, withMapConfigProvider(map))
-        );
+        const storedUserData = UserData.make({
+          apiKey: Option.some('stored_api_key'),
+          baseURL: Option.some(STAGING_BASE_URL),
+          webURL: Option.some(STAGING_WEB_URL),
+          orgId: Option.none(),
+          projectId: Option.none(),
+          testUserId: Option.none(),
+        });
 
         return Effect.gen(function* () {
-          const expectedUserData = UserData.make({
-            apiKey: Option.some('api_key'),
-            baseURL: Option.none(),
-            webURL: Option.some('https://dashboard.composio.dev/'),
-            orgId: Option.none(),
-            projectId: Option.none(),
-            testUserId: Option.none(),
-          });
-          const userDataAsJson = yield* userDataToJSON(expectedUserData);
+          yield* writeUserDataFile(cwd, yield* userDataToJSON(storedUserData));
 
-          const fs = yield* FileSystem.FileSystem;
-          yield* fs.makeDirectory(path.join(cwd, '.composio'), { recursive: true });
-          yield* fs.writeFileString(path.join(cwd, '.composio', 'user_data.json'), userDataAsJson);
+          yield* Effect.gen(function* () {
+            const ctx = yield* ComposioUserContext;
 
-          const ctx = yield* ComposioUserContext;
-
-          deepStrictEqual(ctx.data, {
-            ...expectedUserData,
-            baseURL: 'https://backend.composio.dev',
-            webURL: expectedUserData.webURL.pipe(Option.getOrUndefined),
-          });
-          deepStrictEqual(ctx.isLoggedIn(), true);
-        }).pipe(Effect.provide(ComposioUserContextTest));
+            deepStrictEqual(ctx.data, {
+              ...storedUserData,
+              apiKey: Option.some('api_key'),
+              baseURL: 'https://backend.composio.dev',
+              webURL: 'https://dashboard.composio.dev/',
+            });
+            deepStrictEqual(ctx.backend.keySource, 'env');
+            deepStrictEqual(ctx.backend.mismatch, false);
+            deepStrictEqual(ctx.isLoggedIn(), true);
+          }).pipe(Effect.provide(makeUserContextLayer(cwd, { COMPOSIO_USER_API_KEY: 'api_key' })));
+        });
       });
     });
 
@@ -384,5 +428,149 @@ describe('ComposioUserContext', () => {
         }).pipe(Effect.provide(ComposioUserContextTest));
       });
     });
+  });
+  describe('[When] resolving the backend for the stored key', () => {
+    const loadContext = (params: {
+      readonly file: Record<string, unknown>;
+      readonly env?: Record<string, string>;
+    }) => {
+      const cwd = tempy.temporaryDirectory();
+      return Effect.gen(function* () {
+        yield* writeUserDataFile(cwd, JSON.stringify(params.file));
+        return yield* ComposioUserContext.pipe(
+          Effect.provide(makeUserContextLayer(cwd, params.env))
+        );
+      });
+    };
+
+    it.effect('[Given] a stored staging login and no env vars [Then] targets staging', () =>
+      Effect.gen(function* () {
+        const ctx = yield* loadContext({ file: stagingLogin });
+
+        deepStrictEqual(ctx.data.baseURL, STAGING_BASE_URL);
+        deepStrictEqual(ctx.data.webURL, STAGING_WEB_URL);
+        deepStrictEqual(ctx.backend.keySource, 'stored');
+        deepStrictEqual(ctx.backend.mismatch, false);
+      })
+    );
+
+    it.effect('[Given] COMPOSIO_BASE_URL points at production [Then] reports a mismatch', () =>
+      Effect.gen(function* () {
+        const ctx = yield* loadContext({
+          file: stagingLogin,
+          env: { COMPOSIO_BASE_URL: 'https://backend.composio.dev' },
+        });
+
+        deepStrictEqual(ctx.data.baseURL, 'https://backend.composio.dev');
+        deepStrictEqual(ctx.backend.mismatch, true);
+        deepStrictEqual(ctx.backend.overrideVariable, 'COMPOSIO_BASE_URL');
+        deepStrictEqual(ctx.backend.stored?.baseURL, STAGING_BASE_URL);
+      })
+    );
+
+    it.effect('[Given] COMPOSIO_ENVIRONMENT=staging [Then] no mismatch', () =>
+      Effect.gen(function* () {
+        const ctx = yield* loadContext({
+          file: stagingLogin,
+          env: { COMPOSIO_ENVIRONMENT: 'staging' },
+        });
+
+        deepStrictEqual(ctx.data.baseURL, STAGING_BASE_URL);
+        deepStrictEqual(ctx.backend.mismatch, false);
+      })
+    );
+
+    it.effect('[Given] COMPOSIO_ENVIRONMENT=production [Then] reports a mismatch', () =>
+      Effect.gen(function* () {
+        const ctx = yield* loadContext({
+          file: stagingLogin,
+          env: { COMPOSIO_ENVIRONMENT: 'production' },
+        });
+
+        deepStrictEqual(ctx.data.baseURL, 'https://backend.composio.dev');
+        deepStrictEqual(ctx.backend.mismatch, true);
+        deepStrictEqual(ctx.backend.overrideVariable, 'COMPOSIO_ENVIRONMENT');
+      })
+    );
+
+    it.effect('[Given] a blank COMPOSIO_BASE_URL [Then] it counts as unset', () =>
+      Effect.gen(function* () {
+        const ctx = yield* loadContext({ file: stagingLogin, env: { COMPOSIO_BASE_URL: '  ' } });
+
+        deepStrictEqual(ctx.data.baseURL, STAGING_BASE_URL);
+        deepStrictEqual(ctx.backend.overrideVariable, undefined);
+      })
+    );
+
+    it.effect('[Given] the override differs only by a trailing slash [Then] no mismatch', () =>
+      Effect.gen(function* () {
+        const ctx = yield* loadContext({
+          file: stagingLogin,
+          env: { COMPOSIO_BASE_URL: `${STAGING_BASE_URL}/` },
+        });
+
+        deepStrictEqual(ctx.backend.mismatch, false);
+      })
+    );
+
+    it.effect(
+      '[Given] a file without base_url [Then] the stored key uses the ambient default',
+      () =>
+        Effect.gen(function* () {
+          const ctx = yield* loadContext({ file: { api_key: 'uak_legacy', base_url: null } });
+
+          deepStrictEqual(ctx.data.baseURL, 'https://backend.composio.dev');
+          deepStrictEqual(ctx.backend.stored, undefined);
+          deepStrictEqual(ctx.backend.keySource, 'stored');
+        })
+    );
+
+    it.effect(
+      '[Given] keychain security with the key in the keyring [Then] uses the stored backend',
+      () => {
+        const cwd = tempy.temporaryDirectory();
+        const deps = Layer.mergeAll(
+          makeInMemoryKeyringLayer({ default: 'uak_from_keyring' }),
+          makeMockCliUserConfigLayer('keychain-subprocess')
+        );
+        const { api_key: _omitted, ...fileWithoutKey } = stagingLogin;
+
+        return Effect.gen(function* () {
+          yield* writeUserDataFile(cwd, JSON.stringify(fileWithoutKey));
+          const ctx = yield* ComposioUserContext.pipe(
+            Effect.provide(makeUserContextLayer(cwd, {}, deps))
+          );
+
+          deepStrictEqual(Option.getOrUndefined(ctx.data.apiKey), 'uak_from_keyring');
+          deepStrictEqual(ctx.data.baseURL, STAGING_BASE_URL);
+          deepStrictEqual(ctx.backend.keySource, 'stored');
+        });
+      }
+    );
+
+    it.effect(
+      '[Given] an override during a keyring migration [Then] the rewrite keeps the stored base_url',
+      () => {
+        const cwd = tempy.temporaryDirectory();
+        const deps = Layer.mergeAll(
+          makeInMemoryKeyringLayer(),
+          makeMockCliUserConfigLayer('keychain-subprocess')
+        );
+
+        return Effect.gen(function* () {
+          yield* writeUserDataFile(cwd, JSON.stringify(stagingLogin));
+          yield* ComposioUserContext.pipe(
+            Effect.provide(
+              makeUserContextLayer(cwd, { COMPOSIO_BASE_URL: 'https://backend.composio.dev' }, deps)
+            )
+          );
+
+          const onDisk = yield* readUserDataFile(cwd);
+          deepStrictEqual(onDisk.api_key, undefined);
+          deepStrictEqual(onDisk.base_url, STAGING_BASE_URL);
+          deepStrictEqual(onDisk.web_url, STAGING_WEB_URL);
+        });
+      }
+    );
   });
 });

--- a/ts/packages/cli/test/src/utils/api-error-extraction.test.ts
+++ b/ts/packages/cli/test/src/utils/api-error-extraction.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { extractApiErrorDetails } from 'src/utils/api-error-extraction';
+import { APIError } from '@composio/client';
+import { UnknownError } from 'effect/Cause';
+import { extractApiErrorDetails, isUserApiKeyRejection } from 'src/utils/api-error-extraction';
+import { HttpServerError } from 'src/services/composio-clients';
+import { userApiKeyRejectionBody } from 'test/__utils__/models/user-api-key-rejection';
 
 describe('extractApiErrorDetails', () => {
   it('extracts details from a well-formed API error body', () => {
@@ -59,5 +63,36 @@ describe('extractApiErrorDetails', () => {
     expect(extractApiErrorDetails({ foo: 'bar' })).toBeUndefined();
     expect(extractApiErrorDetails(undefined)).toBeUndefined();
     expect(extractApiErrorDetails('plain string')).toBeUndefined();
+  });
+});
+
+describe('isUserApiKeyRejection', () => {
+  const sdkRejection = () =>
+    APIError.generate(401, userApiKeyRejectionBody, undefined, new Headers());
+
+  it.each([
+    ['the raw body', () => userApiKeyRejectionBody],
+    ['an SDK APIError', sdkRejection],
+    [
+      'an HttpServerError wrapping an SDK APIError',
+      () => new HttpServerError({ cause: sdkRejection() }),
+    ],
+    [
+      'an HttpServerError carrying the decoded body',
+      () => new HttpServerError({ status: 401, apiError: userApiKeyRejectionBody.error }),
+    ],
+    ['an UnknownError wrapper', () => new UnknownError(sdkRejection())],
+    ['code 2113 without a slug', () => ({ error: { message: 'Unauthorized', code: 2113 } })],
+  ])('[Given] %s [Then] matches', (_label, make) => {
+    expect(isUserApiKeyRejection(make())).toBe(true);
+  });
+
+  it.each([
+    ['a 403 with another slug', { error: { status: 403, slug: 'Forbidden', code: 1003 } }],
+    ['a 401 with another slug', { error: { status: 401, slug: 'ProxyUpstream_Unauthorized' } }],
+    ['a bare 401 status', new HttpServerError({ status: 401, cause: 'HTTP 401 Unauthorized' })],
+    ['a non-object', 'Invalid or revoked user API key'],
+  ])('[Given] %s [Then] does not match', (_label, error) => {
+    expect(isUserApiKeyRejection(error)).toBe(false);
   });
 });

--- a/ts/packages/cli/test/src/utils/backend-resolution.test.ts
+++ b/ts/packages/cli/test/src/utils/backend-resolution.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from '@effect/vitest';
+import {
+  DEFAULT_BASE_URL,
+  DEFAULT_WEB_URL,
+  STAGING_BASE_URL,
+  STAGING_WEB_URL,
+} from 'src/constants';
+import {
+  type BackendOverrides,
+  isSameBackend,
+  loginCommandForBackend,
+  resolveBackend,
+} from 'src/utils/backend-resolution';
+
+const noOverrides: BackendOverrides = {
+  baseURL: undefined,
+  webURL: undefined,
+  environment: undefined,
+};
+
+const storedStaging = { baseURL: STAGING_BASE_URL, webURL: STAGING_WEB_URL };
+
+describe('resolveBackend', () => {
+  it('[Given] a stored staging login and no overrides [Then] targets the stored backend', () => {
+    const resolution = resolveBackend({
+      overrides: noOverrides,
+      stored: storedStaging,
+      keySource: 'stored',
+    });
+
+    expect(resolution.target).toEqual(storedStaging);
+    expect(resolution.stored).toEqual(storedStaging);
+    expect(resolution.mismatch).toBe(false);
+    expect(resolution.overrideVariable).toBeUndefined();
+  });
+
+  it('[Given] no stored base_url [Then] targets the ambient default', () => {
+    const resolution = resolveBackend({
+      overrides: noOverrides,
+      stored: { baseURL: undefined, webURL: STAGING_WEB_URL },
+      keySource: 'stored',
+    });
+
+    expect(resolution.target).toEqual({ baseURL: DEFAULT_BASE_URL, webURL: DEFAULT_WEB_URL });
+    expect(resolution.stored).toBeUndefined();
+    expect(resolution.mismatch).toBe(false);
+  });
+
+  it('[Given] COMPOSIO_BASE_URL points at another backend [Then] the override wins and reports a mismatch', () => {
+    const resolution = resolveBackend({
+      overrides: { ...noOverrides, baseURL: DEFAULT_BASE_URL },
+      stored: storedStaging,
+      keySource: 'stored',
+    });
+
+    expect(resolution.target.baseURL).toBe(DEFAULT_BASE_URL);
+    expect(resolution.mismatch).toBe(true);
+    expect(resolution.overrideVariable).toBe('COMPOSIO_BASE_URL');
+  });
+
+  it('[Given] COMPOSIO_ENVIRONMENT=staging with a stored staging login [Then] no mismatch', () => {
+    const resolution = resolveBackend({
+      overrides: { ...noOverrides, environment: 'staging' },
+      stored: storedStaging,
+      keySource: 'stored',
+    });
+
+    expect(resolution.target).toEqual(storedStaging);
+    expect(resolution.mismatch).toBe(false);
+    expect(resolution.overrideVariable).toBe('COMPOSIO_ENVIRONMENT');
+  });
+
+  it('[Given] COMPOSIO_ENVIRONMENT=production with a stored staging login [Then] reports a mismatch', () => {
+    const resolution = resolveBackend({
+      overrides: { ...noOverrides, environment: 'production' },
+      stored: storedStaging,
+      keySource: 'stored',
+    });
+
+    expect(resolution.target).toEqual({ baseURL: DEFAULT_BASE_URL, webURL: DEFAULT_WEB_URL });
+    expect(resolution.mismatch).toBe(true);
+    expect(resolution.overrideVariable).toBe('COMPOSIO_ENVIRONMENT');
+  });
+
+  it('[Given] COMPOSIO_BASE_URL and COMPOSIO_ENVIRONMENT are both set [Then] names COMPOSIO_BASE_URL', () => {
+    const resolution = resolveBackend({
+      overrides: { ...noOverrides, baseURL: DEFAULT_BASE_URL, environment: 'staging' },
+      stored: storedStaging,
+      keySource: 'stored',
+    });
+
+    expect(resolution.target.baseURL).toBe(DEFAULT_BASE_URL);
+    expect(resolution.overrideVariable).toBe('COMPOSIO_BASE_URL');
+  });
+
+  it('[Given] only COMPOSIO_WEB_URL is set [Then] keeps the stored backend and overrides the web URL', () => {
+    const resolution = resolveBackend({
+      overrides: { ...noOverrides, webURL: 'https://web.example.test/' },
+      stored: storedStaging,
+      keySource: 'stored',
+    });
+
+    expect(resolution.target).toEqual({
+      baseURL: STAGING_BASE_URL,
+      webURL: 'https://web.example.test/',
+    });
+    expect(resolution.mismatch).toBe(false);
+    expect(resolution.overrideVariable).toBeUndefined();
+  });
+
+  it('[Given] a trailing slash on the override [Then] it compares as the same backend', () => {
+    const resolution = resolveBackend({
+      overrides: { ...noOverrides, baseURL: `${STAGING_BASE_URL}/` },
+      stored: storedStaging,
+      keySource: 'stored',
+    });
+
+    expect(resolution.mismatch).toBe(false);
+  });
+
+  it('[Given] the key comes from COMPOSIO_USER_API_KEY [Then] targets the ambient backend without a mismatch', () => {
+    const resolution = resolveBackend({
+      overrides: { ...noOverrides, baseURL: DEFAULT_BASE_URL },
+      stored: storedStaging,
+      keySource: 'env',
+    });
+
+    expect(resolution.target).toEqual({ baseURL: DEFAULT_BASE_URL, webURL: DEFAULT_WEB_URL });
+    expect(resolution.mismatch).toBe(false);
+    expect(resolution.keySource).toBe('env');
+  });
+
+  it('[Given] no key at all [Then] targets the ambient backend', () => {
+    const resolution = resolveBackend({
+      overrides: noOverrides,
+      stored: storedStaging,
+      keySource: 'none',
+    });
+
+    expect(resolution.target).toEqual({ baseURL: DEFAULT_BASE_URL, webURL: DEFAULT_WEB_URL });
+    expect(resolution.mismatch).toBe(false);
+  });
+
+  it('[Given] a stored base_url without web_url [Then] the web URL falls back to the ambient one', () => {
+    const resolution = resolveBackend({
+      overrides: noOverrides,
+      stored: { baseURL: STAGING_BASE_URL, webURL: undefined },
+      keySource: 'stored',
+    });
+
+    expect(resolution.target).toEqual({ baseURL: STAGING_BASE_URL, webURL: DEFAULT_WEB_URL });
+  });
+
+  it('[Given] COMPOSIO_ENVIRONMENT=staging and nothing stored [Then] the ambient backend is staging', () => {
+    const resolution = resolveBackend({
+      overrides: { ...noOverrides, environment: 'staging' },
+      stored: { baseURL: undefined, webURL: undefined },
+      keySource: 'none',
+    });
+
+    expect(resolution.ambient).toEqual(storedStaging);
+    expect(resolution.target).toEqual(storedStaging);
+  });
+});
+
+describe('isSameBackend', () => {
+  it.each([
+    [STAGING_BASE_URL, `${STAGING_BASE_URL}/`, true],
+    [STAGING_BASE_URL, ` ${STAGING_BASE_URL} `, true],
+    [`${DEFAULT_BASE_URL}/api/v3`, DEFAULT_BASE_URL, true],
+    ['HTTPS://Backend.Composio.dev', DEFAULT_BASE_URL, true],
+    [STAGING_BASE_URL, DEFAULT_BASE_URL, false],
+    ['http://localhost:9900', 'http://localhost:9901', false],
+    ['not a url/', 'not a url', true],
+    ['not a url', 'another', false],
+  ])('%s vs %s → %s', (left, right, expected) => {
+    expect(isSameBackend(left, right)).toBe(expected);
+  });
+});
+
+describe('loginCommandForBackend', () => {
+  it('[Given] production [Then] needs no environment prefix', () => {
+    expect(loginCommandForBackend(`${DEFAULT_BASE_URL}/`)).toBe('composio login');
+  });
+
+  it('[Given] staging [Then] spells out COMPOSIO_ENVIRONMENT', () => {
+    expect(loginCommandForBackend(STAGING_BASE_URL)).toBe(
+      'COMPOSIO_ENVIRONMENT=staging composio login'
+    );
+  });
+
+  it('[Given] a custom host [Then] spells out COMPOSIO_BASE_URL', () => {
+    expect(loginCommandForBackend('http://localhost:9900')).toBe(
+      'COMPOSIO_BASE_URL=http://localhost:9900 composio login'
+    );
+  });
+});


### PR DESCRIPTION
This PR:
- makes commands call the backend recorded at login (`base_url` in `user_data.json`) unless `COMPOSIO_BASE_URL` or `COMPOSIO_ENVIRONMENT` overrides it; a key from `COMPOSIO_USER_API_KEY` keeps using the backend the env vars select (`resolveBackend()` in `src/utils/backend-resolution.ts`)
- gives every login path an explicit target: `ctx.login()` records the backend its caller passes, login flows target the ambient environment and name non-production hosts, `orgs switch` keeps the current login's backend, and CLI login sessions are created without sending the stored key
- warns on stderr before any request when an env var sends the stored key to a backend other than the one that issued it
- records `UserApiKey_Unauthorized` rejections where they happen (`AuthRejectionRecorder`, a `fetch` wrapper on SDK clients, and the backend error body kept on `HttpServerError.apiError`), and reports them once per command: an interactive re-login against the stored environment, or the exact next step such as `COMPOSIO_ENVIRONMENT=staging composio login`
- makes `composio login` recheck a stored key and log in again when its backend rejects it
- stops `toolkits info/list/search/version`, `link`, `whoami`, and `run` from printing the raw backend message or a misleading "not found" when the key is rejected
- aligns analytics dispatch, the CLI README precedence notes, the CHANGELOG, and the `toolkits info` e2e suite with the new rule

## Context

A user logged in while `COMPOSIO_BASE_URL` pointed at staging, later ran `composio dev toolkits info slack` with the variable unset, and got `Invalid or revoked user API key` plus a hint to browse toolkits. The key was valid: the CLI stored `base_url` at login but overwrote it with the production default on every run, so the staging key went to production. Logging out and in again would have made it worse by replacing the working staging key with a production one.

Testing:
- `pnpm --filter @composio/cli test`: 1418 passed, 1 skipped (includes `validate:skills` and `validate:boundaries`); repo-root `pnpm typecheck` passes
- `ts/e2e-tests/cli/toolkits/info`: 22/22 on a rebuilt image, including a stored login with no `COMPOSIO_BASE_URL` and a rejected stored key in piped mode
- a spawned `bun src/bin.ts orgs list` against a local 401 server prints one recovery line and no raw error, and fails against the previous `cli-main.ts`
- manual: a stored staging login with a bogus key and no env vars; staging rejected it and stderr showed ``Run `COMPOSIO_ENVIRONMENT=staging composio login` to log in again``, with stdout empty and `user_data.json` unchanged
- not yet run: `ce-code-review`, and an interactive re-login against a real staging account (covered by unit tests with a mocked session repository)
