### PR TITLE
docs: fix auto-upload guide link

### DIFF
--- a/ts/docs/api/composio.md
+++ b/ts/docs/api/composio.md
@@ -173,7 +173,7 @@ await composio.tools.execute(
 );
 ```
 
-See [Auto upload and download](./advanced/auto-upload-download.md#security-sensitive-local-paths) for the security model and error types.
+See [Auto upload and download](../advanced/auto-upload-download.md#security-sensitive-local-paths) for the security model and error types.
 
 ### Restricting automatic uploads to specific directories
 


### PR DESCRIPTION
## Summary

- fix the relative link from the Composio API guide to the auto-upload and download guide
- point one directory up before entering `advanced/`, matching the actual documentation layout

The previous link resolved to the nonexistent `ts/docs/api/advanced/auto-upload-download.md`. The updated link resolves to `ts/docs/advanced/auto-upload-download.md` and retains the security-section anchor.

## Verification

- `git diff --check`
- resolved the relative target from `ts/docs/api/composio.md` and confirmed it exists
- confirmed the target contains the `Security: sensitive local paths` heading

